### PR TITLE
feat: add `ftl build` command

### DIFF
--- a/backend/common/moduleconfig/config.go
+++ b/backend/common/moduleconfig/config.go
@@ -13,6 +13,7 @@ import (
 type ModuleConfig struct {
 	Language string   `toml:"language"`
 	Module   string   `toml:"module"`
+	Build    string   `toml:"build"`
 	Deploy   []string `toml:"deploy"`
 	Schema   string   `toml:"schema"`
 }

--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+
+	"github.com/TBD54566975/ftl/backend/common/exec"
+	"github.com/TBD54566975/ftl/backend/common/log"
+	"github.com/TBD54566975/ftl/backend/common/moduleconfig"
+	"github.com/alecthomas/errors"
+)
+
+type buildCmd struct {
+	Base string `arg:"" help:"Directory containing ftl.toml" type:"existingdir" default:"."`
+}
+
+func (b *buildCmd) Run(ctx context.Context) error {
+	// Load the TOML file.
+	config, err := moduleconfig.LoadConfig(b.Base)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	switch config.Language {
+	case "kotlin":
+		return b.buildKotlin(ctx, config)
+	default:
+		return errors.Errorf("unable to build. unknown language %q", config.Language)
+	}
+}
+
+func (b *buildCmd) buildKotlin(ctx context.Context, config moduleconfig.ModuleConfig) error {
+	logger := log.FromContext(ctx)
+
+	buildCmd := config.Build
+	if buildCmd == "" {
+		buildCmd = "source ../bin/activate-hermit && mvn compile"
+	}
+
+	logger.Infof("Building kotlin module '%s'", config.Module)
+	logger.Infof("Using build command '%s'", buildCmd)
+
+	// Have to activate hermit within the same shell
+	err := exec.Command(ctx, log.Debug, b.Base, "bash", "-c", buildCmd).Run()
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return nil
+}

--- a/cmd/ftl/cmd_deploy.go
+++ b/cmd/ftl/cmd_deploy.go
@@ -22,15 +22,15 @@ import (
 )
 
 type deployCmd struct {
-	Replicas int32  `short:"n" help:"Number of replicas to deploy." default:"1"`
-	Base     string `arg:"" help:"Directory containing ftl.toml" type:"existingdir" default:"."`
+	Replicas  int32  `short:"n" help:"Number of replicas to deploy." default:"1"`
+	ModuleDir string `arg:"" help:"Directory containing ftl.toml" type:"existingdir" default:"."`
 }
 
 func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
 	logger := log.FromContext(ctx)
 
 	// Load the TOML file.
-	config, err := moduleconfig.LoadConfig(d.Base)
+	config, err := moduleconfig.LoadConfig(d.ModuleDir)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -40,12 +40,12 @@ func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 		return errors.Errorf("no deploy paths defined in config")
 	}
 
-	files, err := findFiles(d.Base, config.Deploy)
+	files, err := findFiles(d.ModuleDir, config.Deploy)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
-	filesByHash, err := hashFiles(d.Base, files)
+	filesByHash, err := hashFiles(d.ModuleDir, files)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -54,7 +54,7 @@ func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 		return errors.WithStack(err)
 	}
 
-	schema, err := findFiles(d.Base, []string{config.Schema})
+	schema, err := findFiles(d.ModuleDir, []string{config.Schema})
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -36,6 +36,7 @@ type CLI struct {
 	Update   updateCmd   `cmd:"" help:"Update a deployment."`
 	Kill     killCmd     `cmd:"" help:"Kill a deployment."`
 	Schema   schemaCmd   `cmd:"" help:"FTL schema commands."`
+	Build    buildCmd    `cmd:"" help:"Build an FTL module."`
 	Deploy   deployCmd   `cmd:"" help:"Create a new deployment."`
 	Download downloadCmd `cmd:"" help:"Download a deployment."`
 }


### PR DESCRIPTION
Fixes #597

This currently only supports building `kotlin` modules. `go` support will be added in the future.

I'm not 100% sure if this is the best way to activate `hermit` as part of the build but we can discuss.

Create new module and build:
```bash
ftl init kotlin services alice

ftl build services/ftl-module-alice
info: Building kotlin module 'alice'
info: Using build command 'source ../bin/activate-hermit && mvn compile'
```

With log-level=debug
```bash
ftl build services/ftl-module-alice --log-level=debug
info: Building kotlin module 'alice'
info: Using build command 'source ../bin/activate-hermit && mvn compile'
debug: ../bin/activate-hermit: line 61: /bin/hermit: No such file or directory
debug: ../bin/activate-hermit: line 20: /bin/hermit: No such file or directory
debug: Hermit environment  activated
debug: [INFO] Scanning for projects...
debug: [INFO]
debug: [INFO] ------------------------< ftl:ftl-module-alice >------------------------
debug: [INFO] Building ftl-module-alice 1.0-SNAPSHOT
debug: [INFO] --------------------------------[ jar ]---------------------------------
debug: [INFO]
debug: [INFO] --- maven-dependency-plugin:3.2.0:copy (default) @ ftl-module-alice ---
debug: [INFO] Configured Artifact: xyz.block:ftl-generator:jar-with-dependencies:1.0-SNAPSHOT:jar
```

Default build command can be overridden in `ftl.toml`

```toml
module = "alice"
language = "kotlin"
build = "source ../bin/activate-hermit && mvn clean compile"
deploy = [
  "target/main",
  "target/classes",
  "target/dependency",
  "target/classpath.txt",
]
```
```bash
ftl build services/ftl-module-alice
info: Building kotlin module 'alice'
info: Using build command 'source ../bin/activate-hermit && mvn clean compile'
```

Example errors:

Building a `go` module:
```bash
ftl build echo
ftl: error: unable to build. unknown language "go"
```

`toml` not found
```bash
ftl build bogus
ftl: error: [<base>]: stat /Users/wesbillman/dev/ftl/examples/bogus: no such file or directory
```