### PR TITLE
chore: add buf breaking change detection to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,27 @@ jobs:
         run: go-check-sumtype ./...
       - name: shellcheck
         run: shellcheck -e SC2016 scripts/*
+  proto-breaking:
+    name: Proto Breaking Change Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+      - name: Proto Breaking Change Check
+        run: |
+          buf breaking --against 'https://github.com/TBD54566975/ftl.git#branch=main' | while read -r line; do
+            # Extract the file path, line number, and column number from the warning message
+            file_path=$(echo "$line" | cut -d':' -f1)
+            line_number=$(echo "$line" | cut -d':' -f2)
+            column_number=$(echo "$line" | cut -d':' -f3)
+
+            # Output the warning message in the format expected by GitHub Actions
+            echo "::error file=$file_path,line=$line_number,col=$column_number::$line"
+          done
   console:
     name: Console
     runs-on: ubuntu-latest


### PR DESCRIPTION
For now this will just add comments to the PR, but once we've stabilised we should make it fail CI.

![breaking](https://github.com/TBD54566975/ftl/assets/41767/3e0f3a3d-63a4-46af-b415-b400e0fbb684)
