### PR TITLE
fix: validate module schema on deployment

### DIFF
--- a/backend/schema/schema.go
+++ b/backend/schema/schema.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/alecthomas/participle/v2/lexer"
+	"github.com/alecthomas/types"
 	"golang.org/x/exp/maps"
 	"google.golang.org/protobuf/proto"
 )
@@ -310,6 +311,16 @@ type Schema struct {
 	Pos Position `parser:"" protobuf:"1,optional"`
 
 	Modules []*Module `parser:"@@*" protobuf:"2"`
+}
+
+// Module returns the named module if it exists.
+func (s *Schema) Module(name string) types.Option[*Module] {
+	for _, module := range s.Modules {
+		if module.Name == name {
+			return types.Some(module)
+		}
+	}
+	return types.None[*Module]()
 }
 
 func (s *Schema) DataMap() map[DataRef]*Data {

--- a/backend/schema/validate.go
+++ b/backend/schema/validate.go
@@ -73,10 +73,12 @@ func Validate(schema *Schema) (*Schema, error) {
 	dataRefs := []*DataRef{}
 	merr := []error{}
 	ingress := map[string]*Verb{}
+
 	// Inject builtins.
 	builtins := Builtins()
 	schema.Modules = slices.DeleteFunc(schema.Modules, func(m *Module) bool { return m.Name == builtins.Name })
 	schema.Modules = append([]*Module{builtins}, schema.Modules...)
+
 	// Map from reference to the module it is defined in.
 	localModule := map[*Ref]*Module{}
 


### PR DESCRIPTION
The previous change resulted in relative refs within a module not being written back to the schema before committing to the DB.