### PR TITLE
temporarily use base directory as source for detekt type resolution

### DIFF
--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -177,6 +177,7 @@
                             ${project.build.directory}/dependency/ftl-runtime-${ftl.version}.jar
                         </plugin>
                     </plugins>
+                    <input>${project.basedir}</input>
                 </configuration>
                 <executions>
                     <execution>

--- a/examples/online-boutique/services/ad-kotlin/pom.xml
+++ b/examples/online-boutique/services/ad-kotlin/pom.xml
@@ -176,6 +176,7 @@
                             ${project.build.directory}/dependency/ftl-runtime-${ftl.version}.jar
                         </plugin>
                     </plugins>
+                    <input>${project.basedir}</input>
                 </configuration>
                 <executions>
                     <execution>

--- a/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
+++ b/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
@@ -30,7 +30,7 @@ class ModuleGenerator() {
   fun run(schema: Schema, outputDirectory: File, module: String, moduleClientSuffix: String) {
     val fqOutputDir = outputDirectory.absolutePath
     prepareFtlRoot(fqOutputDir, module)
-    val sourcesDest = File(fqOutputDir, "generated-sources/ftl/ftl")
+    val sourcesDest = File(fqOutputDir, "generated-sources")
     schema.modules.filter { it.name != module }.forEach {
       val file = generateModule(it, moduleClientSuffix)
       file.writeTo(sourcesDest)

--- a/kotlin-runtime/scaffolding/pom.xml
+++ b/kotlin-runtime/scaffolding/pom.xml
@@ -180,6 +180,7 @@
                             ${project.build.directory}/dependency/ftl-runtime-${ftl.version}.jar
                         </plugin>
                     </plugins>
+                    <input>${project.basedir}</input>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
for now, we can use the entire base directory as the input source for detekt type resolution. [i've submitted a change](https://github.com/Ozsie/detekt-maven-plugin/pull/214) against the `detekt-maven-plugin` we're using that will allow us to specify multiple input sources. once this goes through we can be more granular to explicitly use the source directory plus generated sources with the following config:
`<input>${project.basedir}/src/main/kotlin,${project.build.directory}/generated-sources/ftl</input>`