### PR TITLE
chore: parameterize integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -6,9 +6,32 @@ concurrency:
   cancel-in-progress: true
 name: Integration
 jobs:
-  integration:
-    name: Integration tests
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-tests.outputs.matrix }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+      - name: Extract test cases
+        id: extract-tests
+        run: |
+          echo "cases=$(go test -v -list . -tags integration ./integration | grep '^Test' | awk '{print $1}' | cut -d '(' -f1 | tr '\n' ',' | sed 's/,$//')" >> "$GITHUB_OUTPUT"
+      - name: Format test matrix
+        id: set-tests
+        run: |
+          IFS=',' read -ra TESTS <<< "${{ steps.extract-tests.outputs.cases }}"
+          TEST_JSON=$(printf ',"%s"' "${TESTS[@]}")
+          TEST_JSON="[${TEST_JSON:1}]"
+          echo "matrix={\"test\": $TEST_JSON}" >> "$GITHUB_OUTPUT"
+  integration:
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.prepare.outputs.matrix)}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,5 +43,5 @@ jobs:
         run: docker compose up -d --wait
       - name: Download Go Modules
         run: go mod download
-      - name: Integration tests
-        run: go test -v -tags integration ./integration
+      - name: Run ${{ matrix.test }}
+        run: go test -v -tags integration -run ${{ matrix.test }} ./integration

--- a/integration/testdata/go/database/echo.go
+++ b/integration/testdata/go/database/echo.go
@@ -1,0 +1,43 @@
+//ftl:module echo
+package echo
+
+import (
+	"context"
+
+	ftl "github.com/TBD54566975/ftl/go-runtime/sdk" // Import the FTL SDK.
+)
+
+var db = ftl.PostgresDatabase("testdb")
+
+type InsertRequest struct {
+	Data string
+}
+
+type InsertResponse struct{}
+
+//ftl:verb
+func Insert(ctx context.Context, req InsertRequest) (InsertResponse, error) {
+	err := persistRequest(req)
+	if err != nil {
+		return InsertResponse{}, err
+	}
+
+	return InsertResponse{}, nil
+}
+
+func persistRequest(req InsertRequest) error {
+	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS requests
+	       (
+	         data TEXT,
+	         created_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
+	         updated_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc')
+	      );`)
+	if err != nil {
+		return err
+	}
+	_, err = db.Exec("INSERT INTO requests (data) VALUES ($1);", req.Data)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/integration/testdata/go/externalcalls/echo.go
+++ b/integration/testdata/go/externalcalls/echo.go
@@ -1,0 +1,32 @@
+//ftl:module echo
+package echo
+
+import (
+	"context"
+	"fmt"
+
+	"ftl/echo2"
+	ftl "github.com/TBD54566975/ftl/go-runtime/sdk" // Import the FTL SDK.
+)
+
+type EchoRequest struct {
+	Name ftl.Option[string] `json:"name"`
+}
+
+type EchoResponse struct {
+	Message string `json:"message"`
+}
+
+//ftl:verb
+func Echo(ctx context.Context, req EchoRequest) (EchoResponse, error) {
+	return EchoResponse{Message: fmt.Sprintf("Hello, %s!", req.Name.Default("anonymous"))}, nil
+}
+
+//ftl:verb
+func Call(ctx context.Context, req EchoRequest) (EchoResponse, error) {
+	res, err := ftl.Call(ctx, echo2.Echo, echo2.EchoRequest{Name: req.Name})
+	if err != nil {
+		return EchoResponse{}, err
+	}
+	return EchoResponse{Message: res.Message}, nil
+}

--- a/integration/testdata/go/httpingress/echo.go
+++ b/integration/testdata/go/httpingress/echo.go
@@ -1,0 +1,78 @@
+//ftl:module echo
+package echo
+
+import (
+	"context"
+	"fmt"
+
+	"ftl/builtin"
+)
+
+type GetRequest struct {
+	UserID string `json:"userId"`
+	PostID string `json:"postId"`
+}
+
+type GetResponse struct {
+	Message string `json:"message"`
+}
+
+//ftl:verb
+//ftl:ingress http GET /echo/users/{userID}/posts/{postID}
+func Get(ctx context.Context, req builtin.HttpRequest[GetRequest]) (builtin.HttpResponse[GetResponse], error) {
+	return builtin.HttpResponse[GetResponse]{
+		Status:  200,
+		Headers: map[string][]string{"Get": {"Header from FTL"}},
+		Body:    GetResponse{Message: fmt.Sprintf("UserID: %s, PostID: %s", req.Body.UserID, req.Body.PostID)},
+	}, nil
+}
+
+type PostRequest struct {
+	UserID string `json:"userId" alias:"id"`
+	PostID string `json:"postId"`
+}
+
+type PostResponse struct{}
+
+//ftl:verb
+//ftl:ingress http POST /echo/users
+func Post(ctx context.Context, req builtin.HttpRequest[PostRequest]) (builtin.HttpResponse[PostResponse], error) {
+	return builtin.HttpResponse[PostResponse]{
+		Status:  201,
+		Headers: map[string][]string{"Post": {"Header from FTL"}},
+		Body:    PostResponse{},
+	}, nil
+}
+
+type PutRequest struct {
+	UserID string `json:"userId"`
+	PostID string `json:"postId"`
+}
+
+type PutResponse struct{}
+
+//ftl:verb
+//ftl:ingress http PUT /echo/users/{userID}
+func Put(ctx context.Context, req builtin.HttpRequest[PutRequest]) (builtin.HttpResponse[PutResponse], error) {
+	return builtin.HttpResponse[PutResponse]{
+		Status:  200,
+		Headers: map[string][]string{"Put": {"Header from FTL"}},
+		Body:    PutResponse{},
+	}, nil
+}
+
+type DeleteRequest struct {
+	UserID string `json:"userId"`
+}
+
+type DeleteResponse struct{}
+
+//ftl:verb
+//ftl:ingress http DELETE /echo/users/{userID}
+func Delete(ctx context.Context, req builtin.HttpRequest[DeleteRequest]) (builtin.HttpResponse[DeleteResponse], error) {
+	return builtin.HttpResponse[DeleteResponse]{
+		Status:  200,
+		Headers: map[string][]string{"Put": {"Header from FTL"}},
+		Body:    DeleteResponse{},
+	}, nil
+}

--- a/integration/testdata/kotlin/database/Echo.kt
+++ b/integration/testdata/kotlin/database/Echo.kt
@@ -1,22 +1,23 @@
-package ftl.dbtest
+package ftl.echo
 
 import xyz.block.ftl.Context
 import xyz.block.ftl.Verb
 import xyz.block.ftl.Database
 
-data class DbRequest(val data: String?)
-data class DbResponse(val message: String? = "ok")
+data class InsertRequest(val data: String)
+typealias InsertResponse = Unit
 
 val db = Database("testdb")
 
-class DbTest {
+class Echo {
+
   @Verb
-  fun create(context: Context, req: DbRequest): DbResponse {
+  fun insert(context: Context, req: InsertRequest): InsertResponse {
     persistRequest(req)
-    return DbResponse()
+    return InsertResponse
   }
 
-  fun persistRequest(req: DbRequest) {
+  fun persistRequest(req: InsertRequest) {
     db.conn {
       it.prepareStatement(
         """

--- a/integration/testdata/kotlin/externalcalls/Echo.kt
+++ b/integration/testdata/kotlin/externalcalls/Echo.kt
@@ -1,0 +1,21 @@
+package ftl.echo
+
+import ftl.echo2.Echo2ModuleClient
+import xyz.block.ftl.Context
+import xyz.block.ftl.Verb
+
+data class EchoRequest(val name: String)
+data class EchoResponse(val message: String)
+
+class Echo {
+  @Verb
+  fun echo(context: Context, req: EchoRequest): EchoResponse {
+    return EchoResponse(message = "Hello, ${req.name}!")
+  }
+
+  @Verb
+  fun call(context: Context, req: EchoRequest): EchoResponse {
+    val res = context.call(Echo2ModuleClient::echo, ftl.echo2.EchoRequest(name = req.name))
+    return EchoResponse(message = res.message)
+  }
+}

--- a/integration/testdata/kotlin/httpingress/Echo.kt
+++ b/integration/testdata/kotlin/httpingress/Echo.kt
@@ -1,0 +1,97 @@
+package ftl.echo
+
+import ftl.builtin.HttpRequest
+import ftl.builtin.HttpResponse
+import kotlin.String
+import kotlin.Unit
+import xyz.block.ftl.Alias
+import xyz.block.ftl.Context
+import xyz.block.ftl.HttpIngress
+import xyz.block.ftl.Method
+import xyz.block.ftl.Verb
+
+data class GetRequest(
+  val userID: String,
+  val postID: String,
+)
+
+data class GetResponse(
+  val message: String,
+)
+
+data class PostRequest(
+  @Alias("id") val userID: String,
+  val postID: String,
+)
+
+data class PostResponse(
+  val message: String,
+)
+
+data class PutRequest(
+  val userID: String,
+  val postID: String,
+)
+
+data class PutResponse(
+  val message: String,
+)
+
+data class DeleteRequest(
+  val userID: String,
+)
+
+data class DeleteResponse(
+  val message: String,
+)
+
+class Echo {
+  @Verb
+  @HttpIngress(
+    Method.GET,
+    "/echo/users/{userID}/posts/{postID}",
+  )
+  fun `get`(context: Context, req: HttpRequest<GetRequest>): HttpResponse<GetResponse> {
+    return HttpResponse<GetResponse>(
+      status = 200,
+      headers = mapOf("Get" to arrayListOf("Header from FTL")),
+      body = GetResponse(message = "UserID: ${req.body.userID}, PostID ${req.body.postID}")
+    )
+  }
+
+  @Verb
+  @HttpIngress(
+    Method.POST,
+    "/echo/users",
+  )
+  fun post(context: Context, req: HttpRequest<PostRequest>): HttpResponse<PostResponse> {
+    return HttpResponse<PostResponse>(
+      status = 201,
+      headers = mapOf("Post" to arrayListOf("Header from FTL")),
+      body = PostResponse(message = "UserID: ${req.body.userID}, PostID ${req.body.postID}")
+    )
+  }
+
+  @Verb
+  @HttpIngress(
+    Method.PUT,
+    "/echo/users/{userID}",
+  )
+  fun put(context: Context, req: HttpRequest<PutRequest>): HttpResponse<PutResponse> {
+    return HttpResponse<PutResponse>(
+      status = 200,
+      headers = mapOf("Put" to arrayListOf("Header from FTL")),
+      body = PutResponse(message = "UserID: ${req.body.userID}, PostID ${req.body.postID}")
+    )
+  }
+
+  @Verb
+  @HttpIngress(Method.DELETE, "/echo/users/{userID}")
+  fun delete(context: Context, req: HttpRequest<DeleteRequest>): HttpResponse<DeleteResponse> {
+    return HttpResponse<DeleteResponse>(
+      status = 200,
+      headers = mapOf("Delete" to arrayListOf("Header from FTL")),
+      body = DeleteResponse(message = "UserID: ${req.body.userID}")
+    )
+  }
+}

--- a/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/Database.kt
+++ b/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/Database.kt
@@ -24,9 +24,9 @@ class Database(private val name: String) {
 
   fun <R> conn(block: (c: Connection) -> R): R {
     return try {
-      val envVar = listOf(FTL_DSN_VAR_PREFIX, moduleName, name).joinToString("_")
+      val envVar = listOf(FTL_DSN_VAR_PREFIX, moduleName.uppercase(), name.uppercase()).joinToString("_")
       val dsn = System.getenv(envVar)
-      require(dsn != null) { "$envVar environment variable not set" }
+      require(dsn != null) { "missing DSN environment variable $envVar" }
 
       DriverManager.getConnection(dsnToJdbcUrl(dsn)).use {
         block(it)

--- a/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRule.kt
+++ b/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRule.kt
@@ -42,8 +42,6 @@ import kotlin.collections.Map
 import kotlin.io.path.createDirectories
 
 data class ModuleData(val comments: List<String> = emptyList(), val decls: MutableSet<Decl> = mutableSetOf())
-
-data class blah<T>(val a: T)
 // Helpers
 private fun DataRef.compare(module: String, name: String): Boolean = this.name == name && this.module == module
 private fun DataRef.text(): String = "${this.module}.${this.name}"
@@ -455,7 +453,7 @@ class SchemaExtractor(
         return Type(
           dataRef = DataRef(
             name = refName,
-            module = fqName.extractModuleName().takeIf { it != currentModuleName } ?: "",
+            module = fqName.extractModuleName(),
             pos = position,
             typeParameters = this.arguments.map { it.type.toSchemaType(position) }.toList(),
           )

--- a/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRuleTest.kt
+++ b/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRuleTest.kt
@@ -101,6 +101,7 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
                     value_ = Type(
                       dataRef = DataRef(
                         name = "MapValue",
+                        module = "echo"
                       )
                     )
                   )
@@ -148,6 +149,7 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
                     element = Type(
                       dataRef = DataRef(
                         name = "EchoMessage",
+                        module = "echo"
                       )
                     )
                   )
@@ -169,12 +171,14 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
                 name = "EchoRequest",
                 typeParameters = listOf(
                   Type(string = xyz.block.ftl.v1.schema.String())
-                )
+                ),
+                module = "echo"
               )
             ),
             response = Type(
               dataRef = DataRef(
                 name = "EchoResponse",
+                module = "echo"
               )
             ),
             metadata = listOf(

--- a/kotlin-runtime/scaffolding/ftl-module-{{ .Name | lower }}/src/main/kotlin/ftl/{{ .Name | camel | lower }}/{{ .Name | camel }}.kt
+++ b/kotlin-runtime/scaffolding/ftl-module-{{ .Name | lower }}/src/main/kotlin/ftl/{{ .Name | camel | lower }}/{{ .Name | camel }}.kt
@@ -5,12 +5,12 @@ import xyz.block.ftl.Ingress
 import xyz.block.ftl.Method
 import xyz.block.ftl.Verb
 
-data class {{ .Name | camel }}Request(val name: String)
-data class {{ .Name | camel }}Response(val message: String)
+data class EchoRequest(val name: String? = "anonymous")
+data class EchoResponse(val message: String)
 
 class {{ .Name | camel }} {
   @Verb
-  fun echo(context: Context, req: {{ .Name | camel }}Request): {{ .Name | camel }}Response {
-    return {{ .Name | camel }}Response(message = "Hello, ${req.name}!")
+  fun echo(context: Context, req: EchoRequest): EchoResponse {
+    return EchoResponse(message = "Hello, ${req.name}!")
   }
 }

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -1,3 +1,4 @@
 #!/bin/bash
 set -euo pipefail
-go test -count 1 -v -tags integration ./integration
+testName=${1:-}
+go test -count 1 -v -tags integration -run "$testName" ./integration


### PR DESCRIPTION
refactors integration tests to execute identically across runtimes

with this change, we can also specify tests to run with the integration-test script (e.g. `integration-tests TestLifecycle` — all tests are fully encapsulated and can execute alone). providing no option will run all tests.

tests have been split into the following:

- TestLifecycle (init, deploy, call)
- TestHttpIngress (tests aliased fields and all http methods )
- TestDatabase
- TestExternalCalls (kotlin -> go call, kotlin -> kotlin call, etc. for all runtime permutations)

a couple small changes captured by the integration tests are also included in this PR:
- Database.kt converts module name and DB name to uppercase to align with the Go DB SDK
- Kotlin schema extractor includes module names for all DataRef schema objects, even those declared in the referencing module (this fixes builtin.HttpRequest/Response types for HTTP ingress in Kotlin)