### PR TITLE
fix(go): don't inline structs from external modules

### DIFF
--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
+	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -267,6 +268,12 @@ func parseStruct(pctx *parseContext, node ast.Node, tnode types.Type) (*schema.D
 	named, ok := tnode.(*types.Named)
 	if !ok {
 		return nil, fmt.Errorf("expected named type but got %s", tnode)
+	}
+	nodePath := named.Obj().Pkg().Path()
+	if !strings.HasPrefix(nodePath, pctx.pkg.PkgPath) {
+		base := path.Dir(pctx.pkg.PkgPath)
+		destModule := path.Base(strings.TrimPrefix(nodePath, base+"/"))
+		return &schema.DataRef{Module: destModule, Name: named.Obj().Name()}, nil
 	}
 	out := &schema.Data{
 		Pos:  goPosToSchemaPos(node.Pos()),

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -5,15 +5,16 @@ import (
 	"go/types"
 	"testing"
 
-	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/backend/schema"
 )
 
 func TestExtractModuleSchema(t *testing.T) {
-	actual, err := ExtractModuleSchema("testdata")
+	actual, err := ExtractModuleSchema("testdata/one")
 	assert.NoError(t, err)
 	actual = schema.Normalise(actual)
-	expected := `module main {
+	expected := `module one {
   data Nested {
   }
 
@@ -27,6 +28,7 @@ func TestExtractModuleSchema(t *testing.T) {
     nested Nested
     optional Nested?
     time Time
+    user two.User
   }
 
   data Resp {

--- a/go-runtime/compile/testdata/one/one.go
+++ b/go-runtime/compile/testdata/one/one.go
@@ -1,10 +1,11 @@
-//ftl:module main
-package main
+//ftl:module one
+package one
 
 import (
 	"context"
 	"time"
 
+	"github.com/TBD54566975/ftl/go-runtime/compile/testdata/two"
 	"github.com/TBD54566975/ftl/go-runtime/sdk"
 )
 
@@ -21,6 +22,7 @@ type Req struct {
 	Nested   Nested
 	Optional sdk.Option[Nested]
 	Time     time.Time
+	User     two.User
 }
 type Resp struct{}
 

--- a/go-runtime/compile/testdata/two/two.go
+++ b/go-runtime/compile/testdata/two/two.go
@@ -1,0 +1,16 @@
+//ftl:module two
+package two
+
+import "context"
+
+type User struct {
+	Name string
+}
+
+type Request struct{}
+
+type Response struct{}
+
+func Two(ctx context.Context, req Request) (Response, error) {
+	return Response{}, nil
+}


### PR DESCRIPTION
Fixes #690

Before:

```
module checkout {
  data Address {
    streetAddress String
    city String
    state String
    country String
    zipCode Int
  }

  data CreditCardInfo {
    number String
    cVV Int
    expirationYear Int
    expirationMonth Int
  }

  data PlaceOrderRequest {
    userID String
    userCurrency String
    address Address
    email String
    creditCard CreditCardInfo
  }

  data Money {
    currencyCode String
    units Int
    nanos Int
  }

  data Item {
    productID String
    quantity Int
  }

  data OrderItem {
    item Item
    cost Money
  }

  data Order {
    id String
    shippingTrackingID String
    shippingCost Money
    shippingAddress Address
    items [OrderItem]
  }

  verb placeOrder(PlaceOrderRequest) Order
      ingress POST /checkout  calls cart.getCart, productcatalog.get, currency.convert,
            shipping.getQuote, currency.convert, payment.charge,
            shipping.shipOrder, cart.emptyCart
}
```

After:

```
module checkout {
  data PlaceOrderRequest {
    userID String
    userCurrency String
    address shipping.Address
    email String
    creditCard payment.CreditCardInfo
  }

  data OrderItem {
    item cart.Item
    cost money.Money
  }

  data Order {
    id String
    shippingTrackingID String
    shippingCost money.Money
    shippingAddress shipping.Address
    items [OrderItem]
  }

  verb placeOrder(PlaceOrderRequest) Order
      ingress POST /checkout  calls cart.getCart, productcatalog.get, currency.convert,
            shipping.getQuote, currency.convert, payment.charge,
            shipping.shipOrder, cart.emptyCart
}
```