### PR TITLE
fix: disable Kotlin incremental compilation

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,1 +1,0 @@
---also-make

--- a/Bitfile
+++ b/Bitfile
@@ -4,7 +4,6 @@ RELEASE = %{DEST}/release
 
 GO_SOURCES = **/*.go
 
-
 SCHEMA_IN = backend/schema/schema.go backend/schema/protobuf.go \
     cmd/ftl/cmd_schema.go
 SCHEMA_OUT = protos/xyz/block/ftl/v1/schema/schema.proto
@@ -25,7 +24,8 @@ COMMON_LOG_IN = backend/common/log/api.go
 COMMON_LOG_OUT = backend/common/log/log_level_string.go
 
 KT_RUNTIME_IN = kotlin-runtime/ftl-runtime/**/*.{kt,kts} pom.xml kotlin-runtime/**/pom.xml
-KT_RUNTIME_OUT = kotlin-runtime/ftl-runtime/target/ftl-runtime-1.0-SNAPSHOT-jar-with-dependencies.jar
+KT_MVN_OUT = kotlin-runtime/ftl-runtime/target/ftl-runtime-1.0-SNAPSHOT-jar-with-dependencies.jar
+KT_RUNTIME_OUT = build/template/ftl/jars/ftl-runtime.jar
 
 CLIENT_OUT = console/client/dist/index.html
 CLIENT_IN = console/client/**/*
@@ -45,7 +45,9 @@ implicit %{RELEASE}/%{1}: cmd/*
 #  build: go build -o %{OUT} -tags release -ldflags "-X main.version=%{VERSION}" ./cmd/ftl-controller
 
 %{SCHEMA_OUT}: %{SCHEMA_IN}
-  build: ftl-schema > %{OUT}
+  build:
+    ftl-schema > %{OUT}
+    buf format -w
 
 %{PROTO_OUT}: %{PROTO_IN}
   build:
@@ -55,15 +57,15 @@ implicit %{RELEASE}/%{1}: cmd/*
     (cd backend/common/3rdparty/protos && buf generate)
   -clean
 
-%{KT_RUNTIME_OUT}: %{KT_RUNTIME_IN} %{PROTO_IN}
-  build: mvn -pl kotlin-runtime/ftl-runtime install
-  +clean: mvn -pl kotlin-runtime/ftl-runtime clean
+%{KT_MVN_OUT}: %{KT_RUNTIME_IN} %{PROTO_IN}
+  build: mvn -pl :ftl-runtime package
+  +clean: mvn -pl :ftl-runtime clean
 
-build/template/ftl/jars:
+%(dirname %{KT_RUNTIME_OUT})%:
   build: install -m 0700 -d %{OUT}
 
-build/template/ftl/jars/ftl-runtime.jar: %{KT_RUNTIME_OUT} build/template/ftl/jars
-  build: install -m 0600 %{KT_RUNTIME_OUT} %{OUT}
+%{KT_RUNTIME_OUT}: %{KT_MVN_OUT} %(dirname %{KT_RUNTIME_OUT})%
+  build: install -m 0600 %{KT_MVN_OUT} %{OUT}
 
 %{COMMON_LOG_OUT}: %{COMMON_LOG_IN}
   build: go generate %{IN}

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,6 @@ $(KT_RUNTIME_OUT): $(KT_MVN_OUT)
 	mkdir -p build/template/ftl/jars
 	cp $< $@
 
-
-
 console/client/dist/index.html:
 	cd console/client && npm install && npm run build
 

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
-    <groupId>xyz.block.ftl</groupId>
+    <groupId>xyz.block</groupId>
     <artifactId>echo-kotlin</artifactId>
     <version>1.0-SNAPSHOT</version>
 

--- a/kotlin-runtime/ftl-generator/pom.xml
+++ b/kotlin-runtime/ftl-generator/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>xyz.block.ftl</groupId>
+        <groupId>xyz.block</groupId>
         <artifactId>ftl</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/kotlin-runtime/ftl-runtime/pom.xml
+++ b/kotlin-runtime/ftl-runtime/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>xyz.block.ftl</groupId>
+        <groupId>xyz.block</groupId>
         <artifactId>ftl</artifactId>
         <version>1.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
@@ -50,6 +50,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
@@ -74,10 +78,6 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
             <!-- Download the Wire compiler. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -87,10 +87,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>xyz.block.ftl</groupId>
+    <groupId>xyz.block</groupId>
     <artifactId>ftl</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
@@ -19,7 +19,6 @@
         <rootDir>${basedir}</rootDir>
         <java.version>11</java.version>
         <kotlin.version>1.9.0</kotlin.version>
-        <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <wire.version>4.8.1</wire.version>
         <grpc.version>1.56.1</grpc.version>
         <logback.version>1.4.5</logback.version>
@@ -119,6 +118,24 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <executions>
+                        <execution>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>${project.basedir}/target/generated-sources/wire</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.1.2</version>
@@ -155,39 +172,6 @@
                                     <sourceDir>${project.basedir}/src/test/kotlin</sourceDir>
                                 </sourceDirs>
                             </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.10.1</version>
-                    <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>default-compile</id>
-                            <phase>none</phase>
-                        </execution>
-                        <execution>
-                            <id>default-testCompile</id>
-                            <phase>none</phase>
-                        </execution>
-                        <execution>
-                            <id>java-compile</id>
-                            <phase>compile</phase>
-                            <goals>
-                                <goal>compile</goal>
-                            </goals>
-                        </execution>
-                        <execution>
-                            <id>java-test-compile</id>
-                            <phase>test-compile</phase>
-                            <goals>
-                                <goal>testCompile</goal>
-                            </goals>
                         </execution>
                     </executions>
                 </plugin>
@@ -257,24 +241,6 @@
                                     <argument>--kotlin_grpc_server_compatible</argument>
                                     <argument>--includes=xyz.block.ftl.v1.VerbService</argument>
                                 </arguments>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.2.0</version>
-                    <executions>
-                        <execution>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>add-source</goal>
-                            </goals>
-                            <configuration>
-                                <sources>
-                                    <source>target/generated-sources/wire</source>
-                                </sources>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
[This][1] discussion is from 2017, but it seems to reflect the behaviour I was seeing, where running tests would not find the main source code, but re-running it would succeed. Disabling incremental compilation did in fact fix it, so...

[1]: https://discuss.kotlinlang.org/t/kotlin-compiler-incremental-not-copying-resources/5640