### PR TITLE
fix: display full error message for connect errors

### DIFF
--- a/console/client/src/services/console.service.ts
+++ b/console/client/src/services/console.service.ts
@@ -144,8 +144,10 @@ export const streamEvents = async ({ abortControllerSignal, filters, onEventRece
   } catch (error) {
     if (error instanceof ConnectError) {
       if (error.code !== Code.Canceled) {
-        console.error('Connect error:', error.code)
+        console.error('Console service - streamEvents - Connect error:', error)
       }
+    } else {
+      console.error('Console service - streamEvents:', error)
     }
   }
 }


### PR DESCRIPTION
@alecthomas this should provide more detailed connect errors than just the error `code`. 

Although, I doubt we would have got more info with this specific `code 2` error since it's this 
```ts
    /**
     * Unknown error
     */
    Unknown = 2,
```