### PR TITLE
feat: client logs a warning if its version is older than the server

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,7 +11,7 @@ builds:
       - linux
       - darwin
     flags: -trimpath
-    ldflags: -s -w -buildid= -X main.version={{.Version}} -X  main.timestamp={{ .CommitTimestamp }}
+    ldflags: -s -w -buildid= -X github.com/TBD54566975/ftl.Version={{.Version}} -X  github.com/TBD54566975/ftl.Timestamp={{ .CommitTimestamp }}
     tags: [release]
   - id: ftl-runner
     main: ./cmd/ftl-runner
@@ -25,7 +25,7 @@ builds:
       - linux
       - darwin
     flags: -trimpath
-    ldflags: -s -w -buildid= -X main.version={{.Version}} -X  main.timestamp={{ .CommitTimestamp }}
+    ldflags: -s -w -buildid= -X github.com/TBD54566975/ftl.Version={{.Version}} -X  github.com/TBD54566975/ftl.Timestamp={{ .CommitTimestamp }}
     tags: [release]
   - id: ftl
     main: ./cmd/ftl
@@ -39,7 +39,7 @@ builds:
       - linux
       - darwin
     flags: -trimpath
-    ldflags: -s -w -buildid= -X main.version={{.Version}} -X  main.timestamp={{ .CommitTimestamp }}
+    ldflags: -s -w -buildid= -X github.com/TBD54566975/ftl.Version={{.Version}} -X  github.com/TBD54566975/ftl.Timestamp={{ .CommitTimestamp }}
     tags: [release]
   - id: ftl-initdb
     main: ./cmd/ftl-initdb
@@ -53,7 +53,7 @@ builds:
       - linux
       - darwin
     flags: -trimpath
-    ldflags: -s -w -buildid= -X main.version={{.Version}} -X  main.timestamp={{ .CommitTimestamp }}
+    ldflags: -s -w -buildid= -X github.com/TBD54566975/ftl.Version={{.Version}} -X  github.com/TBD54566975/ftl.Timestamp={{ .CommitTimestamp }}
     tags: [release]
 
 archives:

--- a/Bitfile
+++ b/Bitfile
@@ -68,19 +68,19 @@ RUNNER_TEMPLATE_ZIP = backend/controller/scaling/localscaling/template.zip
 # Build all binaries
 # implicit %{RELEASE}/%{1}: cmd/*
 #   inputs: %{RELEASE} %{GO_SOURCES} %{CLIENT_OUT}
-#   build: go build -o %{OUT} -tags release -ldflags "-X main.version=%{VERSION} -X main.timestamp=$(date +%s)" ./cmd/%{1}
+#   build: go build -o %{OUT} -tags release -ldflags "-X github.com/TBD54566975/ftl.Version=%{VERSION} -X github.com/TBD54566975/ftl.Timestamp=$(date +%s)" ./cmd/%{1}
 
 %{RELEASE}/ftl-controller: %{RELEASE} %{GO_SOURCES} %{CLIENT_OUT} cmd/ftl-controller/**/*.go
-  build: go build -o %{OUT} -tags release -ldflags "-X main.version=%{VERSION} -X main.timestamp=$(date +%s)" ./cmd/ftl-controller
+  build: go build -o %{OUT} -tags release -ldflags "-X github.com/TBD54566975/ftl.Version=%{VERSION} -X github.com/TBD54566975/ftl.Timestamp=$(date +%s)" ./cmd/ftl-controller
 
 %{RELEASE}/ftl-runner: %{RELEASE} %{GO_SOURCES} cmd/ftl-runner/**/*.go
-  build: go build -o %{OUT} -tags release -ldflags "-X main.version=%{VERSION} -X main.timestamp=$(date +%s)" ./cmd/ftl-runner
+  build: go build -o %{OUT} -tags release -ldflags "-X github.com/TBD54566975/ftl.Version=%{VERSION} -X github.com/TBD54566975/ftl.Timestamp=$(date +%s)" ./cmd/ftl-runner
 
 %{RELEASE}/ftl: %{RELEASE} %{GO_SOURCES} cmd/ftl/**/*.go %{CLIENT_OUT} **/*.zip
-  build: go build -o %{OUT} -tags release -ldflags "-X main.version=%{VERSION} -X main.timestamp=$(date +%s)" ./cmd/ftl
+  build: go build -o %{OUT} -tags release -ldflags "-X github.com/TBD54566975/ftl.Version=%{VERSION} -X github.com/TBD54566975/ftl.Timestamp=$(date +%s)" ./cmd/ftl
 
 %{RELEASE}/ftl-initdb: %{RELEASE} %{GO_SOURCES} cmd/ftl-initdb/**/*.go
-  build: go build -o %{OUT} -tags release -ldflags "-X main.version=%{VERSION} -X main.timestamp=$(date +%s)" ./cmd/ftl-initdb
+  build: go build -o %{OUT} -tags release -ldflags "-X github.com/TBD54566975/ftl.Version=%{VERSION} -X github.com/TBD54566975/ftl.Timestamp=$(date +%s)" ./cmd/ftl-initdb
 
 # Release builds include zipped scaffolding becaused raw go:embed doesn't
 # preserve permissions or symlinks. Irritating.

--- a/backend/common/rpc/rpc.go
+++ b/backend/common/rpc/rpc.go
@@ -18,7 +18,7 @@ import (
 	ftlv1 "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1"
 )
 
-// InitialiseClients HTTP clients used by the RPC system.
+// InitialiseClients initialises global HTTP clients used by the RPC system.
 //
 // "authenticators" are authenticator executables to use for each endpoint. The key is the URL of the endpoint, the
 // value is the path to the authenticator executable.

--- a/cmd/ftl-controller/main.go
+++ b/cmd/ftl-controller/main.go
@@ -9,15 +9,13 @@ import (
 
 	"github.com/alecthomas/kong"
 
+	"github.com/TBD54566975/ftl"
 	_ "github.com/TBD54566975/ftl/backend/common/automaxprocs" // Set GOMAXPROCS to match Linux container CPU quota.
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/observability"
 	"github.com/TBD54566975/ftl/backend/controller"
 	"github.com/TBD54566975/ftl/backend/controller/scaling"
 )
-
-var version = "dev"
-var timestamp = "0"
 
 var cli struct {
 	Version             kong.VersionFlag     `help:"Show version."`
@@ -27,17 +25,17 @@ var cli struct {
 }
 
 func main() {
-	t, err := strconv.ParseInt(timestamp, 10, 64)
+	t, err := strconv.ParseInt(ftl.Timestamp, 10, 64)
 	if err != nil {
-		panic(fmt.Sprintf("invalid timestamp %q: %s", timestamp, err))
+		panic(fmt.Sprintf("invalid timestamp %q: %s", ftl.Timestamp, err))
 	}
 	kctx := kong.Parse(&cli,
 		kong.Description(`FTL - Towards a 𝝺-calculus for large-scale systems`),
 		kong.UsageOnError(),
-		kong.Vars{"version": version, "timestamp": time.Unix(t, 0).Format(time.RFC3339)},
+		kong.Vars{"version": ftl.Version, "timestamp": time.Unix(t, 0).Format(time.RFC3339)},
 	)
 	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
-	err = observability.Init(ctx, "ftl-controller", version, cli.ObservabilityConfig)
+	err = observability.Init(ctx, "ftl-controller", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
 	err = controller.Start(ctx, cli.ControllerConfig, scaling.NewK8sScaling())

--- a/cmd/ftl-runner/main.go
+++ b/cmd/ftl-runner/main.go
@@ -7,13 +7,12 @@ import (
 
 	"github.com/alecthomas/kong"
 
+	"github.com/TBD54566975/ftl"
 	_ "github.com/TBD54566975/ftl/backend/common/automaxprocs" // Set GOMAXPROCS to match Linux container CPU quota.
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/observability"
 	"github.com/TBD54566975/ftl/backend/runner"
 )
-
-var version = "dev"
 
 var cli struct {
 	Version             kong.VersionFlag     `help:"Show version."`
@@ -33,7 +32,7 @@ FTL - Towards a 𝝺-calculus for large-scale systems
 The Runner is the component of FTL that coordinates with the Controller to spawn
 and route to user code.
 	`), kong.Vars{
-		"version":       version,
+		"version":       ftl.Version,
 		"deploymentdir": filepath.Join(cacheDir, "ftl-runner", "${runner}", "deployments"),
 	})
 	// Substitute in the runner key into the deployment directory.
@@ -45,7 +44,7 @@ and route to user code.
 	})
 	logger := log.Configure(os.Stderr, cli.LogConfig)
 	ctx := log.ContextWithLogger(context.Background(), logger)
-	err = observability.Init(ctx, "ftl-runner", version, cli.ObservabilityConfig)
+	err = observability.Init(ctx, "ftl-runner", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 	err = runner.Start(ctx, cli.RunnerConfig)
 	kctx.FatalIfErrorf(err)

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -180,6 +180,7 @@ func pollContainerHealth(ctx context.Context, containerName string, timeout time
 		select {
 		case <-pollCtx.Done():
 			return errors.New("timed out waiting for container to be healthy")
+
 		case <-time.After(1 * time.Millisecond):
 			output, err := exec.Capture(pollCtx, ".", "docker", "inspect", "--format", "{{.State.Health.Status}}", containerName)
 			if err != nil {

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -12,13 +12,12 @@ import (
 	"github.com/alecthomas/kong"
 	kongtoml "github.com/alecthomas/kong-toml"
 
+	"github.com/TBD54566975/ftl"
 	_ "github.com/TBD54566975/ftl/backend/common/automaxprocs" // Set GOMAXPROCS to match Linux container CPU quota.
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/rpc"
 	"github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/ftlv1connect"
 )
-
-var version = "dev"
 
 type CLI struct {
 	Version   kong.VersionFlag `help:"Show version."`
@@ -56,7 +55,7 @@ func main() {
 			return &kong.Group{Key: node.Name, Title: "Command flags:"}
 		}),
 		kong.Vars{
-			"version": version,
+			"version": ftl.Version,
 			"os":      runtime.GOOS,
 			"arch":    runtime.GOARCH,
 		},

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -32,6 +32,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa // indirect
+	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect

--- a/examples/online-boutique/go.mod
+++ b/examples/online-boutique/go.mod
@@ -35,6 +35,7 @@ require (
 	go.opentelemetry.io/otel v1.21.0 // indirect
 	go.opentelemetry.io/otel/metric v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
+	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect

--- a/version.go
+++ b/version.go
@@ -1,0 +1,7 @@
+package ftl
+
+// Version of FTL binary (set by linker).
+var Version = "dev"
+
+// Timestamp of FTL binary (set by linker).
+var Timestamp = "0"


### PR DESCRIPTION
The FTL servers now return their version in response headers. We should do some "real" semver checking down the line, but for now a simple warning if the client is older than the server should be okay.

Fixes #625 