### PR TITLE
Return logs without a request key

### DIFF
--- a/console/client/src/features/log/LogsPage.tsx
+++ b/console/client/src/features/log/LogsPage.tsx
@@ -56,13 +56,7 @@ export default function LogsPage() {
             </th>
             <th
               scope='col'
-              className='hidden py-2 pl-0 pr-8 font-semibold sm:table-cell'
-            >
-              Runner
-            </th>
-            <th
-              scope='col'
-              className='py-2 pl-0 pr-4 text-right font-semibold sm:pr-8 sm:text-left lg:pr-20'
+              className='py-2 pl-0 pr-4 text-right font-semibold sm:text-left'
             >
               Level
             </th>
@@ -70,13 +64,13 @@ export default function LogsPage() {
               scope='col'
               className='hidden py-2 pl-0 pr-8 font-semibold md:table-cell lg:pr-20'
             >
-              Attributes
+              Message
             </th>
             <th
               scope='col'
               className='hidden py-2 pl-0 pr-8 font-semibold md:table-cell lg:pr-20'
             >
-              Message
+              Attributes
             </th>
             <th
               scope='col'
@@ -102,24 +96,10 @@ export default function LogsPage() {
                   </div>
                 </div>
               </td>
-              <td className='hidden py-4 pl-0 pr-4 sm:table-cell sm:pr-8'>
-                <div className='flex gap-x-3'>
-                  <div className='font-mono text-sm leading-6 text-gray-400'>
-                    {log.runnerKey}
-                  </div>
-                </div>
-              </td>
-              <td className='py-4 pl-0 pr-4 text-sm leading-6 sm:pr-8 lg:pr-20'>
+              <td className='py-4 pl-0 pr-4 text-sm leading-6'>
                 <div className='flex items-center justify-end gap-x-2 sm:justify-start'>
                   <div className={`rounded-md bg-gray-700/40 px-2 py-1 text-xs font-medium text-gray-400 ring-1 ring-inset ring-white/10`}>
                     {log.logLevel}
-                  </div>
-                </div>
-              </td>
-              <td className='hidden py-4 pl-0 pr-8 text-sm leading-6 text-gray-400 md:table-cell lg:pr-20'>
-                <div className='flex gap-x-3'>
-                  <div className='font-mono text-sm leading-6 text-gray-400'>
-                    {JSON.stringify(log.attributes)}
                   </div>
                 </div>
               </td>
@@ -127,6 +107,13 @@ export default function LogsPage() {
                 className={`hidden py-4 pl-0 pr-4 text-sm leading-6 text-gray-400 sm:table-cell sm:pr-6 lg:pr-8`}
               >
                 <div className='truncate text-sm font-medium leading-6 dark:text-white'>{log.message}</div>
+              </td>
+              <td className='hidden py-4 pl-0 pr-8 text-sm leading-6 text-gray-400 md:table-cell lg:pr-20'>
+                <div className='flex gap-x-3'>
+                  <div className='font-mono text-sm leading-6 text-gray-400'>
+                    {JSON.stringify(log.attributes)}
+                  </div>
+                </div>
               </td>
               <td
                 className={`hidden py-4 pl-0 pr-4 text-sm leading-6 text-gray-400 sm:table-cell sm:pr-6 lg:pr-8`}


### PR DESCRIPTION
With the new event setup, we were previously only returning log events that had a `request_key`. But many of the log events happen outside of a request context. For example, a new deploy won't have an associated `request_key`.

This PR makes request_key optional so we can get logs with and without the key.