### PR TITLE
Improve `ftl status` output readability

### DIFF
--- a/cmd/ftl/cmd_status.go
+++ b/cmd/ftl/cmd_status.go
@@ -37,5 +37,7 @@ func (s *statusCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 			deployment.Schema = nil
 		}
 	}
-	return errors.WithStack((&jsonpb.Marshaler{}).Marshal(os.Stdout, status.Msg))
+	return errors.WithStack((&jsonpb.Marshaler{
+		Indent: "  ",
+	}).Marshal(os.Stdout, status.Msg))
 }


### PR DESCRIPTION
Added JSON formatting w/ indents & line breaks for the `ftl status` output -- previously was a giant JSON all on one line