### PR TITLE
fix: suppress noisy log spam when scaling runners

### DIFF
--- a/backend/common/rpc/context.go
+++ b/backend/common/rpc/context.go
@@ -121,6 +121,9 @@ func (m *metadataInterceptor) WrapStreamingHandler(req connect.StreamingHandlerF
 		}
 		err = errors.WithStack(req(ctx, s))
 		if err != nil {
+			if connect.CodeOf(err) == connect.CodeCanceled {
+				return nil
+			}
 			logger.Logf(m.errorLevel, "Streaming RPC failed: %s: %s", err, s.Spec().Procedure)
 			return err
 		}

--- a/backend/common/rpc/rpc.go
+++ b/backend/common/rpc/rpc.go
@@ -168,7 +168,9 @@ func RetryStreamingClientStream[Req, Resp any](
 
 		errored = true
 		delay := retry.Duration()
-		logger.Logf(logLevel, "Stream handler failed, retrying in %s: %s", delay, err)
+		if !errors.Is(err, context.Canceled) {
+			logger.Logf(logLevel, "Stream handler failed, retrying in %s: %s", delay, err)
+		}
 		select {
 		case <-ctx.Done():
 			return

--- a/backend/controller/scaling/local_scaling.go
+++ b/backend/controller/scaling/local_scaling.go
@@ -105,8 +105,8 @@ func (l *LocalScaling) SetReplicas(ctx context.Context, replicas int, idleRunner
 		go func() {
 			logger.Infof("Starting runner: %s", config.Key)
 			err := runner.Start(runnerCtx, config)
-			if err != nil {
-				logger.Errorf(err, "Error starting runner: %s", err)
+			if err != nil && !errors.Is(err, context.Canceled) {
+				logger.Errorf(err, "Runner failed: %s", err)
 			}
 		}()
 	}


### PR DESCRIPTION
Also added `--recreate` flag to `ftl serve`.

Fixes #534

Before:

```
info:reconcileRunners: Removing runner: R00000000000000000000002000
warn:runner0: Stream handler failed, retrying in 100ms: context canceled
warn:runner0: Stream handler failed, retrying in 100ms: context canceled
error:reconcileRunners: Error starting runner: context canceled: context canceled
error:controller0: Streaming RPC failed: invalid_argument: protocol error: incomplete envelope: stream error: stream ID 3; CANCEL: /xyz.block.ftl.v1.ControllerService/RegisterRunner
```

After:

```
info:reconcileRunners: Removing runner: R00000000000000000000002000
error:controller0: Streaming RPC failed: invalid_argument: protocol error: incomplete envelope: stream error: stream ID 9; CANCEL: /xyz.block.ftl.v1.ControllerService/StreamDeploymentLogs
```

There's still one error, but it seems more difficult to fix this one, and it seems more intermittent too.