### PR TITLE
fix: Use existing deployment key if found during creation

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -563,8 +563,7 @@ func (s *Service) UploadArtefact(ctx context.Context, req *connect.Request[ftlv1
 }
 
 func (s *Service) CreateDeployment(ctx context.Context, req *connect.Request[ftlv1.CreateDeploymentRequest]) (*connect.Response[ftlv1.CreateDeploymentResponse], error) {
-	deploymentKey := model.NewDeploymentKey()
-	logger := s.getDeploymentLogger(ctx, deploymentKey)
+	logger := log.FromContext(ctx)
 
 	artefacts := make([]dal.DeploymentArtefact, len(req.Msg.Artefacts))
 	for i, artefact := range req.Msg.Artefacts {
@@ -591,12 +590,13 @@ func (s *Service) CreateDeployment(ctx context.Context, req *connect.Request[ftl
 		return nil, errors.Wrap(err, "invalid module schema")
 	}
 	ingressRoutes := extractIngressRoutingEntries(req.Msg)
-	key, err := s.dal.CreateDeployment(ctx, deploymentKey, ms.Runtime.Language, module, artefacts, ingressRoutes)
+	key, err := s.dal.CreateDeployment(ctx, ms.Runtime.Language, module, artefacts, ingressRoutes)
 	if err != nil {
 		logger.Errorf(err, "Could not create deployment")
 		return nil, errors.Wrap(err, "could not create deployment")
 	}
-	logger.Infof("Created deployment %s", key)
+	deploymentLogger := s.getDeploymentLogger(ctx, key)
+	deploymentLogger.Infof("Created deployment wes %s", key)
 	return connect.NewResponse(&ftlv1.CreateDeploymentResponse{DeploymentKey: key.String()}), nil
 }
 

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -591,13 +591,13 @@ func (s *Service) CreateDeployment(ctx context.Context, req *connect.Request[ftl
 		return nil, errors.Wrap(err, "invalid module schema")
 	}
 	ingressRoutes := extractIngressRoutingEntries(req.Msg)
-	err = s.dal.CreateDeployment(ctx, deploymentKey, ms.Runtime.Language, module, artefacts, ingressRoutes)
+	key, err := s.dal.CreateDeployment(ctx, deploymentKey, ms.Runtime.Language, module, artefacts, ingressRoutes)
 	if err != nil {
 		logger.Errorf(err, "Could not create deployment")
 		return nil, errors.Wrap(err, "could not create deployment")
 	}
-	logger.Infof("Created deployment %s", deploymentKey)
-	return connect.NewResponse(&ftlv1.CreateDeploymentResponse{DeploymentKey: deploymentKey.String()}), nil
+	logger.Infof("Created deployment %s", key)
+	return connect.NewResponse(&ftlv1.CreateDeploymentResponse{DeploymentKey: key.String()}), nil
 }
 
 func (s *Service) getDeployment(ctx context.Context, key string) (*model.Deployment, error) {

--- a/backend/controller/internal/dal/dal_test.go
+++ b/backend/controller/internal/dal/dal_test.go
@@ -43,9 +43,9 @@ func TestDAL(t *testing.T) {
 	})
 
 	module := &schema.Module{Name: "test"}
-	deploymentKey := model.NewDeploymentKey()
+	var deploymentKey model.DeploymentKey
 	t.Run("CreateDeployment", func(t *testing.T) {
-		err = dal.CreateDeployment(ctx, deploymentKey, "go", module, []DeploymentArtefact{{
+		deploymentKey, err = dal.CreateDeployment(ctx, model.NewDeploymentKey(), "go", module, []DeploymentArtefact{{
 			Digest:     testSha,
 			Executable: true,
 			Path:       "dir/filename",

--- a/backend/controller/internal/dal/dal_test.go
+++ b/backend/controller/internal/dal/dal_test.go
@@ -45,7 +45,7 @@ func TestDAL(t *testing.T) {
 	module := &schema.Module{Name: "test"}
 	var deploymentKey model.DeploymentKey
 	t.Run("CreateDeployment", func(t *testing.T) {
-		deploymentKey, err = dal.CreateDeployment(ctx, model.NewDeploymentKey(), "go", module, []DeploymentArtefact{{
+		deploymentKey, err = dal.CreateDeployment(ctx, "go", module, []DeploymentArtefact{{
 			Digest:     testSha,
 			Executable: true,
 			Path:       "dir/filename",


### PR DESCRIPTION
Fixes #236 

The previous change was made to create the key earlier which would allow us to log entries about the deploy during the creation process, before it was in the db. This PR retains that and fixes the reported bug.

This could be simplified but we'll lose the ability to log is some spots before the db call.

Still need to figure out how to log a message after the deployment has been replaced. Currently getting:
```bash
controller | info: Created deployment wes D01H809K9G09THVB5Z0HAMST7RZ
controller | info: Replace deployment for: D01H809K9G09THVB5Z0HAMST7RZ
controller | failed to insert log entry: {2023-08-16 16:14:02.341002 -0700 PDT m=+17.468284876 info map[deployment:D01H80A18Z366G9P1F0Y9PNK77C] Created deployment wes D01H809K9G09THVB5Z0HAMST7RZ <nil>} :: error: ERROR: null value in column "deployment_id" of relation "events" violates not-null constraint (SQLSTATE 23502)
```

@alecthomas maybe we should keep old deployment records around after they are replaced so that the IDs will still be in the db, but new deployments will create new IDs?