### PR TITLE
fix: include JAR dependencies in Kotlin deploys

### DIFF
--- a/backend/common/download/download.go
+++ b/backend/common/download/download.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/alecthomas/errors"
@@ -23,6 +24,8 @@ func Artefacts(ctx context.Context, client ftlv1connect.ControllerServiceClient,
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	start := time.Now()
+	count := 0
 	var digest string
 	var w *os.File
 	for stream.Receive() {
@@ -32,6 +35,7 @@ func Artefacts(ctx context.Context, client ftlv1connect.ControllerServiceClient,
 			if w != nil {
 				w.Close()
 			}
+			count++
 			if !filepath.IsLocal(artefact.Path) {
 				return errors.Errorf("path %q is not local", artefact.Path)
 			}
@@ -59,5 +63,6 @@ func Artefacts(ctx context.Context, client ftlv1connect.ControllerServiceClient,
 	if w != nil {
 		w.Close()
 	}
+	logger.Infof("Downloaded %d artefacts in %s", count, time.Since(start))
 	return errors.WithStack(stream.Err())
 }

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>xyz.block</groupId>
@@ -84,6 +84,17 @@
                                     <destFileName>ftl-generator.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/dependency</outputDirectory>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>

--- a/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
+++ b/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
@@ -175,7 +175,7 @@ class ModuleGenerator() {
       """
       module = "${module}"
       language = "kotlin"
-      deploy = ["main", "classes"]
+      deploy = ["main", "classes", "dependency"]
       """.trimIndent()
     )
 
@@ -183,7 +183,7 @@ class ModuleGenerator() {
     mainFile.writeText(
       """
       #!/bin/bash
-      exec java -cp ftl/jars/ftl-runtime.jar:classes xyz.block.ftl.main.MainKt
+      exec java -cp "classes:$(printf %s: dependency/*.jar)" xyz.block.ftl.main.MainKt
       """.trimIndent(),
     )
     mainFile.setPosixFilePermissions(


### PR DESCRIPTION
By adding the following fragment to the POM:

```xml
<execution>
    <id>copy-dependencies</id>
    <phase>compile</phase>
    <goals>
        <goal>copy-dependencies</goal>
    </goals>
    <configuration>
        <outputDirectory>${project.build.directory}/dependency</outputDirectory>
        <includeScope>runtime</includeScope>
    </configuration>
</execution>
```

`ftl deploy ./target` will upload all dependencies as well as compiled source. This actually works super well in practice, and I think we can completely remove the need for building a custom `ftl-runner` Docker image.

One issue is that this now results in the runners having to download quite a few MB of artefacts on each deploy, but we can mitigate this by making the controller->runner artefact download process incremental too, and have each runner maintain its own cache. Probably something for later though, as it's generally pretty fast so far (eg. `runner4 | info: Downloaded 148 artefacts in 1.562282s`).