### PR TITLE
fix: AbstractRef typenames

### DIFF
--- a/backend/schema/schema.go
+++ b/backend/schema/schema.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"crypto/sha256"
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/alecthomas/types"
@@ -106,6 +107,17 @@ func (s *Schema) ToProto() proto.Message {
 		Pos:     posToProto(s.Pos),
 		Modules: nodeListToProto[*schemapb.Module](s.Modules),
 	}
+}
+
+func TypeName(v any) string {
+	t := reflect.Indirect(reflect.ValueOf(v)).Type()
+
+	// handle AbstractRefs like "AbstractRef[github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema.DataRef]"
+	if strings.HasPrefix(t.Name(), "AbstractRef[") {
+		return strings.TrimSuffix(strings.Split(t.Name(), ".")[2], "]")
+	}
+
+	return t.Name()
 }
 
 // FromProto converts a protobuf Schema to a Schema and validates it.

--- a/cmd/ftl/cmd_init.go
+++ b/cmd/ftl/cmd_init.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/TBD54566975/scaffolder"
@@ -18,6 +17,7 @@ import (
 
 	"github.com/TBD54566975/ftl/backend/common/exec"
 	"github.com/TBD54566975/ftl/backend/common/log"
+	"github.com/TBD54566975/ftl/backend/schema"
 	goruntime "github.com/TBD54566975/ftl/go-runtime"
 	"github.com/TBD54566975/ftl/internal"
 	kotlinruntime "github.com/TBD54566975/ftl/kotlin-runtime"
@@ -144,9 +144,7 @@ var scaffoldFuncs = template.FuncMap{
 	"upper":          strings.ToUpper,
 	"lower":          strings.ToLower,
 	"title":          strings.Title,
-	"typename": func(v any) string {
-		return reflect.Indirect(reflect.ValueOf(v)).Type().Name()
-	},
+	"typename":       schema.TypeName,
 }
 
 func updateGitIgnore(ctx context.Context, dir string) error {

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -124,9 +124,7 @@ var scaffoldFuncs = scaffolder.FuncMap{
 	"upper":          strings.ToUpper,
 	"lower":          strings.ToLower,
 	"title":          strings.Title,
-	"typename": func(v any) string {
-		return reflect.Indirect(reflect.ValueOf(v)).Type().Name()
-	},
+	"typename":       schema.TypeName,
 	"comment": func(s []string) string {
 		if len(s) == 0 {
 			return ""


### PR DESCRIPTION
Types like `AbstractRef[github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema.DataRef]` would return to the generate with `AbstractRef`

What we really want in the generator/templates is `DataRef` for this.