### PR TITLE
Send npm output to debug logger

### DIFF
--- a/console/local.go
+++ b/console/local.go
@@ -17,16 +17,19 @@ import (
 func Server(ctx context.Context) (http.Handler, error) {
 	logger := log.FromContext(ctx)
 	logger.Infof("Starting console dev server")
+	output := logger.WriterAt(log.Debug)
 
 	cmd := exec.Command(ctx, "console", "npm", "install")
-	cmd.Stdout = nil
+	cmd.Stdout = output
+	cmd.Stderr = output
 	err := cmd.Run()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
 	cmd = exec.Command(ctx, "console", "npm", "run", "dev")
-	cmd.Stdout = nil
+	cmd.Stdout = output
+	cmd.Stderr = output
 	err = cmd.Start()
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/console/local.go
+++ b/console/local.go
@@ -17,16 +17,16 @@ import (
 func Server(ctx context.Context) (http.Handler, error) {
 	logger := log.FromContext(ctx)
 	logger.Infof("Starting console dev server")
-	output := logger.WriterAt(log.Info)
 
-	err := exec.Command(ctx, "console", "npm", "install").Run()
+	cmd := exec.Command(ctx, "console", "npm", "install")
+	cmd.Stdout = nil
+	err := cmd.Run()
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
-	cmd := exec.Command(ctx, "console", "npm", "run", "dev")
-	cmd.Stdout = output
-	cmd.Stderr = output
+	cmd = exec.Command(ctx, "console", "npm", "run", "dev")
+	cmd.Stdout = nil
 	err = cmd.Start()
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
@alecthomas Not sure if this is what you were looking for, but here's a shot at cleaning up the output on start-up for the console

```bash
ftl serve ./examples/echo ./examples/time
warn:agent: Starting FTL local agent on http://127.0.0.1:8892
info:agent:time: Starting
info:agent:time: Extracting schema
info:agent:echo: Starting
info:agent:echo: Extracting schema
info:agent:echo: Compiling FTL module...
info:agent:time: Compiling FTL module...
info:agent:echo: Online
info:agent:echo: Online
info:agent:time: Online
info:agent:time: Online
info:agent:time: Online
info:agent:echo: Online
info:agent: Starting console dev server
info:agent:echo: Terminated by signal terminated
info:agent:time: Terminated by signal terminated
warn:agent:echo: Module exited, restarting: context canceled
info:agent:echo: Extracting schema
warn:agent:time: Module exited, restarting: context canceled
info:agent:time: Extracting schema
info:agent:time: Compiling FTL module...
info:agent:echo: Compiling FTL module...
info:agent:time: Online
info:agent:echo: Online
```

DEBUG:
```bash
ftl serve ./examples/echo ./examples/time --log-level=debug
warn:agent: Starting FTL local agent on http://127.0.0.1:8892
debug:agent:echo: Spawning plugin on tcp://127.0.0.1:51190
debug:agent:time: Spawning plugin on tcp://127.0.0.1:51191
debug:agent:time: Starting on tcp://127.0.0.1:51191
debug:agent:echo: Starting on tcp://127.0.0.1:51190
info:agent:echo: Starting
info:agent:echo: Extracting schema
info:agent:time: Starting
info:agent:time: Extracting schema
info:agent:time: Compiling FTL module...
info:agent:echo: Compiling FTL module...
debug:agent:time: Spawning plugin on tcp://127.0.0.1:51200
debug:agent:echo: Spawning plugin on tcp://127.0.0.1:51202
debug:agent:time: Starting on tcp://127.0.0.1:51200
debug:agent:echo: Starting on tcp://127.0.0.1:51202
info:agent:time: Online
info:agent:time: Online
info:agent:echo: Online
info:agent:echo: Online
info:agent:echo: Online
info:agent:time: Online
info:agent: Starting console dev server
debug:agent:time: Received schema update from echo
debug:agent:echo: Received schema update from time
info:agent:time: Terminated by signal terminated
info:agent:echo: Terminated by signal terminated
warn:agent:time: Module exited, restarting: context canceled
info:agent:time: Extracting schema
warn:agent:echo: Module exited, restarting: context canceled
info:agent:echo: Extracting schema
debug:agent:echo: Received schema update from time
debug:agent:time: Received schema update from echo
info:agent:time: Compiling FTL module...
info:agent:echo: Compiling FTL module...
debug:agent:
debug:agent: up to date, audited 264 packages in 411ms
debug:agent:
debug:agent: 51 packages are looking for funding
debug:agent:   run `npm fund` for details
debug:agent:
debug:agent: found 0 vulnerabilities
debug:agent:time: Spawning plugin on tcp://127.0.0.1:51220
debug:agent:echo: Spawning plugin on tcp://127.0.0.1:51222
debug:agent:
debug:agent: > console@0.0.0 dev
debug:agent: > vite
debug:agent:
debug:agent:time: Starting on tcp://127.0.0.1:51220
debug:agent:echo: Starting on tcp://127.0.0.1:51222
2023/04/29 10:37:45 http: proxy error: dial tcp [::1]:5173: connect: connection refused
2023/04/29 10:37:46 http: proxy error: dial tcp [::1]:5173: connect: connection refused
debug:agent:
debug:agent:   VITE v4.3.3  ready in 256 ms
debug:agent:
debug:agent:   ➜  Local:   http://localhost:5173/
debug:agent:   ➜  Network: use --host to expose
info:agent:time: Online
info:agent:echo: Online
```