### PR TITLE
fix: allow secret and config values to be any type

### DIFF
--- a/go-runtime/sdk/config.go
+++ b/go-runtime/sdk/config.go
@@ -9,14 +9,7 @@ import (
 )
 
 // ConfigType is a type that can be used as a configuration value.
-//
-// Supported types are currently limited, but will eventually be extended to
-// allow any type that FTL supports, including structs.
-type ConfigType interface {
-	string | int | float64 | bool |
-		[]string | []int | []float64 | []bool | []byte |
-		map[string]string | map[string]int | map[string]float64 | map[string]bool | map[string][]byte
-}
+type ConfigType interface{ any }
 
 // Config declares a typed configuration key for the current module.
 func Config[T ConfigType](name string) ConfigValue[T] {

--- a/go-runtime/sdk/secrets.go
+++ b/go-runtime/sdk/secrets.go
@@ -8,14 +8,7 @@ import (
 )
 
 // SecretType is a type that can be used as a secret value.
-//
-// Supported types are currently limited, but will eventually be extended to
-// allow any type that FTL supports, including structs.
-type SecretType interface {
-	string | int | float64 | bool |
-		[]string | []int | []float64 | []bool | []byte |
-		map[string]string | map[string]int | map[string]float64 | map[string]bool | map[string][]byte
-}
+type SecretType interface{ any }
 
 // Secret declares a typed secret for the current module.
 func Secret[Type SecretType](name string) SecretValue[Type] {


### PR DESCRIPTION
We'll include referenced data structures in the schema at some point, but for now this will make it more convenient to use.