### PR TITLE
Remove extra padding

### DIFF
--- a/console/client/src/layout/IDELayout.tsx
+++ b/console/client/src/layout/IDELayout.tsx
@@ -121,7 +121,7 @@ export function IDELayout() {
               </Tab.List>
               <div className='flex-grow'></div>
             </div>
-            <div className={`flex-1 p-4 overflow-y-scroll ${panelColor}`}>
+            <div className={`flex-1 overflow-y-scroll ${panelColor}`}>
               <Tab.Panels>
                 {tabs.map(({ id }, i) => {
                   return i === 0


### PR DESCRIPTION
BEFORE (notice the rows behind the filter bar):
<img width="769" alt="Screenshot 2023-08-24 at 2 12 10 PM" src="https://github.com/TBD54566975/ftl/assets/51647/c5a070c8-4f08-44d3-a69a-ae90593dc10b">

AFTER:
<img width="769" alt="Screenshot 2023-08-24 at 2 13 21 PM" src="https://github.com/TBD54566975/ftl/assets/51647/5af79a26-27cb-4a32-a4a4-6cbe9e4f5338">
