### PR TITLE
fix: normalize dataref in jsonschema lookup

### DIFF
--- a/backend/schema/jsonschema.go
+++ b/backend/schema/jsonschema.go
@@ -15,30 +15,30 @@ func DataToJSONSchema(schema *Schema, dataRef DataRef) (*jsonschema.Schema, erro
 	dataTypes := schema.DataMap()
 
 	// Find the root data type.
-	rootData, ok := dataTypes[dataRef]
+	rootData, ok := dataTypes[DataRef{Module: dataRef.Module, Name: dataRef.Name}]
 	if !ok {
 		return nil, fmt.Errorf("unknown data type %s", dataRef)
 	}
 
 	// Encode root, and collect all data types reachable from the root.
 	dataRefs := map[DataRef]bool{}
-	root := nodeToJSSchema(rootData, dataRef, dataRefs)
+	root := nodeToJSSchema(rootData, dataRefs)
 	if len(dataRefs) == 0 {
 		return root, nil
 	}
 	// Resolve and encode all data types reachable from the root.
 	root.Definitions = map[string]jsonschema.SchemaOrBool{}
 	for dataRef := range dataRefs {
-		data, ok := dataTypes[dataRef]
+		data, ok := dataTypes[DataRef{Module: dataRef.Module, Name: dataRef.Name}]
 		if !ok {
 			return nil, fmt.Errorf("unknown data type %s", dataRef)
 		}
-		root.Definitions[dataRef.String()] = jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(data, dataRef, dataRefs)}
+		root.Definitions[dataRef.String()] = jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(data, dataRefs)}
 	}
 	return root, nil
 }
 
-func nodeToJSSchema(node Node, rootRef DataRef, dataRefs map[DataRef]bool) *jsonschema.Schema {
+func nodeToJSSchema(node Node, dataRefs map[DataRef]bool) *jsonschema.Schema {
 	switch node := node.(type) {
 	case *Data:
 		st := jsonschema.Object
@@ -49,7 +49,7 @@ func nodeToJSSchema(node Node, rootRef DataRef, dataRefs map[DataRef]bool) *json
 			AdditionalProperties: jsBool(false),
 		}
 		for _, field := range node.Fields {
-			jsField := nodeToJSSchema(field.Type, rootRef, dataRefs)
+			jsField := nodeToJSSchema(field.Type, dataRefs)
 			jsField.Description = jsComments(field.Comments)
 			if _, ok := field.Type.(*Optional); !ok {
 				schema.Required = append(schema.Required, field.Name)
@@ -85,7 +85,7 @@ func nodeToJSSchema(node Node, rootRef DataRef, dataRefs map[DataRef]bool) *json
 			Type: &jsonschema.Type{SimpleTypes: &st},
 			Items: &jsonschema.Items{
 				SchemaOrBool: &jsonschema.SchemaOrBool{
-					TypeObject: nodeToJSSchema(node.Element, rootRef, dataRefs),
+					TypeObject: nodeToJSSchema(node.Element, dataRefs),
 				},
 			},
 		}
@@ -95,17 +95,12 @@ func nodeToJSSchema(node Node, rootRef DataRef, dataRefs map[DataRef]bool) *json
 		// JSON schema generic map of key type to value type
 		return &jsonschema.Schema{
 			Type:                 &jsonschema.Type{SimpleTypes: &st},
-			PropertyNames:        &jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(node.Key, rootRef, dataRefs)},
-			AdditionalProperties: &jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(node.Value, rootRef, dataRefs)},
+			PropertyNames:        &jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(node.Key, dataRefs)},
+			AdditionalProperties: &jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(node.Value, dataRefs)},
 		}
 
 	case *DataRef:
 		dataRef := *node
-		if dataRef.Module == "" {
-			// handle root data types
-			dataRef.Module = rootRef.Module
-		}
-
 		ref := fmt.Sprintf("#/definitions/%s", dataRef.String())
 		dataRefs[dataRef] = true
 		return &jsonschema.Schema{Ref: &ref}
@@ -113,7 +108,7 @@ func nodeToJSSchema(node Node, rootRef DataRef, dataRefs map[DataRef]bool) *json
 	case *Optional:
 		null := jsonschema.Null
 		return &jsonschema.Schema{AnyOf: []jsonschema.SchemaOrBool{
-			{TypeObject: nodeToJSSchema(node.Type, rootRef, dataRefs)},
+			{TypeObject: nodeToJSSchema(node.Type, dataRefs)},
 			{TypeObject: &jsonschema.Schema{Type: &jsonschema.Type{SimpleTypes: &null}}},
 		}}
 

--- a/backend/schema/jsonschema_test.go
+++ b/backend/schema/jsonschema_test.go
@@ -22,7 +22,7 @@ var jsonSchemaSample = &Schema{
 					{Name: "bool", Type: &Bool{}},
 					{Name: "time", Type: &Time{}},
 					{Name: "array", Type: &Array{Element: &String{}}},
-					{Name: "arrayOfRefs", Type: &Array{Element: &DataRef{Name: "Item"}}},
+					{Name: "arrayOfRefs", Type: &Array{Element: &DataRef{Module: "foo", Name: "Item"}}},
 					{Name: "arrayOfArray", Type: &Array{Element: &Array{Element: &String{}}}},
 					{Name: "optionalArray", Type: &Array{Element: &Optional{Type: &String{}}}},
 					{Name: "map", Type: &Map{Key: &String{}, Value: &Int{}}},


### PR DESCRIPTION
The lookup for finding data in the `dataTypes` map was failing because the refs contained the full definition of the dataRef but the map only contained the `Module` and `Name` fields.

This was causing the console to fail with the following error when using `GetModules` which will build the `jsonSchema` for each module.

```
modules-provider.tsx:27 
POST http://localhost:8892/xyz.block.ftl.v1.console.ConsoleService/GetModules 500 (Internal Server Error)

modules-provider.tsx:32 ModulesProvider - Connect error: ConnectError: [unknown] unknown data type cart.Item
    at errorFromJson (error-json.js:54:19)
    at next (connect-transport.js:84:31)
    at async Object.unary (connect-transport.js:50:20)
    at async Object.getModules (promise-client.js:66:26)
    at async fetchModules (modules-provider.tsx:27:25)
```

I also cleaned up the old handing of not having a `Module` when processing the data refs since all refs will be fully-qualified now.