### PR TITLE
fix: case where a runner ends up reserved without a timeout

### DIFF
--- a/backend/controller/internal/dal/dal.go
+++ b/backend/controller/internal/dal/dal.go
@@ -554,6 +554,9 @@ func (d *DAL) DeregisterRunner(ctx context.Context, key model.RunnerKey) error {
 	return nil
 }
 
+// ReserveRunnerForDeployment reserves a runner for the given deployment.
+//
+// It returns a Reservation that must be committed or rolled back.
 func (d *DAL) ReserveRunnerForDeployment(ctx context.Context, deployment model.DeploymentName, reservationTimeout time.Duration, labels model.Labels) (Reservation, error) {
 	jsonLabels, err := json.Marshal(labels)
 	if err != nil {

--- a/backend/controller/internal/sql/queries.sql
+++ b/backend/controller/internal/sql/queries.sql
@@ -90,25 +90,18 @@ WITH deployment_rel AS (
                ELSE COALESCE((SELECT id
                               FROM deployments d
                               WHERE d.name = sqlc.narg('deployment_name')
-                              LIMIT 1), -1) END AS id),
-     module_rel AS (SELECT m.name
-                    FROM modules m
-                             INNER JOIN deployments d ON m.id = d.module_id
-                    WHERE d.name = sqlc.narg('deployment_name')
-                    LIMIT 1)
+                              LIMIT 1), -1) END AS id)
 INSERT
-INTO runners (key, endpoint, state, labels, module_name, deployment_id, last_seen)
+INTO runners (key, endpoint, state, labels, deployment_id, last_seen)
 VALUES ($1,
         $2,
         $3,
         $4,
-        (SELECT name FROM module_rel),
         (SELECT id FROM deployment_rel),
         NOW() AT TIME ZONE 'utc')
 ON CONFLICT (key) DO UPDATE SET endpoint      = $2,
                                 state         = $3,
                                 labels        = $4,
-                                module_name   = (SELECT name FROM module_rel),
                                 deployment_id = (SELECT id FROM deployment_rel),
                                 last_seen     = NOW() AT TIME ZONE 'utc'
 RETURNING deployment_id;

--- a/backend/controller/internal/sql/queries.sql.go
+++ b/backend/controller/internal/sql/queries.sql.go
@@ -1192,25 +1192,18 @@ WITH deployment_rel AS (
                ELSE COALESCE((SELECT id
                               FROM deployments d
                               WHERE d.name = $5
-                              LIMIT 1), -1) END AS id),
-     module_rel AS (SELECT m.name
-                    FROM modules m
-                             INNER JOIN deployments d ON m.id = d.module_id
-                    WHERE d.name = $5
-                    LIMIT 1)
+                              LIMIT 1), -1) END AS id)
 INSERT
-INTO runners (key, endpoint, state, labels, module_name, deployment_id, last_seen)
+INTO runners (key, endpoint, state, labels, deployment_id, last_seen)
 VALUES ($1,
         $2,
         $3,
         $4,
-        (SELECT name FROM module_rel),
         (SELECT id FROM deployment_rel),
         NOW() AT TIME ZONE 'utc')
 ON CONFLICT (key) DO UPDATE SET endpoint      = $2,
                                 state         = $3,
                                 labels        = $4,
-                                module_name   = (SELECT name FROM module_rel),
                                 deployment_id = (SELECT id FROM deployment_rel),
                                 last_seen     = NOW() AT TIME ZONE 'utc'
 RETURNING deployment_id


### PR DESCRIPTION
I believe this was being triggered when a controller creates a reservation transaction, issues the reservation to a runner, then dies before being able to complete the transaction. This leaves the runner in a state where it is telling controllers it's reserved, without having set a reservation_timeout, as the only place that was previously set was during the reservation transaction. The UpsertRunner calls were not setting this.

To work around this, and another potential issue, I've added two triggers:

1. When a runner is set to the reserved state with a NULL reservation_timeout, set it to a default of 2m.
2. Update runner.module_name whenever runner.deployment_id is set or unset.

Fixes #392