### PR TITLE
fix: kotlin ingress was adding "Method"

### DIFF
--- a/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRule.kt
+++ b/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRule.kt
@@ -152,7 +152,7 @@ class SchemaExtractor(val bindingContext: BindingContext, annotation: KtAnnotati
       }
       MetadataIngress(
         path = pathArg,
-        method = methodArg,
+        method = methodArg.substringAfter("."),
       )
     }
   }


### PR DESCRIPTION
Kotlin `extractIngress` was using the full path of the enum `Method.GET` instead of just the value `GET` This would put an ingress route in the db that wouldn't be found with our query.

Since it couldn't be found, all Kotlin ingresses would return `404 not found`

This is a quick change by pulling just the part of the string we want, but we may way a more robust solution the future.