### PR TITLE
Gracefully handle empty file content in 'ftl deploy'

### DIFF
--- a/cmd/ftl/cmd_deploy.go
+++ b/cmd/ftl/cmd_deploy.go
@@ -60,6 +60,10 @@ func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 		if err != nil {
 			return errors.WithStack(err)
 		}
+		if content == nil || len(content) == 0 {
+			logger.Debugf("Skipping empty or nil content for %s", relToCWD(file.localPath))
+			continue // Skip this iteration and move on to the next one
+		}
 		logger.Debugf("Uploading %s", relToCWD(file.localPath))
 		resp, err := client.UploadArtefact(ctx, connect.NewRequest(&ftlv1.UploadArtefactRequest{
 			Content: content,


### PR DESCRIPTION
Honestly, idk if this is a good idea, but it was blocking me cause I had a stupid empty file in a transitive dependency in my Kotlin target output.

We can merge this is we want, or not. Room for robustness improvements.