### PR TITLE
fix: ftl serve health check existing dbs

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -133,11 +133,6 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 			return "", err
 		}
 
-		err = pollContainerHealth(ctx, ftlContainerName, 10*time.Second)
-		if err != nil {
-			return "", err
-		}
-
 		recreate = true
 	} else {
 		// Start the existing container
@@ -160,6 +155,11 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 		})
 
 		logger.Infof("Reusing existing docker container %q on port %q for postgres db", ftlContainerName, port)
+	}
+
+	err = pollContainerHealth(ctx, ftlContainerName, 10*time.Second)
+	if err != nil {
+		return "", err
 	}
 
 	dsn := fmt.Sprintf("postgres://postgres:secret@localhost:%s/ftl?sslmode=disable", port)


### PR DESCRIPTION
Fixes #783 

After running `docker kill ftl-db-1` the db would need to be started again.

In the previous code, we were only doing the health check on a new db, but we also need it for existing dbs to handle this error.

Here's an example of this working with some debug messages added for visibility:

```bash
docker kill ftl-db-1
```

```bash
ftl serve
info: Reusing existing docker container "ftl-db-1" on port "54320" for postgres db
info: Waiting for ftl-db-1 to be healthy
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
warn: Container ftl-db-1 is starting
info: Container ftl-db-1 is healthy
info: Postgres DSN: postgres://postgres:secret@localhost:54320/ftl?sslmode=disable
info: Starting 1 controller(s) and 0 runner(s)
info:controller0: Starting FTL controller
info:controller0: Building console...
info:controller0: Console started
info:controller0: Starting DB listener
info:controller0: Listening on http://localhost:8892
```

You can see for the logs here that even when reusing a db, we need to wait for the health check loop.