### PR TITLE
fix: use Maven to output the correct classpath for user code

### DIFF
--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -97,6 +97,17 @@
                             <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>build-classpath</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>build-classpath</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.directory}/classpath.txt</outputFile>
+                            <prefix>dependency</prefix>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <!-- Run the Wire compiler -->

--- a/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
+++ b/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
@@ -175,7 +175,7 @@ class ModuleGenerator() {
       """
       module = "${module}"
       language = "kotlin"
-      deploy = ["main", "classes", "dependency"]
+      deploy = ["main", "classes", "dependency", "classpath.txt"]
       """.trimIndent()
     )
 
@@ -183,7 +183,7 @@ class ModuleGenerator() {
     mainFile.writeText(
       """
       #!/bin/bash
-      exec java -cp "classes:$(printf %s: dependency/*.jar)" xyz.block.ftl.main.MainKt
+      exec java -cp "classes:$(cat classpath.txt)" xyz.block.ftl.main.MainKt
       """.trimIndent(),
     )
     mainFile.setPosixFilePermissions(

--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.6.0</version>
                     <executions>
                         <execution>
                             <phase>initialize</phase>


### PR DESCRIPTION
Then extend `ftl.toml` to use it. This fixes issues where older versions of JARs were shadowing newer versions because we were just file-system globbing the classpath.