### PR TITLE
fix: ftl serve auto start docker container

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -133,6 +133,12 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 
 		recreate = true
 	} else {
+		// Start the existing container
+		_, err = exec.Capture(ctx, ".", "docker", "start", ftlContainerName)
+		if err != nil {
+			return "", errors.WithStack(err)
+		}
+
 		// Grab the port from the existing container
 		cmdStr := fmt.Sprintf("docker port %s 5432/tcp | grep -v '\\[::\\]' | awk -F: '{print $NF}'", ftlContainerName)
 		portOutput, err := exec.Capture(ctx, ".", "sh", "-c", cmdStr)
@@ -142,6 +148,7 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 		}
 
 		port = strings.TrimSpace(string(portOutput))
+
 		logger.Infof("Using docker container '%s' for postgres db", ftlContainerName)
 	}
 


### PR DESCRIPTION
Fixes #562 

Output when container is stopped:
```
ftl serve

info: Using docker container 'ftl-db' for postgres db
info: Postgres DSN: postgres://postgres:secret@localhost:5433/ftl-db?sslmode=disable
info: Starting 1 controller(s) and 0 runner(s)
```
