### PR TITLE
fix: two bugs with updating a module's go.mod file

### DIFF
--- a/backend/controller/ingress/ingress_test.go
+++ b/backend/controller/ingress/ingress_test.go
@@ -4,8 +4,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/backend/schema"
 )
 
 type obj = map[string]any


### PR DESCRIPTION
- Don't write go.mod file if FTL version hasn't changed
- Write the file atomically to avoid corruption

Fixes #799 