### PR TITLE
fix(kt): optional fields now default to null

### DIFF
--- a/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
+++ b/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
@@ -69,7 +69,12 @@ class ModuleGenerator() {
     type.fields.forEach { field ->
       dataClassBuilder.addKdoc(field.comments.joinToString("\n"))
       field.type?.let {
-        dataConstructorBuilder.addParameter(field.name, getTypeClass(it, namespace))
+        var parameter = ParameterSpec
+          .builder(field.name, getTypeClass(it, namespace))
+        if (it.optional != null) {
+          parameter = parameter.defaultValue("null")
+        }
+        dataConstructorBuilder.addParameter(parameter.build())
         dataClassBuilder.addProperty(
           PropertySpec.builder(field.name, getTypeClass(it, namespace)).initializer(field.name).build()
         )

--- a/kotlin-runtime/ftl-generator/src/test/kotlin/xyz/block/ftl/generator/ModuleGeneratorTest.kt
+++ b/kotlin-runtime/ftl-generator/src/test/kotlin/xyz/block/ftl/generator/ModuleGeneratorTest.kt
@@ -108,7 +108,7 @@ public data class TestResponse(
   public val string: String,
   public val bool: Boolean,
   public val time: OffsetDateTime,
-  public val optional: String?,
+  public val optional: String? = null,
   public val array: ArrayList<String>,
   public val nestedArray: ArrayList<ArrayList<String>>,
   public val dataRefArray: ArrayList<TestRequest>,


### PR DESCRIPTION
Before:

```kotlin
data class Foo(
  val bar: String?,
)
```

After:

```kotlin
data class Foo(
  val bar: String? = null
)
```