### PR TITLE
fix: prefix ftl version with "v" for go.mod files

### DIFF
--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -214,7 +214,11 @@ func updateGoModule(goModPath string) (version string, err error) {
 		return "", fmt.Errorf("failed to parse %s: %w", goModPath, err)
 	}
 	if ftl.IsRelease(ftl.Version) {
-		if err := goModfile.AddRequire("github.com/TBD54566975/ftl", ftl.Version); err != nil {
+		version := ftl.Version
+		if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
+		if err := goModfile.AddRequire("github.com/TBD54566975/ftl", version); err != nil {
 			return "", fmt.Errorf("failed to add github.com/TBD54566975/ftl to %s: %w", goModPath, err)
 		}
 		goModBytes = modfile.Format(goModfile.Syntax)


### PR DESCRIPTION
When building modules with `ftl` I run into issues where the version would be updated to the format `1.2.3` instead of `v1.2.3`.

Not sure if we want this change specifically, but it seems to resolve the error. Another approach would be to update the `ftl.Version` itself to include the `v`.

Whatcha think @alecthomas ?

The raw error:
```bash
   backend | info: Creating deployment for module exemplar
   backend | info: Building Go module 'exemplar'
   backend | error: Error deploying module [REDACTED]/backend/modules/exemplar. Will retry: failed to build module: failed to parse [REDACTED]/backend/modules/exemplar/go.mod: [REDACTED]/backend/modules/exemplar/go.mod:6:2: require github.com/TBD54566975/ftl: version "0.97.0" invalid: must be of the form v1.2.3
```