### PR TITLE
refactor: switch to errtrace for error stacks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,0 @@
-#!/usr/bin/env sh
-
-cd frontend && npx lint-staged

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,8 @@ jobs:
         run: bit frontend/dist/index.html
       - name: Publish Go Binaries
         run: |
+          git ls-files -- '*.go' | xargs errtrace -w && go mod tidy
           bit build/release/ftl
-          goreleaser release
+          goreleaser release --skip=validate
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,6 +71,7 @@ linters:
     - interfacebloat
     - tagalign
     - nolintlint
+    - wrapcheck # We might want to re-enable this if we manually wrap all the existing errors with fmt.Errorf
 
 linters-settings:
   exhaustive:
@@ -92,15 +93,17 @@ linters-settings:
     rules:
       main:
         deny:
-          - pkg: errors
-            desc: "use github.com/alecthomas/errors"
           - pkg: github.com/pkg/errors
-            desc: "use github.com/alecthomas/errors"
+            desc: "use fmt.Errorf or errors.New"
           - pkg: github.com/stretchr/testify
-            desc: "use alecthomas/assert"
-  wrapcheck:
-    ignorePackageGlobs:
-      - github.com/TBD54566975/ftl/*
+            desc: "use fmt.Errorf or errors.New"
+          - pkg: github.com/alecthomas/errors
+            desc: "use fmt.Errorf or errors.New"
+          - pkg: braces.dev/errtrace
+            desc: "use fmt.Errorf or errors.New"
+  # wrapcheck:
+  #   ignorePackageGlobs:
+  #     - github.com/TBD54566975/ftl/*
 
 issues:
   max-same-issues: 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,0 @@
-repos:
--   repo: local
-    hooks:
-    -   id: lint-staged
-        name: lint-staged
-        entry: .githooks/pre-commit
-        language: script
-        pass_filenames: false  # Use this if your script does not expect file arguments. Adjust as necessary.

--- a/Dockerfile.console
+++ b/Dockerfile.console
@@ -1,9 +1,0 @@
-FROM  mcr.microsoft.com/playwright:v1.40.1-jammy
-
-WORKDIR /console
-
-COPY package-lock.json .
-COPY package.json .
-COPY frontend/package.json frontend/package.json
-
-RUN npm install

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -19,6 +19,7 @@ RUN go mod download -x
 
 # Build
 COPY . /src/
+RUN git ls-files -- '*.go' | xargs errtrace -w && go mod tidy
 RUN bit build/release/ftl-controller
 RUN bit build/release/ftl-initdb
 RUN bit build/release/ftl

--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -26,6 +26,7 @@ COPY . /src/
 RUN bit build/template/ftl/jars/ftl-runtime.jar
 
 # Build runner
+RUN git ls-files -- '*.go' | xargs errtrace -w && go mod tidy
 RUN bit build/release/ftl-runner
 RUN bit build/release/ftl
 

--- a/authn/authn.go
+++ b/authn/authn.go
@@ -3,6 +3,7 @@ package authn
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/alecthomas/errors"
 	"github.com/zalando/go-keyring"
 
 	"github.com/TBD54566975/ftl/backend/common/exec"
@@ -46,7 +46,7 @@ func GetAuthenticationHeaders(ctx context.Context, endpoint *url.URL, authentica
 
 	usr, err := user.Current()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	// First, check if we have credentials in the keyring and that they work.
@@ -62,7 +62,7 @@ func GetAuthenticationHeaders(ctx context.Context, endpoint *url.URL, authentica
 	} else {
 		logger.Tracef("Credentials found in keyring: %s", creds)
 		if headers, err := checkAuth(ctx, logger, endpoint, creds); err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		} else if headers != nil {
 			return headers, nil
 		}
@@ -73,13 +73,13 @@ func GetAuthenticationHeaders(ctx context.Context, endpoint *url.URL, authentica
 	cmd.Stdout = out
 	err = cmd.Run()
 	if err != nil {
-		return nil, errors.Wrapf(err, "authenticator %s failed", authenticator)
+		return nil, fmt.Errorf("authenticator %s failed: %w", authenticator, err)
 	}
 
 	creds = out.String()
 	headers, err := checkAuth(ctx, logger, endpoint, creds)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	} else if headers == nil {
 		return nil, nil
 	}
@@ -108,12 +108,12 @@ func checkAuth(ctx context.Context, logger *log.Logger, endpoint *url.URL, creds
 		line := buf.Text()
 		name, value, ok := strings.Cut(line, ":")
 		if !ok {
-			return nil, errors.Errorf("invalid header %q", line)
+			return nil, fmt.Errorf("invalid header %q", line)
 		}
 		headers[name] = append(headers[name], strings.TrimSpace(value))
 	}
 	if buf.Err() != nil {
-		return nil, errors.WithStack(buf.Err())
+		return nil, buf.Err()
 	}
 
 	// Issue a HEAD request with the headers to verify we get a 200 back.
@@ -125,7 +125,7 @@ func checkAuth(ctx context.Context, logger *log.Logger, endpoint *url.URL, creds
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodHead, endpoint.String(), nil)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	logger.Debugf("Authentication probe: %s %s", req.Method, req.URL)
 	for header, values := range headers {
@@ -136,7 +136,7 @@ func checkAuth(ctx context.Context, logger *log.Logger, endpoint *url.URL, creds
 	logger.Tracef("Authenticating with headers %s", headers)
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	defer resp.Body.Close() //nolint:gosec
 	if resp.StatusCode != http.StatusOK {
@@ -177,7 +177,7 @@ func (a *authnTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		var err error
 		creds, err = GetAuthenticationHeaders(r.Context(), r.URL, a.authenticators)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get authentication headers for %s", r.URL.Hostname())
+			return nil, fmt.Errorf("failed to get authentication headers for %s: %w", r.URL.Hostname(), err)
 		}
 		a.lock.Lock()
 		a.credentials[r.URL.Hostname()] = creds
@@ -189,5 +189,5 @@ func (a *authnTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 	}
 	resp, err := a.next.RoundTrip(r)
-	return resp, errors.WithStack(err)
+	return resp, err
 }

--- a/backend/common/bind/bind_allocator.go
+++ b/backend/common/bind/bind_allocator.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/alecthomas/atomic"
-	"github.com/alecthomas/errors"
 )
 
 type BindAllocator struct {
@@ -18,12 +17,12 @@ type BindAllocator struct {
 func NewBindAllocator(url *url.URL) (*BindAllocator, error) {
 	_, portStr, err := net.SplitHostPort(url.Host)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	port, err := strconv.Atoi(portStr)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	return &BindAllocator{

--- a/backend/common/exec/exec.go
+++ b/backend/common/exec/exec.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"syscall"
 
-	"github.com/alecthomas/errors"
 	"github.com/kballard/go-shellquote"
 
 	"github.com/TBD54566975/ftl/backend/common/log"
@@ -18,7 +17,7 @@ type Cmd struct {
 
 func LookPath(exe string) (string, error) {
 	path, err := exec.LookPath(exe)
-	return path, errors.WithStack(err)
+	return path, err
 }
 
 func Capture(ctx context.Context, dir, exe string, args ...string) ([]byte, error) {
@@ -26,7 +25,7 @@ func Capture(ctx context.Context, dir, exe string, args ...string) ([]byte, erro
 	cmd.Stdout = nil
 	cmd.Stderr = nil
 	out, err := cmd.CombinedOutput()
-	return out, errors.WithStack(err)
+	return out, err
 }
 
 func Command(ctx context.Context, level log.Level, dir, exe string, args ...string) *Cmd {
@@ -54,5 +53,5 @@ func (c *Cmd) Kill(signal syscall.Signal) error {
 	if c.Process == nil {
 		return nil
 	}
-	return errors.WithStack(syscall.Kill(c.Process.Pid, signal))
+	return syscall.Kill(c.Process.Pid, signal)
 }

--- a/backend/common/log/json.go
+++ b/backend/common/log/json.go
@@ -3,10 +3,9 @@ package log
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"io"
 	"time"
-
-	"github.com/alecthomas/errors"
 )
 
 var _ Sink = (*jsonSink)(nil)
@@ -39,7 +38,7 @@ func (j *jsonSink) Log(entry Entry) error {
 		Error: errStr,
 		Entry: entry,
 	}
-	return errors.WithStack(j.enc.Encode(jentry))
+	return j.enc.Encode(jentry)
 }
 
 // JSONStreamer reads a stream of JSON log entries from r and logs them to log.
@@ -73,5 +72,5 @@ func JSONStreamer(r io.Reader, log *Logger, defaultLevel Level) error {
 	if errors.Is(err, io.EOF) {
 		return nil
 	}
-	return errors.WithStack(err)
+	return err
 }

--- a/backend/common/log/plain.go
+++ b/backend/common/log/plain.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/alecthomas/errors"
 	"github.com/mattn/go-isatty"
 )
 
@@ -51,7 +50,7 @@ func (t *plainSink) Log(entry Entry) error {
 		_, err = fmt.Fprintf(t.w, "%s%s\n", prefix, entry.Message)
 	}
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	return nil
 }

--- a/backend/common/log/tee.go
+++ b/backend/common/log/tee.go
@@ -1,7 +1,7 @@
 package log
 
 import (
-	"github.com/alecthomas/errors"
+	"errors"
 )
 
 // Tee returns a sink that writes to all of the given sinks.

--- a/backend/common/model/deployment_name.go
+++ b/backend/common/model/deployment_name.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/types"
 )
 
@@ -37,14 +36,14 @@ func ParseDeploymentName(name string) (DeploymentName, error) {
 	var zero DeploymentName
 	parts := strings.Split(name, "-")
 	if len(parts) < 2 {
-		return zero, errors.Errorf("should be at least <deployment>-<hash>: invalid deployment name %q", name)
+		return zero, fmt.Errorf("should be at least <deployment>-<hash>: invalid deployment name %q", name)
 	}
 	hash, err := hex.DecodeString(parts[len(parts)-1])
 	if err != nil {
-		return zero, errors.Wrapf(err, "invalid deployment name %q", name)
+		return zero, fmt.Errorf("invalid deployment name %q: %w", name, err)
 	}
 	if len(hash) != 5 {
-		return zero, errors.Errorf("hash should be 5 bytes: invalid deployment name %q", name)
+		return zero, fmt.Errorf("hash should be 5 bytes: invalid deployment name %q", name)
 	}
 	return DeploymentName(fmt.Sprintf("%s-%010x", strings.Join(parts[0:len(parts)-1], "-"), hash)), nil
 }

--- a/backend/common/model/model.go
+++ b/backend/common/model/model.go
@@ -1,11 +1,10 @@
 package model
 
 import (
+	"errors"
 	"io"
 	"strconv"
 	"strings"
-
-	"github.com/alecthomas/errors"
 
 	"github.com/TBD54566975/ftl/backend/common/sha256"
 	"github.com/TBD54566975/ftl/backend/schema"

--- a/backend/common/model/request_name.go
+++ b/backend/common/model/request_name.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/types"
 )
 
@@ -43,7 +42,7 @@ func ParseOrigin(origin string) (Origin, error) {
 	case "pubsub":
 		return OriginPubsub, nil
 	default:
-		return "", errors.Errorf("unknown origin %q", origin)
+		return "", fmt.Errorf("unknown origin %q", origin)
 	}
 }
 
@@ -63,18 +62,18 @@ func NewRequestName(origin Origin, key string) RequestName {
 func ParseRequestName(name string) (Origin, RequestName, error) {
 	parts := strings.Split(name, "-")
 	if len(parts) < 3 {
-		return "", "", errors.Errorf("should be <origin>-<key>-<hash>: invalid request name %q", name)
+		return "", "", fmt.Errorf("should be <origin>-<key>-<hash>: invalid request name %q", name)
 	}
 	origin, err := ParseOrigin(parts[0])
 	if err != nil {
-		return "", "", errors.Wrapf(err, "invalid request name %q", name)
+		return "", "", fmt.Errorf("invalid request name %q: %w", name, err)
 	}
 	hash, err := hex.DecodeString(parts[len(parts)-1])
 	if err != nil {
-		return "", "", errors.Wrapf(err, "invalid request name %q", name)
+		return "", "", fmt.Errorf("invalid request name %q: %w", name, err)
 	}
 	if len(hash) != 5 {
-		return "", "", errors.Errorf("hash should be 5 bytes: invalid request name %q", name)
+		return "", "", fmt.Errorf("hash should be 5 bytes: invalid request name %q", name)
 	}
 	return origin, RequestName(fmt.Sprintf("%s-%010x", strings.Join(parts[0:len(parts)-1], "-"), hash)), nil
 }
@@ -102,7 +101,7 @@ func (d *RequestName) Scan(value any) error {
 	}
 	str, ok := value.(string)
 	if !ok {
-		return errors.Errorf("expected string, got %T", value)
+		return fmt.Errorf("expected string, got %T", value)
 	}
 	_, name, err := ParseRequestName(str)
 	if err != nil {

--- a/backend/common/moduleconfig/config.go
+++ b/backend/common/moduleconfig/config.go
@@ -4,7 +4,6 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
-	"github.com/alecthomas/errors"
 )
 
 // ModuleConfig is the configuration for an FTL module.
@@ -26,7 +25,7 @@ func LoadConfig(dir string) (ModuleConfig, error) {
 	config := ModuleConfig{}
 	_, err := toml.DecodeFile(path, &config)
 	if err != nil {
-		return ModuleConfig{}, errors.WithStack(err)
+		return ModuleConfig{}, err
 	}
 	setConfigDefaults(&config)
 	return config, nil

--- a/backend/common/observability/client.go
+++ b/backend/common/observability/client.go
@@ -2,10 +2,10 @@ package observability
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
-	"github.com/alecthomas/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -53,12 +53,12 @@ func Init(ctx context.Context, serviceName, serviceVersion string, config Config
 			semconv.ServiceVersion(serviceVersion),
 		))
 	if err != nil {
-		return errors.Wrap(err, "failed to create OTEL resource")
+		return fmt.Errorf("%s: %w", "failed to create OTEL resource", err)
 	}
 
 	otelMetricExporter, err := otlpmetricgrpc.New(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to create OTEL metric exporter")
+		return fmt.Errorf("%s: %w", "failed to create OTEL metric exporter", err)
 	}
 
 	meterProvider := metric.NewMeterProvider(metric.WithReader(metric.NewPeriodicReader(otelMetricExporter)), metric.WithResource(res))
@@ -66,7 +66,7 @@ func Init(ctx context.Context, serviceName, serviceVersion string, config Config
 
 	otelTraceExporter, err := otlptracegrpc.New(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to create OTEL trace exporter")
+		return fmt.Errorf("%s: %w", "failed to create OTEL trace exporter", err)
 	}
 	traceProvider := trace.NewTracerProvider(trace.WithBatcher(otelTraceExporter), trace.WithResource(res))
 	otel.SetTracerProvider(traceProvider)

--- a/backend/common/rpc/context_test.go
+++ b/backend/common/rpc/context_test.go
@@ -5,9 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/alecthomas/assert/v2"
-
 	"github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/alecthomas/assert/v2"
 )
 
 func TestRPCContext(t *testing.T) {

--- a/backend/common/rpc/headers/headers.go
+++ b/backend/common/rpc/headers/headers.go
@@ -1,9 +1,9 @@
 package headers
 
 import (
+	"fmt"
 	"net/http"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/types"
 
 	"github.com/TBD54566975/ftl/backend/common/model"
@@ -44,7 +44,7 @@ func GetRequestName(header http.Header) (model.RequestName, bool, error) {
 
 	var _, key, err = model.ParseRequestName(keyStr)
 	if err != nil {
-		return "", false, errors.WithStack(err)
+		return "", false, err
 	}
 	return key, true, nil
 }
@@ -59,7 +59,7 @@ func GetCallers(header http.Header) ([]*schema.VerbRef, error) {
 	for i, header := range headers {
 		ref, err := schema.ParseRef(header)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid %s header %q", VerbHeader, header)
+			return nil, fmt.Errorf("invalid %s header %q: %w", VerbHeader, header, err)
 		}
 		refs[i] = (*schema.VerbRef)(ref)
 	}
@@ -76,7 +76,7 @@ func GetCaller(header http.Header) (types.Option[*schema.VerbRef], error) {
 	}
 	ref, err := schema.ParseRef(headers[len(headers)-1])
 	if err != nil {
-		return types.None[*schema.VerbRef](), errors.WithStack(err)
+		return types.None[*schema.VerbRef](), err
 	}
 	return types.Some((*schema.VerbRef)(ref)), nil
 }

--- a/backend/common/sha256/sha256.go
+++ b/backend/common/sha256/sha256.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-
-	"github.com/alecthomas/errors"
 )
 
 // SHA256 is a type-safe wrapper around a SHA256 hash.
@@ -22,13 +20,13 @@ func SumReader(r io.Reader) (SHA256, error) {
 	_, err := io.Copy(h, r)
 	var out SHA256
 	copy(out[:], h.Sum(nil))
-	return out, errors.WithStack(err)
+	return out, err
 }
 
 func SumFile(path string) (SHA256, error) {
 	f, err := os.Open(path)
 	if err != nil {
-		return SHA256{}, errors.WithStack(err)
+		return SHA256{}, err
 	}
 	defer f.Close() //nolint:gosec
 	return SumReader(f)
@@ -59,7 +57,7 @@ func MustParseSHA256(s string) SHA256 {
 
 func (s *SHA256) UnmarshalText(text []byte) error {
 	_, err := hex.Decode(s[:], text)
-	return errors.WithStack(err)
+	return err
 }
 func (s SHA256) MarshalText() ([]byte, error) { return []byte(hex.EncodeToString(s[:])), nil }
 func (s SHA256) String() string               { return hex.EncodeToString(s[:]) }

--- a/backend/controller/dal/dal_test.go
+++ b/backend/controller/dal/dal_test.go
@@ -9,15 +9,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/alecthomas/assert/v2"
-	"github.com/alecthomas/types"
-
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/model"
 	"github.com/TBD54566975/ftl/backend/common/sha256"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
 	"github.com/TBD54566975/ftl/backend/schema"
 	ftlv1 "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1"
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/types"
 )
 
 //nolint:maintidx

--- a/backend/controller/deployment_logs.go
+++ b/backend/controller/deployment_logs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/types"
 
 	"github.com/TBD54566975/ftl/backend/common/log"
@@ -38,7 +37,7 @@ func (d *deploymentLogsSink) Log(entry log.Entry) error {
 	case d.logQueue <- entry:
 	default:
 		// Drop log entry if queue is full
-		return errors.Errorf("log queue is full")
+		return fmt.Errorf("log queue is full")
 	}
 	return nil
 }

--- a/backend/controller/sql/conn.go
+++ b/backend/controller/sql/conn.go
@@ -3,7 +3,6 @@ package sql
 import (
 	"context"
 
-	"github.com/alecthomas/errors"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -26,7 +25,7 @@ func (d *DB) Conn() DBI { return d.conn }
 func (d *DB) Begin(ctx context.Context) (*Tx, error) {
 	tx, err := d.conn.Begin(ctx)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return &Tx{tx: tx, Queries: New(tx)}, nil
 }
@@ -37,11 +36,11 @@ type Tx struct {
 }
 
 func (t *Tx) Commit(ctx context.Context) error {
-	return errors.WithStack(t.tx.Commit(ctx))
+	return t.tx.Commit(ctx)
 }
 
 func (t *Tx) Rollback(ctx context.Context) error {
-	return errors.WithStack(t.tx.Rollback(ctx))
+	return t.tx.Rollback(ctx)
 }
 
 // CommitOrRollback can be used in a defer statement to commit or rollback a
@@ -57,6 +56,6 @@ func (t *Tx) CommitOrRollback(ctx context.Context, err *error) {
 	if *err != nil {
 		_ = t.Rollback(ctx)
 	} else {
-		*err = errors.WithStack(t.Commit(ctx))
+		*err = t.Commit(ctx)
 	}
 }

--- a/backend/controller/sql/databasetesting/devel.go
+++ b/backend/controller/sql/databasetesting/devel.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/alecthomas/errors"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -17,14 +16,14 @@ import (
 func CreateForDevel(ctx context.Context, dsn string, recreate bool) (*pgxpool.Pool, error) {
 	config, err := pgx.ParseConfig(dsn)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	noDBDSN := config.Copy()
 	noDBDSN.Database = ""
 	conn, err := pgx.ConnectConfig(ctx, noDBDSN)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	defer conn.Close(ctx)
 
@@ -36,12 +35,12 @@ func CreateForDevel(ctx context.Context, dsn string, recreate bool) (*pgxpool.Po
 		WHERE datname = $1 AND pid <> pg_backend_pid()`,
 			config.Database)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 
 		_, err = conn.Exec(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %q", config.Database))
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 	}
 
@@ -50,12 +49,12 @@ func CreateForDevel(ctx context.Context, dsn string, recreate bool) (*pgxpool.Po
 
 	err = sql.Migrate(ctx, dsn)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	realConn, err := pgxpool.New(ctx, dsn)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return realConn, nil
 }

--- a/backend/controller/sql/migrate.go
+++ b/backend/controller/sql/migrate.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"database/sql"
 	"embed"
+	"fmt"
 	"net/url"
 
-	"github.com/alecthomas/errors"
 	"github.com/amacneil/dbmate/v2/pkg/dbmate"
 	_ "github.com/amacneil/dbmate/v2/pkg/driver/postgres"
 	_ "github.com/jackc/pgx/v5/stdlib" // SQL driver
@@ -21,11 +21,11 @@ var schema embed.FS
 func Migrate(ctx context.Context, dsn string) error {
 	u, err := url.Parse(dsn)
 	if err != nil {
-		return errors.Wrap(err, "invalid DSN")
+		return fmt.Errorf("%s: %w", "invalid DSN", err)
 	}
 	conn, err := sql.Open("pgx", dsn)
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to database")
+		return fmt.Errorf("%s: %w", "failed to connect to database", err)
 	}
 	defer conn.Close()
 
@@ -35,7 +35,7 @@ func Migrate(ctx context.Context, dsn string) error {
 	db.MigrationsDir = []string{"schema"}
 	err = db.CreateAndMigrate()
 	if err != nil {
-		return errors.Wrap(err, "failed to create and migrate database")
+		return fmt.Errorf("%s: %w", "failed to create and migrate database", err)
 	}
 	return nil
 }

--- a/backend/controller/sql/types.go
+++ b/backend/controller/sql/types.go
@@ -2,9 +2,9 @@ package sql
 
 import (
 	"database/sql/driver"
+	"fmt"
 	"time"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/types"
 	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
@@ -35,7 +35,7 @@ func (u *Key) Scan(src any) error {
 	case string:
 		id, err := uuid.Parse(src)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		*u = Key(id)
 
@@ -43,7 +43,7 @@ func (u *Key) Scan(src any) error {
 		*u = src
 
 	default:
-		return errors.Errorf("invalid key type %T", src)
+		return fmt.Errorf("invalid key type %T", src)
 	}
 	return nil
 }
@@ -51,7 +51,7 @@ func (u *Key) Scan(src any) error {
 func (u *Key) UnmarshalText(text []byte) error {
 	id, err := uuid.ParseBytes(text)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	*u = Key(id)
 	return nil

--- a/backend/runner/deployment_logs.go
+++ b/backend/runner/deployment_logs.go
@@ -1,7 +1,7 @@
 package runner
 
 import (
-	"github.com/alecthomas/errors"
+	"fmt"
 
 	"github.com/TBD54566975/ftl/backend/common/log"
 )
@@ -24,7 +24,7 @@ func (d *deploymentLogsSink) Log(entry log.Entry) error {
 	case d.logQueue <- entry:
 	default:
 		// Drop log entry if queue is full
-		return errors.Errorf("log queue is full")
+		return fmt.Errorf("log queue is full")
 	}
 	return nil
 }

--- a/backend/schema/jsonschema.go
+++ b/backend/schema/jsonschema.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alecthomas/errors"
 	"github.com/swaggest/jsonschema-go"
 )
 
@@ -18,7 +17,7 @@ func DataToJSONSchema(schema *Schema, dataRef DataRef) (*jsonschema.Schema, erro
 	// Find the root data type.
 	rootData, ok := dataTypes[dataRef]
 	if !ok {
-		return nil, errors.Errorf("unknown data type %s", dataRef)
+		return nil, fmt.Errorf("unknown data type %s", dataRef)
 	}
 
 	// Encode root, and collect all data types reachable from the root.
@@ -32,7 +31,7 @@ func DataToJSONSchema(schema *Schema, dataRef DataRef) (*jsonschema.Schema, erro
 	for dataRef := range dataRefs {
 		data, ok := dataTypes[dataRef]
 		if !ok {
-			return nil, errors.Errorf("unknown data type %s", dataRef)
+			return nil, fmt.Errorf("unknown data type %s", dataRef)
 		}
 		root.Definitions[dataRef.String()] = jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(data, dataRef, dataRefs)}
 	}

--- a/backend/schema/protobuf_dec.go
+++ b/backend/schema/protobuf_dec.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"fmt"
 
-	"github.com/alecthomas/errors"
 	"google.golang.org/protobuf/proto"
 
 	schemapb "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema"
@@ -13,7 +12,7 @@ import (
 func FromProto(s *schemapb.Schema) (*Schema, error) {
 	modules, err := moduleListToSchema(s.Modules)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	schema := &Schema{
 		Modules: modules,
@@ -26,7 +25,7 @@ func moduleListToSchema(s []*schemapb.Module) ([]*Module, error) {
 	for _, n := range s {
 		module, err := ModuleFromProto(n)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		out = append(out, module)
 	}
@@ -46,7 +45,7 @@ func ModuleFromProto(s *schemapb.Module) (*Module, error) {
 func ModuleFromBytes(b []byte) (*Module, error) {
 	s := &schemapb.Module{}
 	if err := proto.Unmarshal(b, s); err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return ModuleFromProto(s)
 }

--- a/backend/schema/protobuf_test.go
+++ b/backend/schema/protobuf_test.go
@@ -3,9 +3,8 @@ package schema
 import (
 	"testing"
 
-	"github.com/alecthomas/assert/v2"
-
 	schemapb "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema"
+	"github.com/alecthomas/assert/v2"
 )
 
 func TestProtoRoundtrip(t *testing.T) {

--- a/backend/schema/schema.go
+++ b/backend/schema/schema.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
 	"golang.org/x/exp/maps"
@@ -329,7 +328,7 @@ type typeParserGrammar struct {
 func parseType(pl *lexer.PeekingLexer) (Type, error) {
 	typ, err := typeParser.ParseFromLexer(pl, participle.AllowTrailing(true))
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	if typ.Optional {
 		return &Optional{Type: typ.Type}, nil
@@ -340,7 +339,7 @@ func parseType(pl *lexer.PeekingLexer) (Type, error) {
 func ParseString(filename, input string) (*Schema, error) {
 	mod, err := parser.ParseString(filename, input)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return mod, Validate(mod)
 }
@@ -348,20 +347,20 @@ func ParseString(filename, input string) (*Schema, error) {
 func ParseModuleString(filename, input string) (*Module, error) {
 	mod, err := moduleParser.ParseString(filename, input)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return mod, ValidateModule(mod)
 }
 
 func ParseRef(ref string) (*Ref, error) {
 	r, err := refParser.ParseString("", ref)
-	return r, errors.WithStack(err)
+	return r, err
 }
 
 func Parse(filename string, r io.Reader) (*Schema, error) {
 	mod, err := parser.Parse(filename, r)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return mod, Validate(mod)
 }
@@ -369,7 +368,7 @@ func Parse(filename string, r io.Reader) (*Schema, error) {
 func ParseModule(filename string, r io.Reader) (*Module, error) {
 	mod, err := moduleParser.Parse(filename, r)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return mod, ValidateModule(mod)
 }

--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -6,7 +6,8 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-	"github.com/alecthomas/errors"
+
+	"github.com/TBD54566975/ftl/internal/errors"
 )
 
 var schema = Normalise(&Schema{

--- a/backend/schema/validate.go
+++ b/backend/schema/validate.go
@@ -1,10 +1,10 @@
 package schema
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/alecthomas/errors"
 )
 
 var (
@@ -25,7 +25,7 @@ func Validate(schema *Schema) error {
 	ingress := map[string]*Verb{}
 	for _, module := range schema.Modules {
 		if _, seen := modules[module.Name]; seen {
-			merr = append(merr, errors.Errorf("%s: duplicate module %q", module.Pos, module.Name))
+			merr = append(merr, fmt.Errorf("%s: duplicate module %q", module.Pos, module.Name))
 		}
 		modules[module.Name] = true
 		if err := ValidateModule(module); err != nil {
@@ -44,7 +44,7 @@ func Validate(schema *Schema) error {
 				for _, md := range n.Metadata {
 					if md, ok := md.(*MetadataIngress); ok {
 						if existing, ok := ingress[md.String()]; ok {
-							return errors.Errorf("duplicate %q for %s:%q and %s:%q", md.String(), existing.Pos, existing.Name, n.Pos, n.Name)
+							return fmt.Errorf("duplicate %q for %s:%q and %s:%q", md.String(), existing.Pos, existing.Name, n.Pos, n.Name)
 						}
 						ingress[md.String()] = n
 					}
@@ -66,12 +66,12 @@ func Validate(schema *Schema) error {
 	}
 	for _, ref := range verbRefs {
 		if !verbs[ref.String()] {
-			merr = append(merr, errors.Errorf("%s: reference to unknown Verb %q", ref.Pos, ref))
+			merr = append(merr, fmt.Errorf("%s: reference to unknown Verb %q", ref.Pos, ref))
 		}
 	}
 	for _, ref := range dataRefs {
 		if !data[ref.String()] {
-			merr = append(merr, errors.Errorf("%s: reference to unknown data structure %q", ref.Pos, ref))
+			merr = append(merr, fmt.Errorf("%s: reference to unknown data structure %q", ref.Pos, ref))
 		}
 	}
 	return errors.Join(merr...)
@@ -85,35 +85,35 @@ func ValidateModule(module *Module) error {
 	data := map[string]bool{}
 	merr := []error{}
 	if !validNameRe.MatchString(module.Name) {
-		merr = append(merr, errors.Errorf("%s: module name %q is invalid", module.Pos, module.Name))
+		merr = append(merr, fmt.Errorf("%s: module name %q is invalid", module.Pos, module.Name))
 	}
 	err := Visit(module, func(n Node, next func() error) error {
 		switch n := n.(type) {
 		case *Verb:
 			if !validNameRe.MatchString(n.Name) {
-				merr = append(merr, errors.Errorf("%s: Verb name %q is invalid", n.Pos, n.Name))
+				merr = append(merr, fmt.Errorf("%s: Verb name %q is invalid", n.Pos, n.Name))
 			}
 			if _, ok := reservedIdentNames[n.Name]; ok {
-				merr = append(merr, errors.Errorf("%s: Verb name %q is a reserved word", n.Pos, n.Name))
+				merr = append(merr, fmt.Errorf("%s: Verb name %q is a reserved word", n.Pos, n.Name))
 			}
 			if _, ok := verbs[n.Name]; ok {
-				merr = append(merr, errors.Errorf("%s: duplicate Verb %q", n.Pos, n.Name))
+				merr = append(merr, fmt.Errorf("%s: duplicate Verb %q", n.Pos, n.Name))
 			}
 			verbs[n.Name] = true
 
 		case *Data:
 			if !validNameRe.MatchString(n.Name) {
-				merr = append(merr, errors.Errorf("%s: data structure name %q is invalid", n.Pos, n.Name))
+				merr = append(merr, fmt.Errorf("%s: data structure name %q is invalid", n.Pos, n.Name))
 			}
 			if _, ok := reservedIdentNames[n.Name]; ok {
-				merr = append(merr, errors.Errorf("%s: data structure name %q is a reserved word", n.Pos, n.Name))
+				merr = append(merr, fmt.Errorf("%s: data structure name %q is a reserved word", n.Pos, n.Name))
 			}
 			if _, ok := data[n.Name]; ok {
-				merr = append(merr, errors.Errorf("%s: duplicate data structure %q", n.Pos, n.Name))
+				merr = append(merr, fmt.Errorf("%s: duplicate data structure %q", n.Pos, n.Name))
 			}
 			for _, md := range n.Metadata {
 				if md, ok := md.(*MetadataCalls); ok {
-					merr = append(merr, errors.Errorf("%s: metadata %q is not valid on data structures", md.Pos, strings.TrimSpace(md.String())))
+					merr = append(merr, fmt.Errorf("%s: metadata %q is not valid on data structures", md.Pos, strings.TrimSpace(md.String())))
 				}
 			}
 

--- a/backend/schema/visit.go
+++ b/backend/schema/visit.go
@@ -1,15 +1,11 @@
 package schema
 
-import (
-	"github.com/alecthomas/errors"
-)
-
 // Visit all nodes in the schema.
 func Visit(n Node, visit func(n Node, next func() error) error) error {
 	return visit(n, func() error {
 		for _, child := range n.schemaChildren() {
 			if err := Visit(child, visit); err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 		}
 		return nil

--- a/cmd/ftl-go/main.go
+++ b/cmd/ftl-go/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/kong"
 	"github.com/radovskyb/watcher"
 	"golang.org/x/mod/modfile"
@@ -39,17 +39,14 @@ type watchCmd struct{}
 func (w *watchCmd) Run(ctx context.Context, c *cli, client ftlv1connect.ControllerServiceClient, bctx BuildContext) error {
 	err := buildRemoteModules(ctx, client, bctx)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	wg, ctx := errgroup.WithContext(ctx)
 	wg.Go(func() error { return pullModules(ctx, client, bctx) })
 	wg.Go(func() error { return pushModules(ctx, client, c.WatchFrequency, bctx, c.FTL) })
 
-	if err := wg.Wait(); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
+	return wg.Wait()
 }
 
 type deployCmd struct {
@@ -57,7 +54,7 @@ type deployCmd struct {
 }
 
 func (d *deployCmd) Run(ctx context.Context, c *cli, client ftlv1connect.ControllerServiceClient, bctx BuildContext) error {
-	return errors.WithStack(pushModule(ctx, client, c.FTL, filepath.Join(c.Root, d.Name), bctx))
+	return pushModule(ctx, client, c.FTL, filepath.Join(c.Root, d.Name), bctx)
 }
 
 type cli struct {
@@ -117,7 +114,7 @@ func findImportRoot(root string) (importRoot ImportRoot, err error) {
 	modDir := root
 	for {
 		if modDir == "/" {
-			return ImportRoot{}, errors.Errorf("no go.mod file found")
+			return ImportRoot{}, fmt.Errorf("no go.mod file found")
 		}
 		if _, err := os.Stat(filepath.Join(modDir, "go.mod")); err == nil {
 			break
@@ -127,11 +124,11 @@ func findImportRoot(root string) (importRoot ImportRoot, err error) {
 	modFile := filepath.Join(modDir, "go.mod")
 	data, err := os.ReadFile(modFile)
 	if err != nil {
-		return ImportRoot{}, errors.Wrap(err, "failed to read go.mod")
+		return ImportRoot{}, fmt.Errorf("%s: %w", "failed to read go.mod", err)
 	}
 	module, err := modfile.Parse(modFile, data, nil)
 	if err != nil {
-		return ImportRoot{}, errors.Wrap(err, "failed to parse go.mod")
+		return ImportRoot{}, fmt.Errorf("%s: %w", "failed to parse go.mod", err)
 	}
 	return ImportRoot{
 		Module:      module,
@@ -145,7 +142,7 @@ func pushModules(ctx context.Context, client ftlv1connect.ControllerServiceClien
 	logger := log.FromContext(ctx)
 	entries, err := os.ReadDir(bctx.Root)
 	if err != nil {
-		return errors.Wrap(err, "failed to read root directory")
+		return fmt.Errorf("%s: %w", "failed to read root directory", err)
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -195,16 +192,16 @@ func pushModules(ctx context.Context, client ftlv1connect.ControllerServiceClien
 				}
 
 			case err := <-watch.Error:
-				return errors.Wrap(err, "watch error")
+				return fmt.Errorf("%s: %w", "watch error", err)
 			}
 		}
 	})
 	err = watch.AddRecursive(bctx.Root)
 	if err != nil {
-		return errors.Wrap(err, "failed to watch root directory")
+		return fmt.Errorf("%s: %w", "failed to watch root directory", err)
 	}
-	wg.Go(func() error { return errors.WithStack(watch.Start(watchFrequency)) })
-	return errors.WithStack(wg.Wait())
+	wg.Go(func() error { return watch.Start(watchFrequency) })
+	return wg.Wait()
 }
 
 func pushModule(ctx context.Context, client ftlv1connect.ControllerServiceClient, endpoint string, dir string, bctx BuildContext) error {
@@ -212,7 +209,7 @@ func pushModule(ctx context.Context, client ftlv1connect.ControllerServiceClient
 
 	sch, err := compile.ExtractModuleSchema(dir)
 	if err != nil {
-		return errors.Wrapf(err, "failed to extract schema for module %q", dir)
+		return fmt.Errorf("failed to extract schema for module %q: %w", dir, err)
 	}
 
 	if !hasVerbs(sch) {
@@ -222,25 +219,25 @@ func pushModule(ctx context.Context, client ftlv1connect.ControllerServiceClient
 
 	tmpDir, err := generateBuildDir(dir, sch, bctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to generate build directory")
+		return fmt.Errorf("%s: %w", "failed to generate build directory", err)
 	}
 
 	logger.Infof("Building module %s in %s", sch.Name, tmpDir)
 	cmd := exec.Command(ctx, log.Info, tmpDir, "go", "build", "-o", "main", "-trimpath", "-ldflags=-s -w -buildid=", ".")
 	cmd.Env = append(cmd.Environ(), "GOOS="+bctx.OS, "GOARCH="+bctx.Arch, "CGO_ENABLED=0")
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "failed to build module")
+		return fmt.Errorf("%s: %w", "failed to build module", err)
 	}
 	dest := filepath.Join(tmpDir, "main")
 
 	logger.Infof("Preparing deployment")
 	digest, err := sha256.SumFile(dest)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	r, err := os.Open(dest)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	deployment := &model.Deployment{
 		Language: "go",
@@ -255,12 +252,12 @@ func pushModule(ctx context.Context, client ftlv1connect.ControllerServiceClient
 
 	err = uploadArtefacts(ctx, client, deployment)
 	if err != nil {
-		return errors.Wrap(err, "failed to upload artefacts")
+		return fmt.Errorf("%s: %w", "failed to upload artefacts", err)
 	}
 
 	err = deploy(ctx, client, deployment, endpoint)
 	if err != nil {
-		return errors.Wrap(err, "failed to deploy")
+		return fmt.Errorf("%s: %w", "failed to deploy", err)
 	}
 	return nil
 }
@@ -279,7 +276,7 @@ func deploy(ctx context.Context, client ftlv1connect.ControllerServiceClient, de
 		"languages": []any{"go"},
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to create labels")
+		return fmt.Errorf("%s: %w", "failed to create labels", err)
 	}
 	cdResp, err := client.CreateDeployment(ctx, connect.NewRequest(&ftlv1.CreateDeploymentRequest{
 		Schema: module,
@@ -293,7 +290,7 @@ func deploy(ctx context.Context, client ftlv1connect.ControllerServiceClient, de
 		}),
 	}))
 	if err != nil {
-		return errors.Wrap(err, "failed to create deployment")
+		return fmt.Errorf("%s: %w", "failed to create deployment", err)
 	}
 	logger.Infof("Created deployment %s (%s/deployments/%s)", cdResp.Msg.DeploymentName, endpoint, cdResp.Msg.DeploymentName)
 	_, err = client.ReplaceDeploy(ctx, connect.NewRequest(&ftlv1.ReplaceDeployRequest{
@@ -301,7 +298,7 @@ func deploy(ctx context.Context, client ftlv1connect.ControllerServiceClient, de
 		MinReplicas:    1,
 	}))
 	if err != nil {
-		return errors.Wrapf(err, "failed to deploy %q", cdResp.Msg.DeploymentName)
+		return fmt.Errorf("failed to deploy %q: %w", cdResp.Msg.DeploymentName, err)
 	}
 	return nil
 }
@@ -311,7 +308,7 @@ func uploadArtefacts(ctx context.Context, client ftlv1connect.ControllerServiceC
 	digests := slices.Map(deployment.Artefacts, func(t *model.Artefact) string { return t.Digest.String() })
 	gadResp, err := client.GetArtefactDiffs(ctx, connect.NewRequest(&ftlv1.GetArtefactDiffsRequest{ClientDigests: digests}))
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	artefactsToUpload := slices.Filter(deployment.Artefacts, func(t *model.Artefact) bool {
 		for _, missing := range gadResp.Msg.MissingDigests {
@@ -324,11 +321,11 @@ func uploadArtefacts(ctx context.Context, client ftlv1connect.ControllerServiceC
 	for _, artefact := range artefactsToUpload {
 		content, err := io.ReadAll(artefact.Content)
 		if err != nil {
-			return errors.Wrapf(err, "failed to read artefact %q", artefact.Path)
+			return fmt.Errorf("failed to read artefact %q: %w", artefact.Path, err)
 		}
 		_, err = client.UploadArtefact(ctx, connect.NewRequest(&ftlv1.UploadArtefactRequest{Content: content}))
 		if err != nil {
-			return errors.Wrapf(err, "failed to upload artefact %q", artefact.Path)
+			return fmt.Errorf("failed to upload artefact %q: %w", artefact.Path, err)
 		}
 		logger.Infof("Uploaded %s:%s", artefact.Digest, artefact.Path)
 	}
@@ -338,22 +335,22 @@ func uploadArtefacts(ctx context.Context, client ftlv1connect.ControllerServiceC
 func generateBuildDir(dir string, sch *schema.Module, bctx BuildContext) (string, error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get user cache directory")
+		return "", fmt.Errorf("%s: %w", "failed to get user cache directory", err)
 	}
 	dirHash := sha256.Sum([]byte(dir))
 	tmpDir := filepath.Join(cacheDir, "ftl-go", "build", fmt.Sprintf("%s-%s", sch.Name, dirHash))
 	if err := os.MkdirAll(tmpDir, 0750); err != nil {
-		return "", errors.Wrap(err, "failed to create build directory")
+		return "", fmt.Errorf("%s: %w", "failed to create build directory", err)
 	}
 	mainFile := filepath.Join(tmpDir, "main.go")
 	if err := generate.File(mainFile, bctx.FTLBasePkg, generate.Main, sch); err != nil {
-		return "", errors.Wrap(err, "failed to generate main.go")
+		return "", fmt.Errorf("%s: %w", "failed to generate main.go", err)
 	}
 	goWorkFile := filepath.Join(tmpDir, "go.work")
 	if err := generate.File(goWorkFile, bctx.FTLBasePkg, generate.GenerateGoWork, []string{
 		bctx.GoModuleDir,
 	}); err != nil {
-		return "", errors.Wrap(err, "failed to generate go.work")
+		return "", fmt.Errorf("%s: %w", "failed to generate go.work", err)
 	}
 	goModFile := filepath.Join(tmpDir, "go.mod")
 	replace := map[string]string{
@@ -362,7 +359,7 @@ func generateBuildDir(dir string, sch *schema.Module, bctx BuildContext) (string
 	if err := generate.File(goModFile, bctx.FTLBasePkg, generate.GenerateGoMod, generate.GoModConfig{
 		Replace: replace,
 	}); err != nil {
-		return "", errors.Wrap(err, "failed to generate go.mod")
+		return "", fmt.Errorf("%s: %w", "failed to generate go.mod", err)
 	}
 	return tmpDir, nil
 }
@@ -379,27 +376,30 @@ func hasVerbs(sch *schema.Module) bool {
 func pullModules(ctx context.Context, client ftlv1connect.ControllerServiceClient, bctx BuildContext) error {
 	resp, err := client.PullSchema(ctx, connect.NewRequest(&ftlv1.PullSchemaRequest{}))
 	if err != nil {
-		return errors.Wrap(err, "failed to pull schema")
+		return fmt.Errorf("%s: %w", "failed to pull schema", err)
 	}
 	for resp.Receive() {
 		msg := resp.Msg()
 		err = generateModuleFromSchema(ctx, msg.Schema, bctx)
 		if err != nil {
-			return errors.Wrap(err, "failed to sync module")
+			return fmt.Errorf("%s: %w", "failed to sync module", err)
 		}
 	}
-	return errors.Wrap(resp.Err(), "failed to pull schema")
+	if err := resp.Err(); err != nil {
+		return fmt.Errorf("%s: %w", "failed to pull schema", err)
+	}
+	return nil
 }
 
 func buildRemoteModules(ctx context.Context, client ftlv1connect.ControllerServiceClient, bctx BuildContext) error {
 	fullSchema, err := client.GetSchema(ctx, connect.NewRequest(&ftlv1.GetSchemaRequest{}))
 	if err != nil {
-		return errors.Wrap(err, "failed to retrieve schema")
+		return fmt.Errorf("%s: %w", "failed to retrieve schema", err)
 	}
 	for _, module := range fullSchema.Msg.Schema.Modules {
 		err := generateModuleFromSchema(ctx, module, bctx)
 		if err != nil {
-			return errors.Wrap(err, "failed to generate module")
+			return fmt.Errorf("%s: %w", "failed to generate module", err)
 		}
 	}
 	return err
@@ -408,7 +408,7 @@ func buildRemoteModules(ctx context.Context, client ftlv1connect.ControllerServi
 func generateModuleFromSchema(ctx context.Context, msg *schemapb.Module, bctx BuildContext) error {
 	sch, err := schema.ModuleFromProto(msg)
 	if err != nil {
-		return errors.Wrap(err, "failed to parse schema")
+		return fmt.Errorf("%s: %w", "failed to parse schema", err)
 	}
 	dir := filepath.Join(bctx.Root, sch.Name)
 	if _, err := os.Stat(dir); err == nil {
@@ -417,7 +417,7 @@ func generateModuleFromSchema(ctx context.Context, msg *schemapb.Module, bctx Bu
 		}
 	}
 	if err := generateModule(ctx, dir, sch, bctx); err != nil {
-		return errors.Wrap(err, "failed to generate module")
+		return fmt.Errorf("%s: %w", "failed to generate module", err)
 	}
 	return nil
 }
@@ -425,19 +425,20 @@ func generateModuleFromSchema(ctx context.Context, msg *schemapb.Module, bctx Bu
 func generateModule(ctx context.Context, dir string, sch *schema.Module, bctx BuildContext) error {
 	logger := log.FromContext(ctx)
 	logger.Infof("Generating stubs for FTL module %s", sch.Name)
-	err := os.MkdirAll(dir, 0750)
-	if err != nil {
-		return errors.Wrap(err, "failed to create module directory")
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return fmt.Errorf("%s: %w", "failed to create module directory", err)
 	}
 	w, err := os.Create(filepath.Join(dir, "generated_ftl_module.go~"))
 	if err != nil {
-		return errors.Wrap(err, "failed to create stub file")
+		return fmt.Errorf("%s: %w", "failed to create stub file", err)
 	}
 	defer w.Close() //nolint:gosec
 	defer os.Remove(w.Name())
-	err = generate.ExternalModule(w, sch, bctx.FTLBasePkg)
-	if err != nil {
-		return errors.Wrap(err, "failed to generate stubs")
+	if err := generate.ExternalModule(w, sch, bctx.FTLBasePkg); err != nil {
+		return fmt.Errorf("%s: %w", "failed to generate stubs", err)
 	}
-	return errors.WithStack(os.Rename(w.Name(), strings.TrimRight(w.Name(), "~")))
+	if err := os.Rename(w.Name(), strings.TrimRight(w.Name(), "~")); err != nil {
+		return fmt.Errorf("%s: %w", "failed to rename stub file", err)
+	}
+	return nil
 }

--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"context"
-
-	"github.com/alecthomas/errors"
+	"fmt"
 
 	"github.com/TBD54566975/ftl/backend/common/exec"
 	"github.com/TBD54566975/ftl/backend/common/log"
@@ -18,14 +17,14 @@ func (b *buildCmd) Run(ctx context.Context) error {
 	// Load the TOML file.
 	config, err := moduleconfig.LoadConfig(b.ModuleDir)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	switch config.Language {
 	case "kotlin":
 		return b.buildKotlin(ctx, config)
 	default:
-		return errors.Errorf("unable to build. unknown language %q", config.Language)
+		return fmt.Errorf("unable to build. unknown language %q", config.Language)
 	}
 }
 
@@ -37,7 +36,7 @@ func (b *buildCmd) buildKotlin(ctx context.Context, config moduleconfig.ModuleCo
 
 	err := exec.Command(ctx, logger.GetLevel(), b.ModuleDir, "bash", "-c", config.Build).Run()
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	return nil

--- a/cmd/ftl/cmd_download.go
+++ b/cmd/ftl/cmd_download.go
@@ -5,8 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/alecthomas/errors"
-
 	"github.com/TBD54566975/ftl/backend/common/download"
 	"github.com/TBD54566975/ftl/backend/common/model"
 	"github.com/TBD54566975/ftl/backend/common/sha256"
@@ -27,7 +25,7 @@ func (d *downloadCmd) getLocalArtefacts() ([]*ftlv1.DeploymentArtefact, error) {
 	haveArtefacts := []*ftlv1.DeploymentArtefact{}
 	dest, err := filepath.Abs(d.Dest)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	err = filepath.Walk(dest, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -38,12 +36,12 @@ func (d *downloadCmd) getLocalArtefacts() ([]*ftlv1.DeploymentArtefact, error) {
 		}
 		sum, err := sha256.SumFile(path)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		relPath, err := filepath.Rel(dest, path)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		haveArtefacts = append(haveArtefacts, &ftlv1.DeploymentArtefact{
 			Path:       relPath,
@@ -53,7 +51,7 @@ func (d *downloadCmd) getLocalArtefacts() ([]*ftlv1.DeploymentArtefact, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	return haveArtefacts, nil
 }

--- a/cmd/ftl/cmd_kill.go
+++ b/cmd/ftl/cmd_kill.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"github.com/alecthomas/errors"
 
 	"github.com/TBD54566975/ftl/backend/common/model"
 	ftlv1 "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1"
@@ -18,7 +17,7 @@ type killCmd struct {
 func (k *killCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
 	_, err := client.UpdateDeploy(ctx, connect.NewRequest(&ftlv1.UpdateDeployRequest{DeploymentName: k.Deployment.String()}))
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	return nil
 }

--- a/cmd/ftl/cmd_ps.go
+++ b/cmd/ftl/cmd_ps.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	"github.com/alecthomas/errors"
 	"github.com/golang/protobuf/jsonpb"
 	"golang.org/x/exp/maps"
 
@@ -24,14 +23,14 @@ type psCmd struct {
 func (s *psCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
 	status, err := client.ProcessList(ctx, connect.NewRequest(&ftlv1.ProcessListRequest{}))
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	if s.JSON {
 		marshaller := jsonpb.Marshaler{Indent: "  "}
 		for _, process := range status.Msg.Processes {
 			err = marshaller.Marshal(os.Stdout, process)
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 			fmt.Println()
 		}
@@ -68,7 +67,7 @@ func (s *psCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceCl
 					endpoint = runner.Endpoint
 					labels, err := (&jsonpb.Marshaler{}).MarshalToString(runner.Labels)
 					if err != nil {
-						return errors.WithStack(err)
+						return err
 					}
 					runnerLabels = labels
 				}
@@ -76,7 +75,7 @@ func (s *psCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceCl
 				if s.Verbose > 1 {
 					labels, err := (&jsonpb.Marshaler{}).MarshalToString(first.Labels)
 					if err != nil {
-						return errors.WithStack(err)
+						return err
 					}
 					args = append(args, labels, runnerLabels)
 				}

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/kong"
 	"golang.org/x/sync/errgroup"
 
@@ -36,7 +36,7 @@ func (s *serveCmd) Run(ctx context.Context) error {
 
 	dsn, err := s.setupDB(ctx)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	logger.Infof("Starting %d controller(s) and %d runner(s)", s.Controllers, s.Runners)
@@ -45,7 +45,7 @@ func (s *serveCmd) Run(ctx context.Context) error {
 
 	bindAllocator, err := bind.NewBindAllocator(s.Bind)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	controllerAddresses := make([]*url.URL, 0, s.Controllers)
@@ -55,7 +55,7 @@ func (s *serveCmd) Run(ctx context.Context) error {
 
 	runnerScaling, err := localscaling.NewLocalScaling(bindAllocator, controllerAddresses)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	for i := 0; i < s.Controllers; i++ {
@@ -66,24 +66,27 @@ func (s *serveCmd) Run(ctx context.Context) error {
 			AllowOrigins: s.AllowOrigins,
 		}
 		if err := kong.ApplyDefaults(&config); err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		scope := fmt.Sprintf("controller%d", i)
 		controllerCtx := log.ContextWithLogger(ctx, logger.Scope(scope))
 
 		wg.Go(func() error {
-			return errors.Wrapf(controller.Start(controllerCtx, config, runnerScaling), "controller%d failed", i)
+			if err := controller.Start(controllerCtx, config, runnerScaling); err != nil {
+				return fmt.Errorf("controller%d failed: %w", i, err)
+			}
+			return nil
 		})
 	}
 
 	err = runnerScaling.SetReplicas(ctx, s.Runners, nil)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	if err := wg.Wait(); err != nil {
-		return errors.WithStack(err)
+		return fmt.Errorf("serve failed: %w", err)
 	}
 	return nil
 }
@@ -95,7 +98,7 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 	output, err := exec.Capture(ctx, ".", "docker", "ps", "-a", "--filter", nameFlag, "--format", "{{.Names}}")
 	if err != nil {
 		logger.Errorf(err, "%s", output)
-		return "", errors.WithStack(err)
+		return "", err
 	}
 
 	recreate := s.Recreate
@@ -107,7 +110,7 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 		// check if port s.DBPort is already in use
 		_, err := exec.Capture(ctx, ".", "sh", "-c", fmt.Sprintf("lsof -i:%d", s.DBPort))
 		if err == nil {
-			return "", errors.Errorf("port %d is already in use", s.DBPort)
+			return "", fmt.Errorf("port %d is already in use", s.DBPort)
 		}
 
 		err = exec.Command(ctx, logger.GetLevel(), "./", "docker", "run",
@@ -126,7 +129,7 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 		).Run()
 
 		if err != nil {
-			return "", errors.WithStack(err)
+			return "", err
 		}
 
 		err = pollContainerHealth(ctx, ftlContainerName, 10*time.Second)
@@ -139,14 +142,14 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 		// Start the existing container
 		_, err = exec.Capture(ctx, ".", "docker", "start", ftlContainerName)
 		if err != nil {
-			return "", errors.WithStack(err)
+			return "", err
 		}
 
 		// Grab the port from the existing container
 		portOutput, err := exec.Capture(ctx, ".", "docker", "port", ftlContainerName, "5432/tcp")
 		if err != nil {
 			logger.Errorf(err, "%s", portOutput)
-			return "", errors.WithStack(err)
+			return "", err
 		}
 		port = slices.Reduce(strings.Split(string(portOutput), "\n"), "", func(port string, line string) string {
 			if parts := strings.Split(line, ":"); len(parts) == 2 {
@@ -163,7 +166,7 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 
 	_, err = databasetesting.CreateForDevel(ctx, dsn, recreate)
 	if err != nil {
-		return "", errors.WithStack(err)
+		return "", err
 	}
 
 	return dsn, nil
@@ -184,7 +187,7 @@ func pollContainerHealth(ctx context.Context, containerName string, timeout time
 		case <-time.After(1 * time.Millisecond):
 			output, err := exec.Capture(pollCtx, ".", "docker", "inspect", "--format", "{{.State.Health.Status}}", containerName)
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 
 			status := strings.TrimSpace(string(output))

--- a/cmd/ftl/cmd_status.go
+++ b/cmd/ftl/cmd_status.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"connectrpc.com/connect"
-	"github.com/alecthomas/errors"
 	"github.com/golang/protobuf/jsonpb"
 
 	ftlv1 "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1"
@@ -29,7 +28,7 @@ func (s *statusCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 		AllIngressRoutes: s.All || s.AllIngressRoutes,
 	}))
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	msg := status.Msg
 	if !s.Schema {
@@ -37,7 +36,7 @@ func (s *statusCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 			deployment.Schema = nil
 		}
 	}
-	return errors.WithStack((&jsonpb.Marshaler{
+	return (&jsonpb.Marshaler{
 		Indent: "  ",
-	}).Marshal(os.Stdout, status.Msg))
+	}).Marshal(os.Stdout, status.Msg)
 }

--- a/cmd/ftl/cmd_update.go
+++ b/cmd/ftl/cmd_update.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
-	"github.com/alecthomas/errors"
 
 	"github.com/TBD54566975/ftl/backend/common/model"
 	ftlv1 "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1"
@@ -22,7 +21,7 @@ func (u *updateCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 		MinReplicas:    u.Replicas,
 	}))
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	return nil
 }

--- a/examples/echo/echo.go
+++ b/examples/echo/echo.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	timemodule "github.com/TBD54566975/ftl/examples/time"
-
 	ftl "github.com/TBD54566975/ftl/go-runtime/sdk"
 )
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -11,7 +11,6 @@ require (
 	connectrpc.com/grpcreflect v1.2.0 // indirect
 	connectrpc.com/otelconnect v0.6.0 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
-	github.com/alecthomas/errors v0.4.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
 	github.com/alecthomas/types v0.9.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -8,8 +8,6 @@ github.com/alecthomas/assert/v2 v2.4.0 h1:/ZiZ0NnriAWPYYO+4eOjgzNELrFQLaHNr92mHS
 github.com/alecthomas/assert/v2 v2.4.0/go.mod h1:fw5suVxB+wfYJ3291t0hRTqtGzFYdSwstnRQdaQx2DM=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.4.0 h1:zDIapqdw7gVx2BrQpw3Ll5YRGFuaiB0ywcjesqT0RIE=
-github.com/alecthomas/errors v0.4.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.3.0 h1:NeYzUPfjjlqHY4KtzgKJiWd6sVq2eNUPTi34PiFGjY8=

--- a/examples/online-boutique/go.mod
+++ b/examples/online-boutique/go.mod
@@ -6,7 +6,6 @@ replace github.com/TBD54566975/ftl => ../..
 
 require (
 	github.com/TBD54566975/ftl v0.0.0-00010101000000-000000000000
-	github.com/alecthomas/errors v0.4.0
 	github.com/google/uuid v1.4.0
 	github.com/hashicorp/golang-lru/v2 v2.0.5
 	golang.org/x/exp v0.0.0-20231127185646-65229373498e

--- a/examples/online-boutique/go.sum
+++ b/examples/online-boutique/go.sum
@@ -8,8 +8,6 @@ github.com/alecthomas/assert/v2 v2.4.0 h1:/ZiZ0NnriAWPYYO+4eOjgzNELrFQLaHNr92mHS
 github.com/alecthomas/assert/v2 v2.4.0/go.mod h1:fw5suVxB+wfYJ3291t0hRTqtGzFYdSwstnRQdaQx2DM=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.4.0 h1:zDIapqdw7gVx2BrQpw3Ll5YRGFuaiB0ywcjesqT0RIE=
-github.com/alecthomas/errors v0.4.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.3.0 h1:NeYzUPfjjlqHY4KtzgKJiWd6sVq2eNUPTi34PiFGjY8=

--- a/examples/online-boutique/services/ad/ad.go
+++ b/examples/online-boutique/services/ad/ad.go
@@ -6,9 +6,8 @@ import (
 	_ "embed"
 	"math/rand"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/TBD54566975/ftl/examples/online-boutique/common"
+	"golang.org/x/exp/maps"
 )
 
 const maxAdsToServe = 2

--- a/examples/online-boutique/services/checkout/checkout.go
+++ b/examples/online-boutique/services/checkout/checkout.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
-
 	"github.com/TBD54566975/ftl/backend/common/slices"
 	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/cart"
@@ -15,6 +13,7 @@ import (
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/productcatalog"
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/shipping"
 	ftl "github.com/TBD54566975/ftl/go-runtime/sdk"
+	"github.com/google/uuid"
 )
 
 type PlaceOrderRequest struct {

--- a/examples/online-boutique/services/currency/currency.go
+++ b/examples/online-boutique/services/currency/currency.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"math"
 
-	"golang.org/x/exp/maps"
-
 	"github.com/TBD54566975/ftl/examples/online-boutique/common"
 	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
+	"golang.org/x/exp/maps"
 )
 
 var (

--- a/examples/online-boutique/services/echo/generated_ftl_module.go
+++ b/examples/online-boutique/services/echo/generated_ftl_module.go
@@ -1,6 +1,2 @@
 //ftl:module echo
 package echo
-
-import (
-  "context"
-)

--- a/examples/online-boutique/services/payment/payment.go
+++ b/examples/online-boutique/services/payment/payment.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
-
 	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
+	"github.com/google/uuid"
 )
 
 type InvalidCreditCardErr struct{}

--- a/examples/online-boutique/services/productcatalog/productcatalog.go
+++ b/examples/online-boutique/services/productcatalog/productcatalog.go
@@ -4,9 +4,8 @@ package productcatalog
 import (
 	"context"
 	_ "embed"
+	"fmt"
 	"strings"
-
-	"github.com/alecthomas/errors"
 
 	"github.com/TBD54566975/ftl/examples/online-boutique/common"
 	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
@@ -54,7 +53,7 @@ func Get(ctx context.Context, req GetRequest) (Product, error) {
 			return p, nil
 		}
 	}
-	return Product{}, errors.Errorf("product not found: %q", req.ID)
+	return Product{}, fmt.Errorf("product not found: %q", req.ID)
 }
 
 type SearchRequest struct {

--- a/examples/online-boutique/services/recommendation/recommendation.go
+++ b/examples/online-boutique/services/recommendation/recommendation.go
@@ -3,9 +3,8 @@ package recommendation
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
-
-	"github.com/alecthomas/errors"
 
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/productcatalog"
 	ftl "github.com/TBD54566975/ftl/go-runtime/sdk"
@@ -26,7 +25,7 @@ func List(ctx context.Context, req ListRequest) (ListResponse, error) {
 
 	catalog, err := ftl.Call(ctx, productcatalog.List, productcatalog.ListRequest{})
 	if err != nil {
-		return ListResponse{}, errors.Wrap(err, "failed to retrieve product catalog")
+		return ListResponse{}, fmt.Errorf("%s: %w", "failed to retrieve product catalog", err)
 	}
 
 	// Remove user-provided products from the catalog, to avoid recommending

--- a/frontend/local.go
+++ b/frontend/local.go
@@ -9,8 +9,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/alecthomas/errors"
-
 	"github.com/TBD54566975/ftl/backend/common/cors"
 	"github.com/TBD54566975/ftl/backend/common/exec"
 	"github.com/TBD54566975/ftl/backend/common/log"
@@ -25,12 +23,12 @@ func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (htt
 
 	err := exec.Command(ctx, log.Debug, "frontend", "npm", "install").Run()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 
 	err = exec.Command(ctx, log.Debug, "frontend", "npm", "run", "dev").Start()
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	logger.Infof("Console started")
 

--- a/frontend/release.go
+++ b/frontend/release.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/alecthomas/errors"
+	"errors"
 
 	"github.com/TBD54566975/ftl/backend/common/cors"
 )
@@ -25,7 +25,7 @@ var build embed.FS
 func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (http.Handler, error) {
 	dir, err := fs.Sub(build, "dist")
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, err
 	}
 	var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var f fs.File

--- a/go-runtime/compile/generate/external_module.go
+++ b/go-runtime/compile/generate/external_module.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/alecthomas/errors"
 	"github.com/iancoleman/strcase"
 	"golang.org/x/exp/maps"
 
@@ -62,10 +61,10 @@ var moduleTmpl = template.Must(template.New("external_module.go.tmpl").
 
 // ExternalModule Go stubs for the given module.
 func ExternalModule(w io.Writer, module *schema.Module, importRoot string) error {
-	return errors.WithStack(moduleTmpl.Execute(w, &externalModuleCtx{
+	return moduleTmpl.Execute(w, &externalModuleCtx{
 		ImportRoot: importRoot,
 		Module:     module,
-	}))
+	})
 }
 
 func genType(t schema.Type) string {

--- a/go-runtime/compile/generate/external_module_test.go
+++ b/go-runtime/compile/generate/external_module_test.go
@@ -4,9 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alecthomas/assert/v2"
-
 	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/alecthomas/assert/v2"
 )
 
 func TestCodegen(t *testing.T) {

--- a/go-runtime/compile/generate/file.go
+++ b/go-runtime/compile/generate/file.go
@@ -4,20 +4,18 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-
-	"github.com/alecthomas/errors"
 )
 
 // File is a helper function for the generator functions in this package, to create a file and its parent directories, then call a generator function.
 func File[T any](path string, importRoot string, generator func(io.Writer, T, string) error, parameter T) error {
 	err := os.MkdirAll(filepath.Dir(path), 0o750)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	w, err := os.Create(path)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	defer w.Close() //nolint:gosec
-	return errors.WithStack(generator(w, parameter, importRoot))
+	return generator(w, parameter, importRoot)
 }

--- a/go-runtime/compile/generate/gomod.go
+++ b/go-runtime/compile/generate/gomod.go
@@ -4,8 +4,6 @@ import (
 	_ "embed"
 	"io"
 	"text/template"
-
-	"github.com/alecthomas/errors"
 )
 
 //go:embed go.mod.tmpl
@@ -19,5 +17,5 @@ type GoModConfig struct {
 
 // GenerateGoMod generates a go.mod file.
 func GenerateGoMod(w io.Writer, config GoModConfig, importRoot string) error {
-	return errors.WithStack(goModTmpl.Execute(w, config))
+	return goModTmpl.Execute(w, config)
 }

--- a/go-runtime/compile/generate/gowork.go
+++ b/go-runtime/compile/generate/gowork.go
@@ -4,8 +4,6 @@ import (
 	_ "embed"
 	"io"
 	"text/template"
-
-	"github.com/alecthomas/errors"
 )
 
 //go:embed go.work.tmpl
@@ -14,5 +12,5 @@ var goWorkTmpl = template.Must(template.New("go.mod.tmpl").Parse(goWorkTmplSourc
 
 // GenerateGoWork generates a go.work file.
 func GenerateGoWork(w io.Writer, modules []string, importRoot string) error {
-	return errors.WithStack(goWorkTmpl.Execute(w, modules))
+	return goWorkTmpl.Execute(w, modules)
 }

--- a/go-runtime/compile/generate/main.go
+++ b/go-runtime/compile/generate/main.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/alecthomas/errors"
-
 	"github.com/TBD54566975/ftl/backend/schema"
 )
 
@@ -25,8 +23,8 @@ type mainTmplCtx struct {
 }
 
 func Main(w io.Writer, module *schema.Module, importRoot string) error {
-	return errors.WithStack(mainTmpl.Execute(w, &mainTmplCtx{
+	return mainTmpl.Execute(w, &mainTmplCtx{
 		ImportRoot: importRoot,
 		Module:     module,
-	}))
+	})
 }

--- a/go-runtime/compile/generate/main_test.go
+++ b/go-runtime/compile/generate/main_test.go
@@ -4,9 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alecthomas/assert/v2"
-
 	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/alecthomas/assert/v2"
 )
 
 func TestGenerateMain(t *testing.T) {

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -5,9 +5,8 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/alecthomas/assert/v2"
-
 	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/alecthomas/assert/v2"
 )
 
 func TestExtractModuleSchema(t *testing.T) {

--- a/go-runtime/sdk/kvstore/kvstore.go
+++ b/go-runtime/sdk/kvstore/kvstore.go
@@ -3,8 +3,6 @@ package kvstore
 
 import (
 	"sync"
-
-	"github.com/alecthomas/errors"
 )
 
 type Interface[V any] interface {
@@ -52,7 +50,7 @@ func (k *KV[V]) Upsert(key string, upsert func(v V, created bool) (V, error)) (V
 	v, ok := k.store[key]
 	newValue, err := upsert(v, !ok)
 	if err != nil {
-		return v, errors.WithStack(err)
+		return v, err
 	}
 	k.store[key] = newValue
 	return newValue, nil

--- a/go-runtime/sdk/types.go
+++ b/go-runtime/sdk/types.go
@@ -2,9 +2,8 @@ package sdk
 
 import (
 	"context"
+	"fmt"
 	"strings"
-
-	"github.com/alecthomas/errors"
 
 	schemapb "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema"
 )
@@ -33,7 +32,7 @@ type VerbRef struct {
 func (v *VerbRef) UnmarshalText(text []byte) error {
 	parts := strings.Split(string(text), ".")
 	if len(parts) != 2 {
-		return errors.Errorf("invalid reference %q", string(text))
+		return fmt.Errorf("invalid reference %q", string(text))
 	}
 	v.Module = parts[0]
 	v.Name = parts[1]
@@ -63,7 +62,7 @@ type DataRef struct {
 func (v *DataRef) UnmarshalText(text []byte) error {
 	parts := strings.Split(string(text), ".")
 	if len(parts) != 2 {
-		return errors.Errorf("invalid reference %q", string(text))
+		return fmt.Errorf("invalid reference %q", string(text))
 	}
 	v.Module = parts[0]
 	v.Name = parts[1]
@@ -78,7 +77,7 @@ func (v DataRef) ToProto() *schemapb.DataRef {
 func parseRef(s string) (string, string, error) {
 	parts := strings.Split(s, ".")
 	if len(parts) != 2 {
-		return "", "", errors.Errorf("invalid reference %q", s)
+		return "", "", fmt.Errorf("invalid reference %q", s)
 	}
 	return parts[0], parts[1], nil
 }

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/alecthomas/assert/v2 v2.4.0
 	github.com/alecthomas/atomic v0.1.0-alpha2
 	github.com/alecthomas/concurrency v0.0.2
-	github.com/alecthomas/errors v0.4.0
 	github.com/alecthomas/participle/v2 v2.1.1
 	github.com/alecthomas/types v0.9.0
 	github.com/beevik/etree v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,6 @@ github.com/alecthomas/atomic v0.1.0-alpha2 h1:dqwXmax66gXvHhsOS4pGPZKqYOlTkapELk
 github.com/alecthomas/atomic v0.1.0-alpha2/go.mod h1:zD6QGEyw49HIq19caJDc2NMXAy8rNi9ROrxtMXATfyI=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
-github.com/alecthomas/errors v0.4.0 h1:zDIapqdw7gVx2BrQpw3Ll5YRGFuaiB0ywcjesqT0RIE=
-github.com/alecthomas/errors v0.4.0/go.mod h1:0DQf6/xQp3f9rv+k72g2NmeTW2lC74kXA6b/8dN9BwY=
 github.com/alecthomas/kong v0.8.1 h1:acZdn3m4lLRobeh3Zi2S2EpnXTd1mOL6U7xVml+vfkY=
 github.com/alecthomas/kong v0.8.1/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/kong-toml v0.1.0 h1:jKrdGj/G0mkHGbOV5a+Cok3cTDZ+Qxa5CBq177gPKUA=

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -13,9 +13,10 @@ import (
 	"testing"
 	"time"
 
+	"errors"
+
 	"connectrpc.com/connect"
 	"github.com/alecthomas/assert/v2"
-	"github.com/alecthomas/errors"
 	"golang.org/x/exp/maps"
 
 	"github.com/TBD54566975/ftl/backend/common/exec"
@@ -109,7 +110,7 @@ func TestIntegration(t *testing.T) {
 
 	ic.assertWithRetry(t, func(t testing.TB, ic itContext) error {
 		_, err := ic.controller.Status(ic, connect.NewRequest(&ftlv1.StatusRequest{}))
-		return errors.WithStack(err)
+		return err
 	})
 
 	for _, tt := range tests {
@@ -154,7 +155,7 @@ func status(check func(t testing.TB, status *ftlv1.StatusResponse)) assertion {
 	return func(t testing.TB, ic itContext) error {
 		status, err := ic.controller.Status(ic, connect.NewRequest(&ftlv1.StatusRequest{}))
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		check(t, status.Msg)
 		return nil
@@ -173,7 +174,7 @@ func call[Resp any](module, verb string, req obj, onResponse func(t testing.TB, 
 			Body: jreq,
 		}))
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		if cresp.Msg.GetError() != nil {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,32 @@
+package errors
+
+// UnwrapAll recursively unwraps all errors in err, including all intermediate errors.
+//
+//nolint:errorlint
+func UnwrapAll(err error) []error {
+	out := []error{}
+	if inner, ok := err.(interface{ Unwrap() []error }); ok {
+		for _, e := range inner.Unwrap() {
+			out = append(out, UnwrapAll(e)...)
+		}
+		return out
+	}
+	if inner, ok := err.(interface{ Unwrap() error }); ok && inner.Unwrap() != nil {
+		out = append(out, UnwrapAll(inner.Unwrap())...)
+	}
+	out = append(out, err)
+	return out
+}
+
+// Innermost returns true if err cannot be further unwrapped.
+//
+//nolint:errorlint
+func Innermost(err error) bool {
+	if err, ok := err.(interface{ Unwrap() []error }); ok && len(err.Unwrap()) > 0 {
+		return false
+	}
+	if err, ok := err.(interface{ Unwrap() error }); ok && err.Unwrap() != nil {
+		return false
+	}
+	return true
+}

--- a/internal/zip.go
+++ b/internal/zip.go
@@ -3,30 +3,29 @@ package internal
 import (
 	"archive/zip"
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-
-	"github.com/alecthomas/errors"
 )
 
 // UnzipDir unzips a ZIP archive into the specified directory.
 func UnzipDir(zipReader *zip.Reader, destDir string) error {
 	err := os.MkdirAll(destDir, 0700)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	for _, file := range zipReader.File {
 		destPath := filepath.Clean(filepath.Join(destDir, file.Name)) //nolint:gosec
 		if destDir != "." && !strings.HasPrefix(destPath, destDir) {
-			return errors.Errorf("invalid file path: %q", destPath)
+			return fmt.Errorf("invalid file path: %q", destPath)
 		}
 		// Create directory if it doesn't exist
 		if file.FileInfo().IsDir() {
 			err := os.MkdirAll(destPath, file.Mode())
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 			continue
 		}
@@ -35,16 +34,16 @@ func UnzipDir(zipReader *zip.Reader, destDir string) error {
 		if file.Mode()&os.ModeSymlink != 0 {
 			reader, err := file.Open()
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 			buf := &bytes.Buffer{}
 			_, err = io.Copy(buf, reader) //nolint:gosec
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 			err = os.Symlink(buf.String(), destPath)
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 			continue
 		}
@@ -52,19 +51,19 @@ func UnzipDir(zipReader *zip.Reader, destDir string) error {
 		// Handle regular files
 		fileReader, err := file.Open()
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		defer fileReader.Close()
 
 		destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		defer destFile.Close()
 
 		_, err = io.Copy(destFile, fileReader) //nolint:gosec
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 	}
 	return nil
@@ -73,68 +72,64 @@ func UnzipDir(zipReader *zip.Reader, destDir string) error {
 func ZipDir(srcDir, destZipFile string) error {
 	zipFile, err := os.Create(destZipFile)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	defer zipFile.Close()
 
 	zipWriter := zip.NewWriter(zipFile)
 	defer zipWriter.Close()
 
-	return errors.WithStack(filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
+	return filepath.Walk(srcDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
-		// Determine path for the zip file header
 		headerPath := strings.TrimPrefix(path, srcDir)
 		if strings.HasPrefix(headerPath, string(filepath.Separator)) {
 			headerPath = headerPath[1:]
 		}
 
-		// Add trailing slash to directory paths
 		if info.IsDir() {
 			headerPath += "/"
 		}
 
 		header, err := zip.FileInfoHeader(info)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 		header.Name = headerPath
 
-		// Handle symlink
 		if info.Mode()&os.ModeSymlink != 0 {
 			dest, err := os.Readlink(path)
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 
 			header.Method = zip.Store
 			writer, err := zipWriter.CreateHeader(header)
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 			_, err = writer.Write([]byte(dest))
-			return errors.WithStack(err)
+			return err
 		}
 
-		// Handle regular files and directories
 		writer, err := zipWriter.CreateHeader(header)
 		if err != nil {
-			return errors.WithStack(err)
+			return err
 		}
 
 		if !info.IsDir() {
 			file, err := os.Open(path)
 			if err != nil {
-				return errors.WithStack(err)
+				return err
 			}
 			defer file.Close()
 
 			_, err = io.Copy(writer, file)
-			return errors.WithStack(err)
+			return err
 		}
 
 		return nil
-	}))
+	})
 }

--- a/protos/xyz/block/ftl/v1/mixins.go
+++ b/protos/xyz/block/ftl/v1/mixins.go
@@ -1,9 +1,9 @@
 package ftlv1
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/alecthomas/errors"
 	"github.com/alecthomas/types"
 
 	model "github.com/TBD54566975/ftl/backend/common/model"
@@ -66,7 +66,7 @@ func (r *RegisterRunnerRequest) DeploymentAsOptional() (types.Option[model.Deplo
 	}
 	key, err := model.ParseDeploymentName(*r.Deployment)
 	if err != nil {
-		return types.None[model.DeploymentName](), errors.Wrap(err, "invalid deployment key")
+		return types.None[model.DeploymentName](), fmt.Errorf("%s: %w", "invalid deployment key", err)
 	}
 	return types.Some(key), nil
 }


### PR DESCRIPTION
[errtrace][1] includes a tool that automatically instruments error returns to provide stack traces.

This obviates the need for us to manually wrap errors to get stacks. Instead, we'll just use normal Go error functions (`errors.New()` and `fmt.Errorf()` with `%w` - see docs) and automatically add the instrumentation when building production release binaries.

[1]: https://github.com/bracesdev/errtrace