### PR TITLE
fix: console errors on jsonschema

### DIFF
--- a/backend/schema/jsonschema.go
+++ b/backend/schema/jsonschema.go
@@ -29,7 +29,7 @@ func DataToJSONSchema(schema *Schema, dataRef DataRef) (*jsonschema.Schema, erro
 	// Resolve and encode all data types reachable from the root.
 	root.Definitions = map[string]jsonschema.SchemaOrBool{}
 	for dataRef := range dataRefs {
-		data, ok := dataTypes[dataRef]
+		data, ok := dataTypes[Ref{Module: dataRef.Module, Name: dataRef.Name}]
 		if !ok {
 			return nil, fmt.Errorf("unknown data type %s", dataRef)
 		}


### PR DESCRIPTION
Displaying deployments and the graph was broken on the console

```
error: Unary RPC failed: unknown data type {/dev/ftl/examples/online-boutique/services/cart/cart.go:29:1 cart Item}: /xyz.block.ftl.v1.console.ConsoleService/GetModules
```