### PR TITLE
revert: "fix: schema scaffold copy errors"

### DIFF
--- a/cmd/ftl/cmd_schema.go
+++ b/cmd/ftl/cmd_schema.go
@@ -12,7 +12,6 @@ import (
 	"github.com/TBD54566975/scaffolder"
 	"github.com/alecthomas/errors"
 	"github.com/golang/protobuf/proto"
-	"github.com/otiai10/copy"
 	"github.com/radovskyb/watcher"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
@@ -177,9 +176,6 @@ func (s *schemaGenerateCmd) regenerateModules(logger *log.Logger, modules []*sch
 		return errors.WithStack(err)
 	}
 	for _, module := range modules {
-		if err := copy.Copy(s.Template, s.Dest); err != nil {
-			return errors.WithStack(err)
-		}
 		if err := scaffolder.Scaffold(s.Template, s.Dest, module, scaffolder.Functions(scaffoldFuncs)); err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
Reverts TBD54566975/ftl#615

This needs a bit more thought. It's also copying the template files, which we won't want to do.