### PR TITLE
feat: experimental dynamic routing updates

### DIFF
--- a/backend/common/slices/slices.go
+++ b/backend/common/slices/slices.go
@@ -47,3 +47,16 @@ func Reduce[T, U any](slice []T, initial U, fn func(U, T) U) U {
 	}
 	return result
 }
+
+// AppendOrReplace appends a value to a slice if the slice does not contain a
+// value for which the given function returns true. If the slice does contain
+// such a value, it is replaced.
+func AppendOrReplace[T any](slice []T, value T, fn func(T) bool) []T {
+	for i, v := range slice {
+		if fn(v) {
+			slice[i] = value
+			return slice
+		}
+	}
+	return append(slice, value)
+}

--- a/backend/controller/internal/dal/dal_test.go
+++ b/backend/controller/internal/dal/dal_test.go
@@ -291,13 +291,14 @@ func TestDAL(t *testing.T) {
 	})
 
 	t.Run("GetRoutingTable", func(t *testing.T) {
-		routes, err := dal.GetRoutingTable(ctx, deployment.Module)
+		routes, err := dal.GetRoutingTable(ctx, []string{deployment.Module})
 		assert.NoError(t, err)
 		assert.Equal(t, []Route{{
+			Module:     "test",
 			Runner:     expectedRunner.Key,
 			Deployment: deploymentName,
 			Endpoint:   expectedRunner.Endpoint,
-		}}, routes)
+		}}, routes[deployment.Module])
 	})
 
 	t.Run("UpdateRunnerInvalidDeployment", func(t *testing.T) {
@@ -331,7 +332,7 @@ func TestDAL(t *testing.T) {
 	})
 
 	t.Run("GetRoutingTable", func(t *testing.T) {
-		_, err := dal.GetRoutingTable(ctx, deployment.Module)
+		_, err := dal.GetRoutingTable(ctx, []string{deployment.Module})
 		assert.IsError(t, err, ErrNotFound)
 	})
 

--- a/backend/controller/internal/sql/models.go
+++ b/backend/controller/internal/sql/models.go
@@ -218,6 +218,7 @@ type Runner struct {
 	ReservationTimeout sqltypes.NullTime
 	State              RunnerState
 	Endpoint           string
+	ModuleName         types.Option[string]
 	DeploymentID       types.Option[int64]
 	Labels             []byte
 }

--- a/backend/controller/internal/sql/querier.go
+++ b/backend/controller/internal/sql/querier.go
@@ -43,7 +43,9 @@ type Querier interface {
 	// Get the runner endpoints corresponding to the given ingress route.
 	GetIngressRoutes(ctx context.Context, method string, path string) ([]GetIngressRoutesRow, error)
 	GetModulesByID(ctx context.Context, ids []int64) ([]Module, error)
-	GetRoutingTable(ctx context.Context, name string) ([]GetRoutingTableRow, error)
+	// Retrieve routing information for a runner.
+	GetRouteForRunner(ctx context.Context, key model.RunnerKey) (GetRouteForRunnerRow, error)
+	GetRoutingTable(ctx context.Context, modules []string) ([]GetRoutingTableRow, error)
 	GetRunner(ctx context.Context, key model.RunnerKey) (GetRunnerRow, error)
 	GetRunnerState(ctx context.Context, key model.RunnerKey) (RunnerState, error)
 	GetRunnersForDeployment(ctx context.Context, name model.DeploymentName) ([]GetRunnersForDeploymentRow, error)

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/go-logr/logr v1.2.4
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/golang-lru/v2 v2.0.5
 	github.com/jackc/pgx/v5 v5.3.1
+	github.com/jellydator/ttlcache/v3 v3.1.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/otiai10/copy v1.12.0
 	github.com/radovskyb/watcher v1.0.7
@@ -36,7 +36,6 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/puddle/v2 v2.2.0 // indirect
-	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.16.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.39.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -75,7 +75,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -166,8 +165,6 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 h1:BZHcxBETFHIdVyhyEfOvn/RdU/QG
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru/v2 v2.0.5 h1:wW7h1TG88eUIJ2i69gaE3uNVtEPIagzhGvHgwfx2Vm4=
-github.com/hashicorp/golang-lru/v2 v2.0.5/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
@@ -183,6 +180,8 @@ github.com/jackc/pgx/v5 v5.3.1 h1:Fcr8QJ1ZeLi5zsPZqQeUZhNhxfkkKBOgJuYkJHoBOtU=
 github.com/jackc/pgx/v5 v5.3.1/go.mod h1:t3JDKnCBlYIc0ewLF0Q7B8MXmoIaBOZj/ic7iHozM/8=
 github.com/jackc/puddle/v2 v2.2.0 h1:RdcDk92EJBuBS55nQMMYFXTxwstHug4jkhT5pq8VxPk=
 github.com/jackc/puddle/v2 v2.2.0/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jellydator/ttlcache/v3 v3.1.0 h1:0gPFG0IHHP6xyUyXq+JaD8fwkDCqgqwohXNJBcYE71g=
+github.com/jellydator/ttlcache/v3 v3.1.0/go.mod h1:hi7MGFdMAwZna5n2tuvh63DvFLzVKySzCVW6+0gA2n4=
 github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -264,6 +263,8 @@ go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJP
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.uber.org/automaxprocs v1.5.2 h1:2LxUOGiR3O6tw8ui5sZa2LAaHnsviZdVOUZw4fvbnME=
 go.uber.org/automaxprocs v1.5.2/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/scripts/ftl-run
+++ b/scripts/ftl-run
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+top="$(git rev-parse --show-toplevel)"
+cd "${top}"
+
+prepare_template() (
+  mkdir -p build/template/ftl/jars
+  (cd "${top}/kotlin-runtime/ftl-runtime" && gradle jar)
+  cp "${top}/kotlin-runtime/ftl-runtime/build/libs/ftl-runtime.jar" build/template/ftl/jars
+)
+
+prepare_template
+
+overmind start -f Procfile.nowatch


### PR DESCRIPTION
Previously the routes for each request were retrieved via a databas query. This change introduces dynamic routing updates from triggers on the runners table.

For now this can be disabled with `ftl-controller --no-experimental-dynamic-routing-updates`.