### PR TITLE
fix: don't build ftl-runtime uber JAR

### DIFF
--- a/Bitfile
+++ b/Bitfile
@@ -32,7 +32,7 @@ COMMON_LOG_IN = backend/common/log/api.go
 COMMON_LOG_OUT = backend/common/log/log_level_string.go
 
 KT_RUNTIME_IN = kotlin-runtime/ftl-runtime/**/*.{kt,kts} pom.xml kotlin-runtime/ftl-runtime/**/pom.xml
-KT_RUNTIME_OUT = kotlin-runtime/ftl-runtime/target/ftl-runtime-1.0-SNAPSHOT-jar-with-dependencies.jar
+KT_RUNTIME_OUT = kotlin-runtime/ftl-runtime/target/ftl-runtime-1.0-SNAPSHOT.jar
 KT_RUNTIME_RUNNER_TEMPLATE_OUT = build/template/ftl/jars/ftl-runtime.jar
 
 KT_GENERATOR_IN = kotlin-runtime/ftl-generator/**/*.{kt,kts} pom.xml kotlin-runtime/ftl-runtime/**/pom.xml %{KT_RUNTIME_OUT}

--- a/examples/echo-kotlin/pom.xml
+++ b/examples/echo-kotlin/pom.xml
@@ -89,7 +89,6 @@
                                     <groupId>xyz.block</groupId>
                                     <artifactId>ftl-runtime</artifactId>
                                     <version>${ftl.version}</version>
-                                    <classifier>jar-with-dependencies</classifier>
                                     <destFileName>ftl-runtime.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>

--- a/examples/online-boutique/services/ad-kotlin/pom.xml
+++ b/examples/online-boutique/services/ad-kotlin/pom.xml
@@ -89,7 +89,6 @@
                                     <groupId>xyz.block</groupId>
                                     <artifactId>ftl-runtime</artifactId>
                                     <version>${ftl.version}</version>
-                                    <classifier>jar-with-dependencies</classifier>
                                     <destFileName>ftl-runtime.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>

--- a/kotlin-runtime/ftl-runtime/pom.xml
+++ b/kotlin-runtime/ftl-runtime/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -78,23 +78,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
@@ -122,4 +105,3 @@
         </repository>
     </distributionManagement>
 </project>
-

--- a/kotlin-runtime/scaffolding/pom.xml
+++ b/kotlin-runtime/scaffolding/pom.xml
@@ -89,7 +89,6 @@
                                     <groupId>xyz.block</groupId>
                                     <artifactId>ftl-runtime</artifactId>
                                     <version>${ftl.version}</version>
-                                    <classifier>jar-with-dependencies</classifier>
                                     <destFileName>ftl-runtime.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -16,7 +16,7 @@ build_release() {
   bit build/release/ftl-controller \
     build/release/ftl-runner \
     build/release/ftl \
-    kotlin-runtime/ftl-runtime/target/ftl-runtime-1.0-SNAPSHOT-jar-with-dependencies.jar \
+    kotlin-runtime/ftl-runtime/target/ftl-runtime-1.0-SNAPSHOT.jar \
     kotlin-runtime/ftl-generator/target/ftl-generator-1.0-SNAPSHOT-jar-with-dependencies.jar \
     build/template/ftl/jars/ftl-runtime.jar
 }


### PR DESCRIPTION
Instead we rely on classpath.txt to include everything we need.