### PR TITLE
fix: validate full schema on deploy

### DIFF
--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -21,6 +21,8 @@ type Querier interface {
 	CreateIngressRoute(ctx context.Context, arg CreateIngressRouteParams) error
 	DeregisterRunner(ctx context.Context, key Key) (int64, error)
 	ExpireRunnerReservations(ctx context.Context) (int64, error)
+	GetActiveDeploymentSchemas(ctx context.Context) ([]GetActiveDeploymentSchemasRow, error)
+	GetActiveDeployments(ctx context.Context, all bool) ([]GetActiveDeploymentsRow, error)
 	GetActiveRunners(ctx context.Context, all bool) ([]GetActiveRunnersRow, error)
 	GetAllIngressRoutes(ctx context.Context, all bool) ([]GetAllIngressRoutesRow, error)
 	GetArtefactContentRange(ctx context.Context, start int32, count int32, iD int64) ([]byte, error)
@@ -30,7 +32,6 @@ type Querier interface {
 	GetDeployment(ctx context.Context, name model.DeploymentName) (GetDeploymentRow, error)
 	// Get all artefacts matching the given digests.
 	GetDeploymentArtefacts(ctx context.Context, deploymentID int64) ([]GetDeploymentArtefactsRow, error)
-	GetDeployments(ctx context.Context, all bool) ([]GetDeploymentsRow, error)
 	GetDeploymentsByID(ctx context.Context, ids []int64) ([]Deployment, error)
 	// Get deployments that have a mismatch between the number of assigned and required replicas.
 	GetDeploymentsNeedingReconciliation(ctx context.Context) ([]GetDeploymentsNeedingReconciliationRow, error)

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -140,13 +140,16 @@ WHERE sqlc.arg('all')::bool = true
    OR r.state <> 'dead'
 ORDER BY r.key;
 
--- name: GetDeployments :many
+-- name: GetActiveDeployments :many
 SELECT sqlc.embed(d), m.name AS module_name, m.language
 FROM deployments d
          INNER JOIN modules m on d.module_id = m.id
 WHERE sqlc.arg('all')::bool = true
    OR min_replicas > 0
 ORDER BY d.name;
+
+-- name: GetActiveDeploymentSchemas :many
+SELECT name, schema FROM deployments WHERE min_replicas > 0;
 
 -- name: GetProcessList :many
 SELECT d.min_replicas,

--- a/examples/online-boutique/common/money/money.go
+++ b/examples/online-boutique/common/money/money.go
@@ -16,6 +16,8 @@ package money
 
 import (
 	"errors"
+
+	"github.com/TBD54566975/ftl/examples/online-boutique/services/currency"
 )
 
 const (
@@ -29,66 +31,49 @@ var (
 	ErrMismatchingCurrency = errors.New("mismatching currency codes")
 )
 
-// Money represents an amount of money along with the currency type.
-type Money struct {
-	// The 3-letter currency code defined in ISO 4217.
-	CurrencyCode string `json:"currencyCode"`
-
-	// The whole units of the amount.
-	// For example if `currencyCode` is `"USD"`, then 1 unit is one US dollar.
-	Units int `json:"units"`
-
-	// Number of nano (10^-9) units of the amount.
-	// The value must be between -999,999,999 and +999,999,999 inclusive.
-	// If `units` is positive, `nanos` must be positive or zero.
-	// If `units` is zero, `nanos` can be positive, zero, or negative.
-	// If `units` is negative, `nanos` must be negative or zero.
-	// For example $-1.75 is represented as `units`=-1 and `nanos`=-750,000,000.
-	Nanos int `json:"nanos"`
-}
-
 // IsValid checks if specified value has a valid units/nanos signs and ranges.
-func IsValid(m Money) bool {
+func IsValid(m currency.Money) bool {
 	return signMatches(m) && validNanos(m.Nanos)
 }
 
-func signMatches(m Money) bool {
+func signMatches(m currency.Money) bool {
 	return m.Nanos == 0 || m.Units == 0 || (m.Nanos < 0) == (m.Units < 0)
 }
 
 func validNanos(nanos int) bool { return nanosMin <= nanos && nanos <= nanosMax }
 
 // IsZero returns true if the specified money value is equal to zero.
-func IsZero(m Money) bool { return m.Units == 0 && m.Nanos == 0 }
+func IsZero(m currency.Money) bool { return m.Units == 0 && m.Nanos == 0 }
 
 // IsPositive returns true if the specified money value is valid and is
 // positive.
-func IsPositive(m Money) bool {
+func IsPositive(m currency.Money) bool {
 	return IsValid(m) && m.Units > 0 || (m.Units == 0 && m.Nanos > 0)
 }
 
 // IsNegative returns true if the specified money value is valid and is
 // negative.
-func IsNegative(m Money) bool {
+func IsNegative(m currency.Money) bool {
 	return IsValid(m) && m.Units < 0 || (m.Units == 0 && m.Nanos < 0)
 }
 
 // AreSameCurrency returns true if values l and r have a currency code and
 // they are the same values.
-func AreSameCurrency(l, r Money) bool {
+func AreSameCurrency(l, r currency.Money) bool {
 	return l.CurrencyCode == r.CurrencyCode && l.CurrencyCode != ""
 }
 
 // AreEquals returns true if values l and r are the equal, including the
-// currency. This does not check validity of the provided values.
-func AreEquals(l, r Money) bool {
+//
+//	This does not check validity of the provided values.
+func AreEquals(l, r currency.Money) bool {
 	return l.CurrencyCode == r.CurrencyCode &&
 		l.Units == r.Units && l.Nanos == r.Nanos
 }
 
 // Negate returns the same amount with the sign negated.
-func Negate(m Money) Money {
-	return Money{
+func Negate(m currency.Money) currency.Money {
+	return currency.Money{
 		Units:        -m.Units,
 		Nanos:        -m.Nanos,
 		CurrencyCode: m.CurrencyCode}
@@ -96,7 +81,7 @@ func Negate(m Money) Money {
 
 // Must panics if the given error is not nil. This can be used with other
 // functions like: "m := Must(Sum(a,b))".
-func Must(v Money, err error) Money {
+func Must(v currency.Money, err error) currency.Money {
 	if err != nil {
 		panic(err)
 	}
@@ -106,11 +91,11 @@ func Must(v Money, err error) Money {
 // Sum adds two values. Returns an error if one of the values are invalid or
 // currency codes are not matching (unless currency code is unspecified for
 // both).
-func Sum(l, r Money) (Money, error) {
+func Sum(l, r currency.Money) (currency.Money, error) {
 	if !IsValid(l) || !IsValid(r) {
-		return Money{}, ErrInvalidValue
+		return currency.Money{}, ErrInvalidValue
 	} else if l.CurrencyCode != r.CurrencyCode {
-		return Money{}, ErrMismatchingCurrency
+		return currency.Money{}, ErrMismatchingCurrency
 	}
 	units := l.Units + r.Units
 	nanos := l.Nanos + r.Nanos
@@ -130,7 +115,7 @@ func Sum(l, r Money) (Money, error) {
 		}
 	}
 
-	return Money{
+	return currency.Money{
 		Units:        units,
 		Nanos:        nanos,
 		CurrencyCode: l.CurrencyCode}, nil
@@ -138,7 +123,7 @@ func Sum(l, r Money) (Money, error) {
 
 // MultiplySlow is a slow multiplication operation done through adding the value
 // to itself n-1 times.
-func MultiplySlow(m Money, n uint32) Money {
+func MultiplySlow(m currency.Money, n uint32) currency.Money {
 	out := m
 	for n > 1 {
 		out = Must(Sum(out, m))

--- a/examples/online-boutique/services/checkout/checkout.go
+++ b/examples/online-boutique/services/checkout/checkout.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/TBD54566975/ftl/backend/common/slices"
 	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/cart"
@@ -13,7 +15,6 @@ import (
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/productcatalog"
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/shipping"
 	ftl "github.com/TBD54566975/ftl/go-runtime/sdk"
-	"github.com/google/uuid"
 )
 
 type PlaceOrderRequest struct {
@@ -27,13 +28,13 @@ type PlaceOrderRequest struct {
 
 type OrderItem struct {
 	Item cart.Item
-	Cost money.Money
+	Cost currency.Money
 }
 
 type Order struct {
 	ID                 string
 	ShippingTrackingID string
-	ShippingCost       money.Money
+	ShippingCost       currency.Money
 	ShippingAddress    shipping.Address
 	Items              []OrderItem
 }
@@ -80,7 +81,7 @@ func PlaceOrder(ctx context.Context, req PlaceOrderRequest) (Order, error) {
 		return Order{}, fmt.Errorf("failed to convert shipping cost to currency: %w", err)
 	}
 
-	total := money.Money{CurrencyCode: req.UserCurrency}
+	total := currency.Money{CurrencyCode: req.UserCurrency}
 	total = money.Must(money.Sum(total, shippingPrice))
 	for _, it := range orders {
 		multPrice := money.MultiplySlow(it.Cost, uint32(it.Item.Quantity))

--- a/examples/online-boutique/services/currency/currency.go
+++ b/examples/online-boutique/services/currency/currency.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/TBD54566975/ftl/examples/online-boutique/common"
-	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
 	"golang.org/x/exp/maps"
+
+	"github.com/TBD54566975/ftl/examples/online-boutique/common"
 )
 
 var (
@@ -17,6 +17,24 @@ var (
 	databaseJSON []byte
 	database     = common.LoadDatabase[map[string]float64](databaseJSON)
 )
+
+// Money represents an amount of money along with the currency type.
+type Money struct {
+	// The 3-letter currency code defined in ISO 4217.
+	CurrencyCode string `json:"currencyCode"`
+
+	// The whole units of the amount.
+	// For example if `currencyCode` is `"USD"`, then 1 unit is one US dollar.
+	Units int `json:"units"`
+
+	// Number of nano (10^-9) units of the amount.
+	// The value must be between -999,999,999 and +999,999,999 inclusive.
+	// If `units` is positive, `nanos` must be positive or zero.
+	// If `units` is zero, `nanos` can be positive, zero, or negative.
+	// If `units` is negative, `nanos` must be negative or zero.
+	// For example $-1.75 is represented as `units`=-1 and `nanos`=-750,000,000.
+	Nanos int `json:"nanos"`
+}
 
 type GetSupportedCurrenciesRequest struct {
 }
@@ -32,21 +50,21 @@ func GetSupportedCurrencies(ctx context.Context, req GetSupportedCurrenciesReque
 }
 
 type ConvertRequest struct {
-	From   money.Money
+	From   Money
 	ToCode string
 }
 
 //ftl:verb
 //ftl:ingress POST /currency/convert
-func Convert(ctx context.Context, req ConvertRequest) (money.Money, error) {
+func Convert(ctx context.Context, req ConvertRequest) (Money, error) {
 	from := req.From
 	fromRate, ok := database[from.CurrencyCode]
 	if !ok {
-		return money.Money{}, fmt.Errorf("unknown origin currency %q", req.From.CurrencyCode)
+		return Money{}, fmt.Errorf("unknown origin currency %q", req.From.CurrencyCode)
 	}
 	toRate, ok := database[req.ToCode]
 	if !ok {
-		return money.Money{}, fmt.Errorf("unknown destination currency %q", req.ToCode)
+		return Money{}, fmt.Errorf("unknown destination currency %q", req.ToCode)
 	}
 	euros := carry(float64(from.Units)/fromRate, float64(from.Nanos)/fromRate)
 	to := carry(float64(euros.Units)*toRate, float64(euros.Nanos)*toRate)
@@ -55,12 +73,12 @@ func Convert(ctx context.Context, req ConvertRequest) (money.Money, error) {
 }
 
 // carry is a helper function that handles decimal/fractional carrying.
-func carry(units float64, nanos float64) money.Money {
+func carry(units float64, nanos float64) Money {
 	const fractionSize = 1000000000 // 1B
 	nanos += math.Mod(units, 1.0) * fractionSize
 	units = math.Floor(units) + math.Floor(nanos/fractionSize)
 	nanos = math.Mod(nanos, fractionSize)
-	return money.Money{
+	return Money{
 		Units: int(units),
 		Nanos: int(nanos),
 	}

--- a/examples/online-boutique/services/email/email.go
+++ b/examples/online-boutique/services/email/email.go
@@ -1,1 +1,0 @@
-package email

--- a/examples/online-boutique/services/payment/payment.go
+++ b/examples/online-boutique/services/payment/payment.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
 	"github.com/google/uuid"
+
+	"github.com/TBD54566975/ftl/examples/online-boutique/services/currency"
 )
 
 type InvalidCreditCardErr struct{}
@@ -42,7 +43,7 @@ func (c CreditCardInfo) LastFour() string {
 }
 
 type ChargeRequest struct {
-	Amount     money.Money
+	Amount     currency.Money
 	CreditCard CreditCardInfo
 }
 

--- a/examples/online-boutique/services/productcatalog/productcatalog.go
+++ b/examples/online-boutique/services/productcatalog/productcatalog.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/TBD54566975/ftl/examples/online-boutique/common"
-	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
+	"github.com/TBD54566975/ftl/examples/online-boutique/services/currency"
 )
 
 var (
@@ -18,11 +18,11 @@ var (
 )
 
 type Product struct {
-	ID          string      `json:"id"`
-	Name        string      `json:"name"`
-	Description string      `json:"description"`
-	Picture     string      `json:"picture"`
-	PriceUSD    money.Money `json:"priceUSD"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Picture     string         `json:"picture"`
+	PriceUSD    currency.Money `json:"priceUSD"`
 
 	// Categories such as "clothing" or "kitchen" that can be used to look up
 	// other related products.

--- a/examples/online-boutique/services/shipping/shipping.go
+++ b/examples/online-boutique/services/shipping/shipping.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/TBD54566975/ftl/examples/online-boutique/common/money"
 	"github.com/TBD54566975/ftl/examples/online-boutique/services/cart"
+	"github.com/TBD54566975/ftl/examples/online-boutique/services/currency"
 )
 
 type Address struct {
@@ -25,7 +25,7 @@ type ShippingRequest struct {
 
 //ftl:verb
 //ftl:ingress POST /shipping/quote
-func GetQuote(ctx context.Context, req ShippingRequest) (money.Money, error) {
+func GetQuote(ctx context.Context, req ShippingRequest) (currency.Money, error) {
 	return moneyFromUSD(8.99), nil
 }
 
@@ -40,9 +40,9 @@ func ShipOrder(ctx context.Context, req ShippingRequest) (ShipOrderResponse, err
 	return ShipOrderResponse{ID: createTrackingID(baseAddress)}, nil
 }
 
-func moneyFromUSD(value float64) money.Money {
+func moneyFromUSD(value float64) currency.Money {
 	units, fraction := math.Modf(value)
-	return money.Money{
+	return currency.Money{
 		CurrencyCode: "USD",
 		Units:        int(units),
 		Nanos:        int(math.Trunc(fraction * 10000000)),


### PR DESCRIPTION
This change loads all existing schemas, merges the current deployment's schema, then validates the entire schema together. This ensures only valid modules can be deployed to the cluster, but requires deployment in a specific order.