### PR TITLE
feat: add (hacky) support for config and secrets

### DIFF
--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -10,10 +10,9 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/TBD54566975/scaffolder"
 	"github.com/iancoleman/strcase"
 	"google.golang.org/protobuf/proto"
-
-	"github.com/TBD54566975/scaffolder"
 
 	"github.com/TBD54566975/ftl/backend/common/exec"
 	"github.com/TBD54566975/ftl/backend/common/log"

--- a/go-runtime/sdk/config.go
+++ b/go-runtime/sdk/config.go
@@ -1,0 +1,66 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+)
+
+// ConfigType is a type that can be used as a configuration value.
+//
+// Supported types are currently limited, but will eventually be extended to
+// allow any type that FTL supports, including structs.
+type ConfigType interface {
+	string | int | float64 | bool |
+		[]string | []int | []float64 | []bool | []byte |
+		map[string]string | map[string]int | map[string]float64 | map[string]bool | map[string][]byte
+}
+
+// Config declares a typed configuration key for the current module.
+func Config[T ConfigType](name string) ConfigValue[T] {
+	module := callerModule()
+	return ConfigValue[T]{module, name}
+}
+
+// ConfigValue is a typed configuration key for the current module.
+type ConfigValue[T ConfigType] struct {
+	module string
+	name   string
+}
+
+func (c *ConfigValue[T]) String() string {
+	return fmt.Sprintf("config %s.%s", c.module, c.name)
+}
+
+// Get returns the value of the configuration key from FTL.
+func (c *ConfigValue[T]) Get() (out T) {
+	value, ok := os.LookupEnv(fmt.Sprintf("FTL_CONFIG_%s_%s", strings.ToUpper(c.module), strings.ToUpper(c.name)))
+	if !ok {
+		return out
+	}
+	if err := json.Unmarshal([]byte(value), &out); err != nil {
+		panic(fmt.Errorf("failed to parse %s value %q: %w", c, value, err))
+	}
+	return
+}
+
+func callerModule() string {
+	pc, _, _, ok := runtime.Caller(2)
+	if !ok {
+		panic("failed to get caller")
+	}
+	details := runtime.FuncForPC(pc)
+	if details == nil {
+		panic("failed to get caller")
+	}
+	module := details.Name()
+	if strings.HasPrefix(module, "github.com/TBD54566975/ftl/go-runtime/sdk") {
+		return "testing"
+	}
+	if !strings.HasPrefix(module, "ftl/") {
+		panic(fmt.Sprintf("must be called from an FTL module not %s", module))
+	}
+	return strings.Split(strings.Split(module, "/")[1], ".")[0]
+}

--- a/go-runtime/sdk/config_test.go
+++ b/go-runtime/sdk/config_test.go
@@ -1,0 +1,13 @@
+package sdk
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestConfig(t *testing.T) {
+	t.Setenv("FTL_CONFIG_TESTING_TEST", `["one", "two", "three"]`)
+	config := Config[[]string]("test")
+	assert.Equal(t, []string{"one", "two", "three"}, config.Get())
+}

--- a/go-runtime/sdk/secrets.go
+++ b/go-runtime/sdk/secrets.go
@@ -1,0 +1,46 @@
+package sdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SecretType is a type that can be used as a secret value.
+//
+// Supported types are currently limited, but will eventually be extended to
+// allow any type that FTL supports, including structs.
+type SecretType interface {
+	string | int | float64 | bool |
+		[]string | []int | []float64 | []bool | []byte
+	map[string]string | map[string]int | map[string]float64 | map[string]bool | map[string][]byte
+}
+
+// Secret declares a typed secret for the current module.
+func Secret[Type SecretType](name string) SecretValue[Type] {
+	module := callerModule()
+	return SecretValue[Type]{module, name}
+}
+
+// SecretValue is a typed secret for the current module.
+type SecretValue[Type SecretType] struct {
+	module string
+	name   string
+}
+
+func (s *SecretValue[Type]) String() string {
+	return fmt.Sprintf("secret %s.%s", s.module, s.name)
+}
+
+// Get returns the value of the secret from FTL.
+func (c *SecretValue[Type]) Get() (out Type) {
+	value, ok := os.LookupEnv(fmt.Sprintf("FTL_SECRET_%s_%s", strings.ToUpper(c.module), strings.ToUpper(c.name)))
+	if !ok {
+		return out
+	}
+	if err := json.Unmarshal([]byte(value), &out); err != nil {
+		panic(fmt.Errorf("failed to parse %s: %w", c, err))
+	}
+	return
+}

--- a/kotlin-runtime/ftl-runtime/pom.xml
+++ b/kotlin-runtime/ftl-runtime/pom.xml
@@ -109,6 +109,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/config/Config.kt
+++ b/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/config/Config.kt
@@ -1,0 +1,21 @@
+package xyz.block.ftl.config
+
+import xyz.block.ftl.serializer.makeGson
+
+class Secret<T>(val name: String) {
+  val _module: String
+  val _gson = makeGson()
+
+  init {
+    val caller = Thread.currentThread().stackTrace[2].className
+    require(caller.startsWith("ftl.") || caller.startsWith("xyz.block.ftl.config.")) { "Config must be defined in an FTL module not $caller" }
+    val parts = caller.split(".")
+    _module = parts[parts.size - 2]
+  }
+
+  inline fun <reified T> get(): T {
+    val key = "FTL_CONFIG_${_module.uppercase()}_${name.uppercase()}"
+    val value = System.getenv(key) ?: throw Exception("Config key ${_module}.${name} not found")
+    return _gson.fromJson(value, T::class.java)
+  }
+}

--- a/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/config/ConfigTest.kt
+++ b/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/config/ConfigTest.kt
@@ -1,0 +1,14 @@
+package xyz.block.ftl.config
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junitpioneer.jupiter.SetEnvironmentVariable
+
+class ConfigTest {
+  @Test
+  @SetEnvironmentVariable(key = "FTL_SECRET_SECRETS_TEST", value = "testingtesting")
+  fun testSecret() {
+    val secret = Secret<String>("test")
+    assertEquals("testingtesting", secret.get())
+  }
+}

--- a/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/secrets/SecretTest.kt
+++ b/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/secrets/SecretTest.kt
@@ -1,0 +1,14 @@
+package xyz.block.ftl.secrets
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junitpioneer.jupiter.SetEnvironmentVariable
+
+class SecretTest {
+  @Test
+  @SetEnvironmentVariable(key = "FTL_SECRET_SECRETS_TEST", value = "testingtesting")
+  fun testSecret() {
+    val secret = Secret<String>("test")
+    assertEquals("testingtesting", secret.get())
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
 
@@ -195,6 +195,10 @@
                             <include>Test*</include>
                             <include>*Test</include>
                         </includes>
+                        <argLine>
+                            --add-opens java.base/java.util=ALL-UNNAMED
+                            --add-opens java.base/java.lang=ALL-UNNAMED
+                        </argLine>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
This currently loads from environment variables
`FTL_{CONFIG,SECRET}_<MODULE>_<KEY>`, which will eventually be delivered by the Runner.