### PR TITLE
fix: request graph loading calls in reverse order

### DIFF
--- a/console/client/src/components/CodeBlock.tsx
+++ b/console/client/src/components/CodeBlock.tsx
@@ -22,7 +22,7 @@ export const CodeBlock = ({ code, language, maxHeight }: Props) => {
 
   return (
     <pre>
-      <code className={`max-h-[${maxHeight}px] language-${language} text-sm`}>{code}</code>
+      <code className={`max-h-[${maxHeight}px] language-${language} text-xs`}>{code}</code>
     </pre>
   )
 }

--- a/console/client/src/features/timeline/Timeline.tsx
+++ b/console/client/src/features/timeline/Timeline.tsx
@@ -36,7 +36,7 @@ export const Timeline = ({ timeSettings, filters }: Props) => {
       if (timeSettings.newerThan || timeSettings.olderThan) {
         eventFilters = [timeFilter(timeSettings.olderThan, timeSettings.newerThan), ...filters]
       }
-      const events = await getEvents(eventFilters)
+      const events = await getEvents({ filters: eventFilters })
       setEntries(events)
     }
 

--- a/console/client/src/services/console.service.ts
+++ b/console/client/src/services/console.service.ts
@@ -93,7 +93,9 @@ export const timeFilter = (olderThan: Timestamp | undefined, newerThan: Timestam
 }
 
 export const getRequestCalls = async (requestKey: string): Promise<Call[]> => {
-  const allEvents = await getEvents([requestKeysFilter([requestKey]), eventTypesFilter([EventType.CALL])])
+  const allEvents = await getEvents({
+    filters: [requestKeysFilter([requestKey]), eventTypesFilter([EventType.CALL])],
+  })
   return allEvents.map((e) => e.entry.value) as Call[]
 }
 
@@ -102,20 +104,24 @@ export const getCalls = async (
   destVerb: string | undefined = undefined,
   sourceModule: string | undefined = undefined,
 ): Promise<Call[]> => {
-  const allEvents = await getEvents([
-    callFilter(destModule, destVerb, sourceModule),
-    eventTypesFilter([EventType.CALL]),
-  ])
+  const allEvents = await getEvents({
+    filters: [callFilter(destModule, destVerb, sourceModule), eventTypesFilter([EventType.CALL])],
+  })
   return allEvents.map((e) => e.entry.value) as Call[]
 }
 
-export const getEvents = async (
-  filters: EventsQuery_Filter[] = [],
-  limit: number = 100,
-  order: EventsQuery_Order = EventsQuery_Order.DESC,
-): Promise<Event[]> => {
-  const response = await client.getEvents({ filters, limit, order })
+interface GetEventsParams {
+  limit?: number
+  order?: EventsQuery_Order
+  filters?: EventsQuery_Filter[]
+}
 
+export const getEvents = async ({
+  limit = 1000,
+  order = EventsQuery_Order.ASC,
+  filters = [],
+}: GetEventsParams): Promise<Event[]> => {
+  const response = await client.getEvents({ filters, limit, order })
   return response.events
 }
 


### PR DESCRIPTION
Fixes #405 

<img width="490" alt="Screenshot 2023-09-19 at 7 31 28 AM" src="https://github.com/TBD54566975/ftl/assets/51647/f8d5f6a1-9260-4302-8458-71168b4bab94">
