### PR TITLE
chore: upgrade alecthomas/types

### DIFF
--- a/backend/common/model/deployment_name.go
+++ b/backend/common/model/deployment_name.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 )
 
 type DeploymentName string
 
-type MaybeDeploymentName types.Option[DeploymentName]
+type MaybeDeploymentName optional.Option[DeploymentName]
 
 var _ interface {
 	sql.Scanner

--- a/backend/common/model/request_name.go
+++ b/backend/common/model/request_name.go
@@ -10,13 +10,13 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 )
 
 // A RequestName represents an inbound request into the cluster.
 type RequestName string
 
-type MaybeRequestName types.Option[RequestName]
+type MaybeRequestName optional.Option[RequestName]
 
 var _ interface {
 	sql.Scanner

--- a/backend/common/rpc/headers/headers.go
+++ b/backend/common/rpc/headers/headers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 
 	"github.com/TBD54566975/ftl/backend/common/model"
 	"github.com/TBD54566975/ftl/backend/schema"
@@ -69,16 +69,16 @@ func GetCallers(header http.Header) ([]*schema.VerbRef, error) {
 // GetCaller returns the module.verb of the caller, if any.
 //
 // Will return an error if the header is malformed.
-func GetCaller(header http.Header) (types.Option[*schema.VerbRef], error) {
+func GetCaller(header http.Header) (optional.Option[*schema.VerbRef], error) {
 	headers := header.Values(VerbHeader)
 	if len(headers) == 0 {
-		return types.None[*schema.VerbRef](), nil
+		return optional.None[*schema.VerbRef](), nil
 	}
 	ref, err := schema.ParseVerbRef(headers[len(headers)-1])
 	if err != nil {
-		return types.None[*schema.VerbRef](), err
+		return optional.None[*schema.VerbRef](), err
 	}
-	return types.Some(ref), nil
+	return optional.Some(ref), nil
 }
 
 // AddCaller to an outgoing request.

--- a/backend/controller/console.go
+++ b/backend/controller/console.go
@@ -8,10 +8,9 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/alecthomas/types/optional"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
-
-	"github.com/alecthomas/types/optional"
 
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/model"

--- a/backend/controller/console.go
+++ b/backend/controller/console.go
@@ -8,9 +8,10 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/alecthomas/types"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/alecthomas/types/optional"
 
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/model"
@@ -269,13 +270,13 @@ func eventsQueryProtoToDAL(pb *pbconsole.EventsQuery) ([]dal.EventFilter, error)
 			}
 			query = append(query, dal.FilterIDRange(lowerThan, higherThan))
 		case *pbconsole.EventsQuery_Filter_Call:
-			var sourceModule types.Option[string]
+			var sourceModule optional.Option[string]
 			if filter.Call.SourceModule != nil {
-				sourceModule = types.Some(*filter.Call.SourceModule)
+				sourceModule = optional.Some(*filter.Call.SourceModule)
 			}
-			var destVerb types.Option[string]
+			var destVerb optional.Option[string]
 			if filter.Call.DestVerb != nil {
-				destVerb = types.Some(*filter.Call.DestVerb)
+				destVerb = optional.Some(*filter.Call.DestVerb)
 			}
 			query = append(query, dal.FilterCall(sourceModule, filter.Call.DestModule, destVerb))
 

--- a/backend/controller/dal/dal_test.go
+++ b/backend/controller/dal/dal_test.go
@@ -9,14 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/types/optional"
+
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/model"
 	"github.com/TBD54566975/ftl/backend/common/sha256"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
 	"github.com/TBD54566975/ftl/backend/schema"
 	ftlv1 "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1"
-	"github.com/alecthomas/assert/v2"
-	"github.com/alecthomas/types"
 )
 
 //nolint:maintidx
@@ -128,7 +129,7 @@ func TestDAL(t *testing.T) {
 		Labels:     labels,
 		Endpoint:   "http://localhost:8080",
 		State:      RunnerStateReserved,
-		Deployment: types.Some(deploymentName),
+		Deployment: optional.Some(deploymentName),
 	}
 
 	t.Run("GetDeploymentsNeedingReconciliation", func(t *testing.T) {
@@ -190,7 +191,7 @@ func TestDAL(t *testing.T) {
 			Labels:     labels,
 			Endpoint:   "http://localhost:8080",
 			State:      RunnerStateAssigned,
-			Deployment: types.Some(deploymentName),
+			Deployment: optional.Some(deploymentName),
 		})
 		assert.NoError(t, err)
 	})
@@ -209,7 +210,7 @@ func TestDAL(t *testing.T) {
 			Labels:     labels,
 			Endpoint:   "http://localhost:8080",
 			State:      RunnerStateAssigned,
-			Deployment: types.Some(deploymentName),
+			Deployment: optional.Some(deploymentName),
 		}}, runners)
 	})
 
@@ -222,7 +223,7 @@ func TestDAL(t *testing.T) {
 	callEvent := &CallEvent{
 		Time:           time.Now().Round(time.Millisecond),
 		DeploymentName: deploymentName,
-		RequestName:    types.Some(requestName),
+		RequestName:    optional.Some(requestName),
 		Request:        []byte("{}"),
 		Response:       []byte(`{"time": "now"}`),
 		DestVerb:       schema.VerbRef{Module: "time", Name: "time"},
@@ -235,7 +236,7 @@ func TestDAL(t *testing.T) {
 	logEvent := &LogEvent{
 		Time:           time.Now().Round(time.Millisecond),
 		DeploymentName: deploymentName,
-		RequestName:    types.Some(requestName),
+		RequestName:    optional.Some(requestName),
 		Level:          int32(log.Warn),
 		Attributes:     map[string]string{"attr": "value"},
 		Message:        "A log entry",
@@ -270,7 +271,7 @@ func TestDAL(t *testing.T) {
 		})
 
 		t.Run("ByCall", func(t *testing.T) {
-			events, err := dal.QueryEvents(ctx, 1000, FilterTypes(EventTypeCall), FilterCall(types.None[string](), "time", types.None[string]()))
+			events, err := dal.QueryEvents(ctx, 1000, FilterTypes(EventTypeCall), FilterCall(optional.None[string](), "time", optional.None[string]()))
 			assert.NoError(t, err)
 			assertEventsEqual(t, []Event{callEvent}, events)
 		})
@@ -299,7 +300,7 @@ func TestDAL(t *testing.T) {
 			Labels:     labels,
 			Endpoint:   "http://localhost:8080",
 			State:      RunnerStateAssigned,
-			Deployment: types.Some(model.NewDeploymentName("test")),
+			Deployment: optional.Some(model.NewDeploymentName("test")),
 		})
 		assert.Error(t, err)
 		assert.IsError(t, err, ErrNotFound)

--- a/backend/controller/deployment_logs.go
+++ b/backend/controller/deployment_logs.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 
 	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/model"
@@ -58,16 +58,16 @@ func (d *deploymentLogsSink) processLogs(ctx context.Context) {
 			}
 			deployment = dep
 
-			var errorStr types.Option[string]
+			var errorStr optional.Option[string]
 			if entry.Error != nil {
-				errorStr = types.Some(entry.Error.Error())
+				errorStr = optional.Some(entry.Error.Error())
 			}
 
-			var request types.Option[model.RequestName]
+			var request optional.Option[model.RequestName]
 			if reqStr, ok := entry.Attributes["request"]; ok {
 				_, req, err := model.ParseRequestName(reqStr)
 				if err == nil {
-					request = types.Some(req)
+					request = optional.Some(req)
 				}
 			}
 

--- a/backend/controller/sql/models.go
+++ b/backend/controller/sql/models.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/TBD54566975/ftl/backend/common/model"
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 )
 
 type ControllerState string
@@ -225,12 +225,12 @@ type Event struct {
 	ID           int64
 	TimeStamp    time.Time
 	DeploymentID int64
-	RequestID    types.Option[int64]
+	RequestID    optional.Option[int64]
 	Type         EventType
-	CustomKey1   types.Option[string]
-	CustomKey2   types.Option[string]
-	CustomKey3   types.Option[string]
-	CustomKey4   types.Option[string]
+	CustomKey1   optional.Option[string]
+	CustomKey2   optional.Option[string]
+	CustomKey3   optional.Option[string]
+	CustomKey4   optional.Option[string]
 	Payload      json.RawMessage
 }
 
@@ -263,7 +263,7 @@ type Runner struct {
 	ReservationTimeout NullTime
 	State              RunnerState
 	Endpoint           string
-	ModuleName         types.Option[string]
-	DeploymentID       types.Option[int64]
+	ModuleName         optional.Option[string]
+	DeploymentID       optional.Option[int64]
 	Labels             []byte
 }

--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/TBD54566975/ftl/backend/common/model"
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 )
 
 type Querier interface {
@@ -68,7 +68,7 @@ type Querier interface {
 	// otherwise we try to retrieve the deployments.id using the key. If
 	// there is no corresponding deployment, then the deployment ID is -1
 	// and the parent statement will fail due to a foreign key constraint.
-	UpsertRunner(ctx context.Context, arg UpsertRunnerParams) (types.Option[int64], error)
+	UpsertRunner(ctx context.Context, arg UpsertRunnerParams) (optional.Option[int64], error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/TBD54566975/ftl/backend/common/model"
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 )
 
 const associateArtefactWithDeployment = `-- name: AssociateArtefactWithDeployment :exec
@@ -228,8 +228,8 @@ type GetActiveRunnersRow struct {
 	State          RunnerState
 	Labels         []byte
 	LastSeen       time.Time
-	ModuleName     types.Option[string]
-	DeploymentName types.Option[string]
+	ModuleName     optional.Option[string]
+	DeploymentName optional.Option[string]
 }
 
 func (q *Queries) GetActiveRunners(ctx context.Context, all bool) ([]GetActiveRunnersRow, error) {
@@ -755,7 +755,7 @@ type GetProcessListRow struct {
 	DeploymentName   model.DeploymentName
 	DeploymentLabels []byte
 	RunnerKey        NullKey
-	Endpoint         types.Option[string]
+	Endpoint         optional.Option[string]
 	RunnerLabels     []byte
 }
 
@@ -796,7 +796,7 @@ WHERE r.key = $1
 type GetRouteForRunnerRow struct {
 	Endpoint       string
 	RunnerKey      Key
-	ModuleName     types.Option[string]
+	ModuleName     optional.Option[string]
 	DeploymentName model.DeploymentName
 	State          RunnerState
 }
@@ -827,7 +827,7 @@ WHERE state = 'assigned'
 type GetRoutingTableRow struct {
 	Endpoint       string
 	RunnerKey      Key
-	ModuleName     types.Option[string]
+	ModuleName     optional.Option[string]
 	DeploymentName model.DeploymentName
 }
 
@@ -877,8 +877,8 @@ type GetRunnerRow struct {
 	State          RunnerState
 	Labels         []byte
 	LastSeen       time.Time
-	ModuleName     types.Option[string]
-	DeploymentName types.Option[string]
+	ModuleName     optional.Option[string]
+	DeploymentName optional.Option[string]
 }
 
 func (q *Queries) GetRunner(ctx context.Context, key Key) (GetRunnerRow, error) {
@@ -925,8 +925,8 @@ type GetRunnersForDeploymentRow struct {
 	ReservationTimeout NullTime
 	State              RunnerState
 	Endpoint           string
-	ModuleName         types.Option[string]
-	DeploymentID       types.Option[int64]
+	ModuleName         optional.Option[string]
+	DeploymentID       optional.Option[int64]
 	Labels             []byte
 	ID_2               int64
 	CreatedAt          time.Time
@@ -1000,17 +1000,17 @@ VALUES ((SELECT id FROM deployments WHERE deployments.name = $1::TEXT),
 
 type InsertCallEventParams struct {
 	DeploymentName string
-	RequestName    types.Option[string]
+	RequestName    optional.Option[string]
 	TimeStamp      time.Time
-	SourceModule   types.Option[string]
-	SourceVerb     types.Option[string]
+	SourceModule   optional.Option[string]
+	SourceVerb     optional.Option[string]
 	DestModule     string
 	DestVerb       string
 	DurationMs     int64
 	Request        []byte
 	Response       []byte
-	Error          types.Option[string]
-	Stack          types.Option[string]
+	Error          optional.Option[string]
+	Stack          optional.Option[string]
 }
 
 func (q *Queries) InsertCallEvent(ctx context.Context, arg InsertCallEventParams) error {
@@ -1050,7 +1050,7 @@ type InsertDeploymentCreatedEventParams struct {
 	Language       string
 	ModuleName     string
 	MinReplicas    int32
-	Replaced       types.Option[string]
+	Replaced       optional.Option[string]
 }
 
 func (q *Queries) InsertDeploymentCreatedEvent(ctx context.Context, arg InsertDeploymentCreatedEventParams) error {
@@ -1107,12 +1107,12 @@ RETURNING id
 
 type InsertEventParams struct {
 	DeploymentID int64
-	RequestID    types.Option[int64]
+	RequestID    optional.Option[int64]
 	Type         EventType
-	CustomKey1   types.Option[string]
-	CustomKey2   types.Option[string]
-	CustomKey3   types.Option[string]
-	CustomKey4   types.Option[string]
+	CustomKey1   optional.Option[string]
+	CustomKey2   optional.Option[string]
+	CustomKey3   optional.Option[string]
+	CustomKey4   optional.Option[string]
 	Payload      json.RawMessage
 }
 
@@ -1150,13 +1150,13 @@ VALUES ((SELECT id FROM deployments d WHERE d.name = $1 LIMIT 1),
 
 type InsertLogEventParams struct {
 	DeploymentName model.DeploymentName
-	RequestName    types.Option[string]
+	RequestName    optional.Option[string]
 	TimeStamp      time.Time
 	Level          int32
 	Message        string
 	Attributes     []byte
-	Error          types.Option[string]
-	Stack          types.Option[string]
+	Error          optional.Option[string]
+	Stack          optional.Option[string]
 }
 
 func (q *Queries) InsertLogEvent(ctx context.Context, arg InsertLogEventParams) error {
@@ -1337,7 +1337,7 @@ type UpsertRunnerParams struct {
 	Endpoint       string
 	State          RunnerState
 	Labels         []byte
-	DeploymentName types.Option[string]
+	DeploymentName optional.Option[string]
 }
 
 // Upsert a runner and return the deployment ID that it is assigned to, if any.
@@ -1345,7 +1345,7 @@ type UpsertRunnerParams struct {
 // otherwise we try to retrieve the deployments.id using the key. If
 // there is no corresponding deployment, then the deployment ID is -1
 // and the parent statement will fail due to a foreign key constraint.
-func (q *Queries) UpsertRunner(ctx context.Context, arg UpsertRunnerParams) (types.Option[int64], error) {
+func (q *Queries) UpsertRunner(ctx context.Context, arg UpsertRunnerParams) (optional.Option[int64], error) {
 	row := q.db.QueryRow(ctx, upsertRunner,
 		arg.Key,
 		arg.Endpoint,
@@ -1353,7 +1353,7 @@ func (q *Queries) UpsertRunner(ctx context.Context, arg UpsertRunnerParams) (typ
 		arg.Labels,
 		arg.DeploymentName,
 	)
-	var deployment_id types.Option[int64]
+	var deployment_id optional.Option[int64]
 	err := row.Scan(&deployment_id)
 	return deployment_id, err
 }

--- a/backend/controller/sql/types.go
+++ b/backend/controller/sql/types.go
@@ -5,22 +5,22 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 	"github.com/google/uuid"
 	"github.com/oklog/ulid/v2"
 )
 
-type NullKey = types.Option[Key]
+type NullKey = optional.Option[Key]
 
-// FromOption converts a types.Option[~ulid.ULID] to a NullKey.
-func FromOption[T ~[16]byte](o types.Option[T]) NullKey {
+// FromOption converts a optional.Option[~ulid.ULID] to a NullKey.
+func FromOption[T ~[16]byte](o optional.Option[T]) NullKey {
 	if v, ok := o.Get(); ok {
 		return SomeKey(Key(v))
 	}
 	return NoneKey()
 }
-func SomeKey(key Key) NullKey { return types.Some(key) }
-func NoneKey() NullKey        { return types.None[Key]() }
+func SomeKey(key Key) NullKey { return optional.Some(key) }
+func NoneKey() NullKey        { return optional.None[Key]() }
 
 // Key is a ULID that can be used as a column in a database.
 type Key ulid.ULID
@@ -57,5 +57,5 @@ func (u *Key) UnmarshalText(text []byte) error {
 	return nil
 }
 
-type NullTime = types.Option[time.Time]
-type NullDuration = types.Option[time.Duration]
+type NullTime = optional.Option[time.Time]
+type NullDuration = optional.Option[time.Duration]

--- a/backend/schema/schema.go
+++ b/backend/schema/schema.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 	"google.golang.org/protobuf/proto"
 
 	schemapb "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema"
@@ -71,13 +71,13 @@ func (s *Schema) ResolveVerbRef(ref *VerbRef) *Verb {
 }
 
 // Module returns the named module if it exists.
-func (s *Schema) Module(name string) types.Option[*Module] {
+func (s *Schema) Module(name string) optional.Option[*Module] {
 	for _, module := range s.Modules {
 		if module.Name == name {
-			return types.Some(module)
+			return optional.Some(module)
 		}
 	}
-	return types.None[*Module]()
+	return optional.None[*Module]()
 }
 
 func (s *Schema) DataMap() map[Ref]*Data {

--- a/backend/schema/verb.go
+++ b/backend/schema/verb.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alecthomas/types"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/alecthomas/types/optional"
 
 	schemapb "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema"
 )
@@ -62,13 +63,13 @@ func (v *Verb) AddCall(verb *VerbRef) {
 	v.Metadata = append(v.Metadata, &MetadataCalls{Calls: []*VerbRef{verb}})
 }
 
-func (v *Verb) GetMetadataIngress() types.Option[*MetadataIngress] {
+func (v *Verb) GetMetadataIngress() optional.Option[*MetadataIngress] {
 	for _, m := range v.Metadata {
 		if m, ok := m.(*MetadataIngress); ok {
-			return types.Some(m)
+			return optional.Some(m)
 		}
 	}
-	return types.None[*MetadataIngress]()
+	return optional.None[*MetadataIngress]()
 }
 
 func (v *Verb) ToProto() proto.Message {

--- a/backend/schema/verb.go
+++ b/backend/schema/verb.go
@@ -4,9 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/alecthomas/types/optional"
+	"google.golang.org/protobuf/proto"
 
 	schemapb "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/schema"
 )

--- a/examples/online-boutique/services/checkout/go.mod
+++ b/examples/online-boutique/services/checkout/go.mod
@@ -18,7 +18,7 @@ require (
 	connectrpc.com/otelconnect v0.7.0 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
-	github.com/alecthomas/types v0.9.0 // indirect
+	github.com/alecthomas/types v0.10.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/examples/online-boutique/services/checkout/go.sum
+++ b/examples/online-boutique/services/checkout/go.sum
@@ -12,8 +12,8 @@ github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6i
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.3.0 h1:NeYzUPfjjlqHY4KtzgKJiWd6sVq2eNUPTi34PiFGjY8=
 github.com/alecthomas/repr v0.3.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/alecthomas/types v0.9.0 h1:g/P/fNElr7Ot1tWxSEms/I2gnRemxAqGNeetW6HOlO4=
-github.com/alecthomas/types v0.9.0/go.mod h1:t7PnU03TVweFpbPVKaeLtFykjJD8rqiBJ7gfkp6UvLQ=
+github.com/alecthomas/types v0.10.0 h1:u9dDe+EFuCHLiBw5QsKAYXGEbkmrOW3se0RPEuvJVT8=
+github.com/alecthomas/types v0.10.0/go.mod h1:fIOGnLeeUJXe1AAVofQmMaEMWLxY9bK4QxTLGIo30PA=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/bool64/dev v0.2.31 h1:OS57EqYaYe2M/2bw9uhDCIFiZZwywKFS/4qMLN6JUmQ=

--- a/examples/online-boutique/services/recommendation/go.mod
+++ b/examples/online-boutique/services/recommendation/go.mod
@@ -14,7 +14,7 @@ require (
 	connectrpc.com/otelconnect v0.7.0 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
-	github.com/alecthomas/types v0.9.0 // indirect
+	github.com/alecthomas/types v0.10.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect

--- a/examples/online-boutique/services/recommendation/go.sum
+++ b/examples/online-boutique/services/recommendation/go.sum
@@ -12,8 +12,8 @@ github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6i
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.3.0 h1:NeYzUPfjjlqHY4KtzgKJiWd6sVq2eNUPTi34PiFGjY8=
 github.com/alecthomas/repr v0.3.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/alecthomas/types v0.9.0 h1:g/P/fNElr7Ot1tWxSEms/I2gnRemxAqGNeetW6HOlO4=
-github.com/alecthomas/types v0.9.0/go.mod h1:t7PnU03TVweFpbPVKaeLtFykjJD8rqiBJ7gfkp6UvLQ=
+github.com/alecthomas/types v0.10.0 h1:u9dDe+EFuCHLiBw5QsKAYXGEbkmrOW3se0RPEuvJVT8=
+github.com/alecthomas/types v0.10.0/go.mod h1:fIOGnLeeUJXe1AAVofQmMaEMWLxY9bK4QxTLGIo30PA=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/bool64/dev v0.2.31 h1:OS57EqYaYe2M/2bw9uhDCIFiZZwywKFS/4qMLN6JUmQ=

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/alecthomas/kong v0.8.1
 	github.com/alecthomas/kong-toml v0.1.0
 	github.com/alecthomas/participle/v2 v2.1.1
-	github.com/alecthomas/types v0.9.0
+	github.com/alecthomas/types v0.10.0
 	github.com/amacneil/dbmate/v2 v2.10.0
 	github.com/beevik/etree v1.3.0
 	github.com/bmatcuk/doublestar/v4 v4.6.1

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6i
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.3.0 h1:NeYzUPfjjlqHY4KtzgKJiWd6sVq2eNUPTi34PiFGjY8=
 github.com/alecthomas/repr v0.3.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/alecthomas/types v0.9.0 h1:g/P/fNElr7Ot1tWxSEms/I2gnRemxAqGNeetW6HOlO4=
-github.com/alecthomas/types v0.9.0/go.mod h1:t7PnU03TVweFpbPVKaeLtFykjJD8rqiBJ7gfkp6UvLQ=
+github.com/alecthomas/types v0.10.0 h1:u9dDe+EFuCHLiBw5QsKAYXGEbkmrOW3se0RPEuvJVT8=
+github.com/alecthomas/types v0.10.0/go.mod h1:fIOGnLeeUJXe1AAVofQmMaEMWLxY9bK4QxTLGIo30PA=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/amacneil/dbmate/v2 v2.10.0 h1:bGp1sL/tijenf/BhQBw/t0LmiYvBTi+LXn6uBiHwLII=

--- a/protos/xyz/block/ftl/v1/mixins.go
+++ b/protos/xyz/block/ftl/v1/mixins.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/alecthomas/types"
+	"github.com/alecthomas/types/optional"
 
 	model "github.com/TBD54566975/ftl/backend/common/model"
 )
@@ -32,13 +32,13 @@ func (m *Metadata) Add(key, value string) {
 	m.Values = append(m.Values, &Metadata_Pair{Key: key, Value: value})
 }
 
-func (m *Metadata) Get(key string) types.Option[string] {
+func (m *Metadata) Get(key string) optional.Option[string] {
 	for _, pair := range m.Values {
 		if strings.EqualFold(pair.Key, key) {
-			return types.Some(pair.Value)
+			return optional.Some(pair.Value)
 		}
 	}
-	return types.None[string]()
+	return optional.None[string]()
 }
 
 func (m *Metadata) GetAll(key string) (out []string) {
@@ -60,13 +60,13 @@ func (m *Metadata) Delete(key string) {
 	m.Values = out
 }
 
-func (r *RegisterRunnerRequest) DeploymentAsOptional() (types.Option[model.DeploymentName], error) {
+func (r *RegisterRunnerRequest) DeploymentAsOptional() (optional.Option[model.DeploymentName], error) {
 	if r.Deployment == nil {
-		return types.None[model.DeploymentName](), nil
+		return optional.None[model.DeploymentName](), nil
 	}
 	key, err := model.ParseDeploymentName(*r.Deployment)
 	if err != nil {
-		return types.None[model.DeploymentName](), fmt.Errorf("%s: %w", "invalid deployment key", err)
+		return optional.None[model.DeploymentName](), fmt.Errorf("%s: %w", "invalid deployment key", err)
 	}
-	return types.Some(key), nil
+	return optional.Some(key), nil
 }

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -24,42 +24,42 @@ sql:
           - db_type: "timestamptz"
             nullable: true
             go_type:
-              type:  "NullTime"
+              type: "NullTime"
           - db_type: "uuid"
             go_type:
-              type:  "Key"
+              type: "Key"
           - db_type: "uuid"
             nullable: true
             go_type:
-              type:  "NullKey"
+              type: "NullKey"
           - db_type: "pg_catalog.varchar"
             nullable: true
-            go_type: "github.com/alecthomas/types.Option[string]"
+            go_type: "github.com/alecthomas/types/optional.Option[string]"
           - db_type: "text"
             go_type: "string"
           - db_type: "text"
             nullable: true
-            go_type: "github.com/alecthomas/types.Option[string]"
+            go_type: "github.com/alecthomas/types/optional.Option[string]"
           - db_type: "pg_catalog.int8"
             nullable: true
-            go_type: "github.com/alecthomas/types.Option[int64]"
+            go_type: "github.com/alecthomas/types/optional.Option[int64]"
           - db_type: "bigint"
             nullable: true
-            go_type: "github.com/alecthomas/types.Option[int64]"
+            go_type: "github.com/alecthomas/types/optional.Option[int64]"
           - db_type: "int"
             nullable: true
-            go_type: "github.com/alecthomas/types.Option[int32]"
+            go_type: "github.com/alecthomas/types/optional.Option[int32]"
           - db_type: "bool"
             nullable: true
-            go_type: "github.com/alecthomas/types.Option[bool]"
+            go_type: "github.com/alecthomas/types/optional.Option[bool]"
           # Can't use until https://github.com/sqlc-dev/sqlc/issues/2632 is fixed, if it ever is...
-#          - column: "ingress_requests.key"
-#            go_type: "github.com/TBD54566975/ftl/backend/common/model.RequestName"
-#          - column: "ingress_requests.key"
-#            nullable: true
-#            go_type: "github.com/TBD54566975/ftl/backend/common/model.NullRequestName"
-#          - column: "runners.key"
-#            go_type: "github.com/TBD54566975/ftl/backend/common/model.RunnerKey"
+          #          - column: "ingress_requests.key"
+          #            go_type: "github.com/TBD54566975/ftl/backend/common/model.RequestName"
+          #          - column: "ingress_requests.key"
+          #            nullable: true
+          #            go_type: "github.com/TBD54566975/ftl/backend/common/model.NullRequestName"
+          #          - column: "runners.key"
+          #            go_type: "github.com/TBD54566975/ftl/backend/common/model.RunnerKey"
           - column: "controller.key"
             go_type: "github.com/TBD54566975/ftl/backend/common/model.ControllerKey"
           - column: "deployments.name"
@@ -71,9 +71,9 @@ sql:
       # - postgresql-query-too-costly
       - postgresql-no-seq-scan
 rules:
-- name: postgresql-query-too-costly
-  message: "Query cost estimate is too high"
-  rule: "postgresql.explain.plan.total_cost > 500.0"
-- name: postgresql-no-seq-scan
-  message: "Query plan results in a sequential scan"
-  rule: "postgresql.explain.plan.node_type == 'Seq Scan'"
+  - name: postgresql-query-too-costly
+    message: "Query cost estimate is too high"
+    rule: "postgresql.explain.plan.total_cost > 500.0"
+  - name: postgresql-no-seq-scan
+    message: "Query plan results in a sequential scan"
+    rule: "postgresql.explain.plan.node_type == 'Seq Scan'"


### PR DESCRIPTION
The types were moved into separate packages, so this upgrade couldn't be automated by Renovate.