### PR TITLE
fix: add flags to ftl-go for multi-platform support

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -133,7 +133,7 @@ func New(ctx context.Context, db *dal.DAL, config Config) (*Service, error) {
 	go runWithRetries(ctx, time.Second*10, time.Second*20, svc.reapStaleControllers)
 	go runWithRetries(ctx, config.RunnerTimeout, time.Second*10, svc.reapStaleRunners)
 	go runWithRetries(ctx, config.DeploymentReservationTimeout, time.Second*20, svc.releaseExpiredReservations)
-	go runWithRetries(ctx, config.RunnerTimeout, time.Second*10, svc.reconcileDeployments)
+	go runWithRetries(ctx, time.Second*1, time.Second*5, svc.reconcileDeployments)
 	return svc, nil
 }
 

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -60,11 +60,13 @@ deploy_echo_kotlin() (
 deploy_time_go() (
   info "Deploying time"
   cd examples
-  ftl-go deploy time
+  # Pull a supported platforms from the cluster.
+  platform="$(ftl status | jq -r '.runners[].labels | "\(.os)-\(.arch)"' | sort | uniq | head -1)"
+  ftl-go --os "${platform%-*}" --arch "${platform#*-}" deploy time
 )
 
 wait_for_deploys() {
-  wait_for "deployments to come up" '[ "$(ftl ps --json | jq -r .module | sort | paste -sd " " -)" == "echo time" ]'
+  wait_for "deployments to come up" 'ftl status | jq -r ".routes[].module" | sort | paste -sd " " - | grep -q "echo time"'
 }
 
 build_release
@@ -79,7 +81,6 @@ deploy_echo_kotlin
 wait_for_deploys
 
 info "Calling echo"
-wait_for "echo to respond" 'ftl call echo.echo'
 message="$(ftl call echo.echo '{"name": "Alice"}' | jq -r .message)"
 [[ "$message" =~ "Hello, Alice! The time is " ]] || error "Unexpected response from echo: $message"
 info "Success!"


### PR DESCRIPTION
Also update `integration-test` script to pull the supported platforms from the cluster before deploying.