### PR TITLE
fix(plugin): log JSON decoding errors for lines that appear to be JSON

### DIFF
--- a/backend/common/log/json.go
+++ b/backend/common/log/json.go
@@ -53,6 +53,10 @@ func JSONStreamer(r io.Reader, log *Logger, defaultLevel Level) error {
 		line := scan.Bytes()
 		err := json.Unmarshal(line, &entry)
 		if err != nil {
+			if len(line) > 0 && line[0] == '{' {
+				log.Warnf("Invalid JSON log entry: %s", err)
+				log.Warnf("Entry: %s", line)
+			}
 			log.Log(Entry{Level: defaultLevel, Time: time.Now(), Message: string(line)})
 		} else {
 			if entry.Error != "" {

--- a/backend/common/plugin/spawn.go
+++ b/backend/common/plugin/spawn.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"context"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -156,7 +155,7 @@ func Spawn[Client PingableClient](
 	}()
 
 	// Write the PID file.
-	err = ioutil.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0600)
+	err = os.WriteFile(pidFile, []byte(strconv.Itoa(cmd.Process.Pid)), 0600)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}


### PR DESCRIPTION
Previously, anything that failed to decode would silently be converted to a text line. With this change, a line that fails to decode but looks like it is JSON will result in a warning.