### PR TITLE
fix: `{Get,Pull}Schema()` weren't returning builtin module

### DIFF
--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -243,8 +243,8 @@ func TestParsing(t *testing.T) {
 					Decls: []Decl{
 						&Verb{
 							Name:     "myIngress",
-							Request:  &DataRef{Module: "ftl", Name: "HttpRequest"},
-							Response: &DataRef{Module: "ftl", Name: "HttpResponse"},
+							Request:  &DataRef{Module: "builtin", Name: "HttpRequest"},
+							Response: &DataRef{Module: "builtin", Name: "HttpResponse"},
 						},
 					},
 				}},

--- a/backend/schema/validate.go
+++ b/backend/schema/validate.go
@@ -23,7 +23,7 @@ var (
 	// BuiltinsSource is the schema source code for built-in types.
 	BuiltinsSource = `
 // Built-in types for FTL.
-builtin module ftl {
+builtin module builtin {
   // HTTP request structure used for HTTP ingress verbs.
   data HttpRequest {
     method String
@@ -152,7 +152,7 @@ func resolveRef(localModule *Module, ref *Ref, exist map[string]bool) bool {
 	if ref.Module != "" {
 		return exist[ref.String()]
 	}
-	for _, module := range []string{localModule.Name, "ftl"} {
+	for _, module := range []string{localModule.Name, "builtin"} {
 		clone := reflect.DeepCopy(ref)
 		clone.Module = module
 		if exist[clone.String()] {
@@ -173,7 +173,7 @@ func ValidateModule(module *Module) error {
 	if !validNameRe.MatchString(module.Name) {
 		merr = append(merr, fmt.Errorf("%s: module name %q is invalid", module.Pos, module.Name))
 	}
-	if module.Builtin && module.Name != "ftl" {
+	if module.Builtin && module.Name != "builtin" {
 		merr = append(merr, fmt.Errorf("%s: only the \"ftl\" module can be marked as builtin", module.Pos))
 	}
 	err := Visit(module, func(n Node, next func() error) error {


### PR DESCRIPTION
Also renamed builtin module to "builtin" from "ftl" so that imports are `ftl.builtin` rather than `ftl.ftl`.