### PR TITLE
feat: reduce logging levels

### DIFF
--- a/authn/authn.go
+++ b/authn/authn.go
@@ -31,7 +31,7 @@ func GetAuthenticationHeaders(ctx context.Context, endpoint *url.URL, authentica
 	logger := log.FromContext(ctx).Scope(endpoint.Hostname())
 
 	// Next, try the authenticator.
-	logger.Debugf("Trying authenticator")
+	logger.Tracef("Trying authenticator")
 	authenticator, ok := authenticators[endpoint.Hostname()]
 	if !ok {
 		logger.Tracef("No authenticator found for %s in %s", endpoint, authenticators)
@@ -51,13 +51,13 @@ func GetAuthenticationHeaders(ctx context.Context, endpoint *url.URL, authentica
 
 	// First, check if we have credentials in the keyring and that they work.
 	keyringKey := "ftl+" + endpoint.String()
-	logger.Debugf("Trying keyring key %s", keyringKey)
+	logger.Tracef("Trying keyring key %s", keyringKey)
 	creds, err := keyring.Get(keyringKey, usr.Name)
 	if errors.Is(err, keyring.ErrNotFound) {
 		logger.Tracef("No credentials found in keyring")
 	} else if err != nil {
 		if !strings.Contains(err.Error(), `exec: "dbus-launch": executable file not found in $PATH`) {
-			logger.Debugf("Failed to get credentials from keyring: %s", err)
+			logger.Tracef("Failed to get credentials from keyring: %s", err)
 		}
 	} else {
 		logger.Tracef("Credentials found in keyring: %s", creds)
@@ -84,7 +84,7 @@ func GetAuthenticationHeaders(ctx context.Context, endpoint *url.URL, authentica
 		return nil, nil
 	}
 
-	logger.Debugf("Authenticator %s succeeded", authenticator)
+	logger.Tracef("Authenticator %s succeeded", authenticator)
 	w := &strings.Builder{}
 	for name, values := range headers {
 		for _, value := range values {
@@ -93,7 +93,7 @@ func GetAuthenticationHeaders(ctx context.Context, endpoint *url.URL, authentica
 	}
 	err = keyring.Set(keyringKey, usr.Name, w.String())
 	if err != nil {
-		logger.Debugf("Failed to save credentials to keyring: %s", err)
+		logger.Tracef("Failed to save credentials to keyring: %s", err)
 	}
 	return headers, nil
 }
@@ -127,7 +127,7 @@ func checkAuth(ctx context.Context, logger *log.Logger, endpoint *url.URL, creds
 	if err != nil {
 		return nil, err
 	}
-	logger.Debugf("Authentication probe: %s %s", req.Method, req.URL)
+	logger.Tracef("Authentication probe: %s %s", req.Method, req.URL)
 	for header, values := range headers {
 		for _, value := range values {
 			req.Header.Add(header, value)
@@ -141,12 +141,12 @@ func checkAuth(ctx context.Context, logger *log.Logger, endpoint *url.URL, creds
 	defer resp.Body.Close() //nolint:gosec
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		logger.Debugf("Endpoint returned %d for authenticated request", resp.StatusCode)
-		logger.Debugf("Response headers: %s", resp.Header)
-		logger.Debugf("Response body: %s", body)
+		logger.Tracef("Endpoint returned %d for authenticated request", resp.StatusCode)
+		logger.Tracef("Response headers: %s", resp.Header)
+		logger.Tracef("Response body: %s", body)
 		return nil, nil
 	}
-	logger.Debugf("Successfully authenticated with %s", headers)
+	logger.Tracef("Successfully authenticated with %s", headers)
 	return headers, nil
 }
 

--- a/backend/common/download/download.go
+++ b/backend/common/download/download.go
@@ -39,7 +39,7 @@ func Artefacts(ctx context.Context, client ftlv1connect.ControllerServiceClient,
 			if !filepath.IsLocal(artefact.Path) {
 				return fmt.Errorf("path %q is not local", artefact.Path)
 			}
-			logger.Infof("Downloading %s", filepath.Join(dest, artefact.Path))
+			logger.Debugf("Downloading %s", filepath.Join(dest, artefact.Path))
 			err = os.MkdirAll(filepath.Join(dest, filepath.Dir(artefact.Path)), 0700)
 			if err != nil {
 				return err
@@ -63,6 +63,6 @@ func Artefacts(ctx context.Context, client ftlv1connect.ControllerServiceClient,
 	if w != nil {
 		w.Close()
 	}
-	logger.Infof("Downloaded %d artefacts in %s", count, time.Since(start))
+	logger.Debugf("Downloaded %d artefacts in %s", count, time.Since(start))
 	return stream.Err()
 }

--- a/backend/common/exec/circularbuffer.go
+++ b/backend/common/exec/circularbuffer.go
@@ -1,0 +1,118 @@
+package exec
+
+import (
+	"bufio"
+	"bytes"
+	"container/ring"
+	"context"
+	"fmt"
+	"io"
+	"runtime"
+	"sync"
+
+	"github.com/TBD54566975/ftl/backend/common/log"
+)
+
+type CircularBuffer struct {
+	r    *ring.Ring
+	size int
+	mu   sync.Mutex
+	cap  int
+}
+
+func NewCircularBuffer(capacity int) *CircularBuffer {
+	return &CircularBuffer{
+		r:   ring.New(capacity),
+		cap: capacity,
+	}
+}
+
+// Write accepts a string and stores it in the buffer.
+// It expects entire lines and stores each line as a separate entry in the ring buffer.
+func (cb *CircularBuffer) Write(p string) error {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.r.Value = p
+	cb.r = cb.r.Next()
+
+	if cb.size < cb.cap {
+		cb.size++
+	}
+
+	return nil
+}
+
+func (cb *CircularBuffer) Bytes() []byte {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	if cb.size == 0 {
+		fmt.Println("Buffer is empty.")
+		return []byte{}
+	}
+
+	var buf bytes.Buffer
+	start := cb.r.Move(-cb.size) // Correctly calculate the starting position
+
+	for i := 0; i < cb.size; i++ {
+		if str, ok := start.Value.(string); ok {
+			buf.WriteString(str)
+		} else {
+			fmt.Println("Unexpected type or nil found in buffer")
+		}
+		start = start.Next()
+	}
+
+	return buf.Bytes()
+}
+
+func (cb *CircularBuffer) WriterAt(ctx context.Context, level log.Level) *io.PipeWriter {
+	// Copied from logger.go which is based on logrus
+	// Based on MIT licensed Logrus https://github.com/sirupsen/logrus/blob/bdc0db8ead3853c56b7cd1ac2ba4e11b47d7da6b/writer.go#L27
+	logger := log.FromContext(ctx)
+	reader, writer := io.Pipe()
+	var printFunc func(format string, args ...interface{})
+
+	switch level {
+	case log.Trace:
+		printFunc = logger.Tracef
+	case log.Debug:
+		printFunc = logger.Debugf
+	case log.Info:
+		printFunc = logger.Infof
+	case log.Warn:
+		printFunc = logger.Warnf
+	case log.Error:
+		printFunc = func(format string, args ...interface{}) {
+			logger.Errorf(nil, format, args...)
+		}
+	default:
+		panic(level)
+	}
+
+	go cb.writerScanner(reader, printFunc)
+	runtime.SetFinalizer(writer, writerFinalizer)
+
+	return writer
+}
+
+func (cb *CircularBuffer) writerScanner(reader *io.PipeReader, printFunc func(format string, args ...interface{})) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		text := scanner.Text()
+		printFunc(text)
+		err := cb.Write(text + "\n")
+		if err != nil {
+			fmt.Println("Error writing to buffer")
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println("Error reading from pipe:", err)
+	}
+	reader.Close()
+}
+
+func writerFinalizer(writer *io.PipeWriter) {
+	writer.Close()
+}

--- a/backend/common/observability/client.go
+++ b/backend/common/observability/client.go
@@ -40,7 +40,7 @@ func Init(ctx context.Context, serviceName, serviceVersion string, config Config
 		return nil
 	}
 
-	logger.Infof("OTEL is enabled, exporting to %s", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+	logger.Debugf("OTEL is enabled, exporting to %s", os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
 
 	otelLogger := NewOtelLogger(logger, config.LogLevel)
 	otel.SetLogger(otelLogger)

--- a/backend/common/plugin/serve.go
+++ b/backend/common/plugin/serve.go
@@ -119,14 +119,14 @@ func Start[Impl any, Iface any, Config any](
 	logger = logger.Scope(name)
 	ctx = log.ContextWithLogger(ctx, logger)
 
-	logger.Debugf("Starting on %s", cli.Bind)
+	logger.Tracef("Starting on %s", cli.Bind)
 
 	// Signal handling.
 	sigch := make(chan os.Signal, 1)
 	signal.Notify(sigch, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigch
-		logger.Infof("Terminated by signal %s", sig)
+		logger.Debugf("Terminated by signal %s", sig)
 		cancel()
 		_ = syscall.Kill(-syscall.Getpid(), sig.(syscall.Signal)) //nolint:forcetypeassert
 		os.Exit(0)

--- a/backend/common/plugin/spawn.go
+++ b/backend/common/plugin/spawn.go
@@ -121,7 +121,7 @@ func Spawn[Client PingableClient](
 
 	// Start the plugin process.
 	pluginEndpoint := &url.URL{Scheme: "http", Host: addr.String()}
-	logger.Debugf("Spawning plugin on %s", pluginEndpoint)
+	logger.Tracef("Spawning plugin on %s", pluginEndpoint)
 	cmd := exec.Command(ctx, defaultLevel, dir, exe)
 
 	// Send the plugin's stderr to the logger.
@@ -142,7 +142,7 @@ func Spawn[Client PingableClient](
 	go func() { cancelWithCause(cmd.Wait()) }()
 
 	go func() {
-		err := log.JSONStreamer(pipe, logger, log.Info)
+		err := log.JSONStreamer(pipe, logger, log.Debug)
 		if err != nil {
 			logger.Errorf(err, "Error streaming plugin logs.")
 		}
@@ -196,7 +196,7 @@ func Spawn[Client PingableClient](
 		makeClient(pluginEndpoint.String())
 	}
 
-	logger.Infof("Online")
+	logger.Debugf("Online")
 	plugin = &Plugin[Client]{Cmd: cmd, Endpoint: pluginEndpoint, Client: client}
 	return plugin, cmdCtx, nil
 }

--- a/backend/common/rpc/rpc.go
+++ b/backend/common/rpc/rpc.go
@@ -154,7 +154,7 @@ func RetryStreamingClientStream[Req, Resp any](
 				break
 			}
 			if errored {
-				logger.Infof("Stream recovered")
+				logger.Debugf("Stream recovered")
 				errored = false
 			}
 			select {

--- a/backend/controller/dal/dal.go
+++ b/backend/controller/dal/dal.go
@@ -414,7 +414,7 @@ func (d *DAL) CreateDeployment(ctx context.Context, language string, moduleSchem
 	if err != nil {
 		return "", err
 	} else if existingDeployment != "" {
-		logger.Debugf("Returning existing deployment %s", existingDeployment)
+		logger.Tracef("Returning existing deployment %s", existingDeployment)
 		return existingDeployment, nil
 	}
 

--- a/backend/controller/dal/notify.go
+++ b/backend/controller/dal/notify.go
@@ -53,7 +53,7 @@ type event struct {
 func (d *DAL) runListener(ctx context.Context, conn *pgx.Conn) {
 	logger := log.FromContext(ctx)
 
-	logger.Infof("Starting DB listener")
+	logger.Debugf("Starting DB listener")
 
 	// Wait for the notification channel to be ready.
 	retry := backoff.Backoff{}
@@ -70,10 +70,10 @@ func (d *DAL) runListener(ctx context.Context, conn *pgx.Conn) {
 	// Main loop for listening to notifications.
 	for {
 		delay := time.Millisecond * 100
-		logger.Debugf("Waiting for notification")
+		logger.Tracef("Waiting for notification")
 		notification, err := waitForNotification(ctx, conn)
 		if err == nil {
-			logger.Debugf("Publishing notification: %s", notification)
+			logger.Tracef("Publishing notification: %s", notification)
 			err = d.publishNotification(ctx, notification, logger)
 		}
 		if err != nil {
@@ -111,7 +111,7 @@ func (d *DAL) publishNotification(ctx context.Context, notification event, logge
 		if err != nil {
 			return err
 		}
-		logger.Debugf("Deployment notification: %s", deployment)
+		logger.Tracef("Deployment notification: %s", deployment)
 		d.DeploymentChanges.Publish(deployment)
 
 	default:

--- a/backend/controller/scaling/localscaling/devel.go
+++ b/backend/controller/scaling/localscaling/devel.go
@@ -16,7 +16,7 @@ var templateDirOnce sync.Once
 
 func templateDir(ctx context.Context) string {
 	templateDirOnce.Do(func() {
-		cmd := exec.Command(ctx, log.Info, internal.FTLSourceRoot(), "bit", "build/template/ftl/jars/ftl-runtime.jar")
+		cmd := exec.Command(ctx, log.Debug, internal.FTLSourceRoot(), "bit", "build/template/ftl/jars/ftl-runtime.jar")
 		err := cmd.Run()
 		if err != nil {
 			panic(err)

--- a/backend/controller/scaling/localscaling/local_scaling.go
+++ b/backend/controller/scaling/localscaling/local_scaling.go
@@ -71,7 +71,7 @@ func (l *LocalScaling) SetReplicas(ctx context.Context, replicas int, idleRunner
 		return nil
 	}
 
-	logger.Infof("Adding %d replicas", replicasToAdd)
+	logger.Debugf("Adding %d replicas", replicasToAdd)
 	for i := 0; i < replicasToAdd; i++ {
 		i := i
 
@@ -105,7 +105,7 @@ func (l *LocalScaling) SetReplicas(ctx context.Context, replicas int, idleRunner
 		l.runners[config.Key] = cancel
 
 		go func() {
-			logger.Infof("Starting runner: %s", config.Key)
+			logger.Debugf("Starting runner: %s", config.Key)
 			err := runner.Start(runnerCtx, config)
 			if err != nil && !errors.Is(err, context.Canceled) {
 				logger.Errorf(err, "Runner failed: %s", err)
@@ -118,7 +118,7 @@ func (l *LocalScaling) SetReplicas(ctx context.Context, replicas int, idleRunner
 
 func (l *LocalScaling) remove(ctx context.Context, runner model.RunnerKey) error {
 	log := log.FromContext(ctx)
-	log.Infof("Removing runner: %s", runner)
+	log.Debugf("Removing runner: %s", runner)
 
 	cancel, ok := l.runners[runner]
 	if !ok {

--- a/backend/controller/scheduledtask/scheduledtask_test.go
+++ b/backend/controller/scheduledtask/scheduledtask_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestCron(t *testing.T) {
 	t.Parallel()
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{Level: log.Info}))
+	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{Level: log.Debug}))
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -61,14 +61,14 @@ func Start(ctx context.Context, config Config) error {
 	ctx = rpc.ContextWithClient(ctx, client)
 
 	logger := log.FromContext(ctx).Attrs(map[string]string{"runner": config.Key.String()})
-	logger.Infof("Starting FTL Runner")
-	logger.Infof("Deployment directory: %s", config.DeploymentDir)
+	logger.Debugf("Starting FTL Runner")
+	logger.Debugf("Deployment directory: %s", config.DeploymentDir)
 	err = os.MkdirAll(config.DeploymentDir, 0700)
 	if err != nil {
 		return fmt.Errorf("%s: %w", "failed to create deployment directory", err)
 	}
-	logger.Infof("Using FTL endpoint: %s", config.ControllerEndpoint)
-	logger.Infof("Listening on %s", config.Bind)
+	logger.Debugf("Using FTL endpoint: %s", config.ControllerEndpoint)
+	logger.Debugf("Listening on %s", config.Bind)
 
 	controllerClient := rpc.Dial(ftlv1connect.NewControllerServiceClient, config.ControllerEndpoint.String(), log.Error)
 
@@ -211,7 +211,7 @@ func (s *Service) Deploy(ctx context.Context, req *connect.Request[ftlv1.DeployR
 	verbCtx := log.ContextWithLogger(ctx, deploymentLogger.Attrs(map[string]string{"module": module.Name}))
 	deployment, cmdCtx, err := plugin.Spawn(
 		unstoppable.Context(verbCtx),
-		log.Info,
+		log.FromContext(ctx).GetLevel(),
 		gdResp.Msg.Schema.Name,
 		deploymentDir,
 		"./main",

--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/TBD54566975/ftl/backend/common/log"
 	"github.com/TBD54566975/ftl/backend/common/moduleconfig"
 	"github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/ftlv1connect"
 )
@@ -13,20 +15,35 @@ type buildCmd struct {
 }
 
 func (b *buildCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
+	logger := log.FromContext(ctx)
+
+	startTime := time.Now()
 	// Load the TOML file.
+	var err error
 	config, err := moduleconfig.LoadConfig(b.ModuleDir)
 	if err != nil {
 		return err
 	}
 
+	logger.Infof("Building %s module '%s'", config.Language, config.Module)
+
 	switch config.Language {
 	case "kotlin":
-		return b.buildKotlin(ctx, config)
+		err = b.buildKotlin(ctx, config)
 
 	case "go":
-		return b.buildGo(ctx, config, client)
+		err = b.buildGo(ctx, client)
 
 	default:
 		return fmt.Errorf("unable to build, unknown language %q", config.Language)
 	}
+
+	if err != nil {
+		return err
+	}
+
+	duration := time.Since(startTime)
+	formattedDuration := fmt.Sprintf("%.2fs", duration.Seconds())
+	logger.Infof("Successfully built module '%s' in %s", config.Module, formattedDuration)
+	return nil
 }

--- a/cmd/ftl/cmd_build_go.go
+++ b/cmd/ftl/cmd_build_go.go
@@ -6,17 +6,13 @@ import (
 
 	"connectrpc.com/connect"
 
-	"github.com/TBD54566975/ftl/backend/common/log"
-	"github.com/TBD54566975/ftl/backend/common/moduleconfig"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/go-runtime/compile"
 	ftlv1 "github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/protos/xyz/block/ftl/v1/ftlv1connect"
 )
 
-func (b *buildCmd) buildGo(ctx context.Context, config moduleconfig.ModuleConfig, client ftlv1connect.ControllerServiceClient) error {
-	logger := log.FromContext(ctx)
-	logger.Infof("Building Go module '%s'", config.Module)
+func (b *buildCmd) buildGo(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
 	resp, err := client.GetSchema(ctx, connect.NewRequest(&ftlv1.GetSchemaRequest{}))
 	if err != nil {
 		return err
@@ -28,5 +24,6 @@ func (b *buildCmd) buildGo(ctx context.Context, config moduleconfig.ModuleConfig
 	if err := compile.Build(ctx, b.ModuleDir, sch); err != nil {
 		return fmt.Errorf("failed to build module: %w", err)
 	}
+
 	return nil
 }

--- a/cmd/ftl/cmd_build_kotlin.go
+++ b/cmd/ftl/cmd_build_kotlin.go
@@ -17,16 +17,14 @@ import (
 func (b *buildCmd) buildKotlin(ctx context.Context, config moduleconfig.ModuleConfig) error {
 	logger := log.FromContext(ctx)
 
-	logger.Infof("Building kotlin module '%s'", config.Module)
-
 	if err := setPomProperties(logger, filepath.Join(b.ModuleDir, "..")); err != nil {
 		return fmt.Errorf("unable to update ftl.version in %s: %w", b.ModuleDir, err)
 	}
 
-	logger.Infof("Using build command '%s'", config.Build)
-	err := exec.Command(ctx, logger.GetLevel(), b.ModuleDir, "bash", "-c", config.Build).Run()
+	logger.Debugf("Using build command '%s'", config.Build)
+	err := exec.Command(ctx, log.Debug, b.ModuleDir, "bash", "-c", config.Build).RunBuffered(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to build module: %w", err)
 	}
 
 	return nil
@@ -45,7 +43,7 @@ func setPomProperties(logger *log.Logger, baseDir string) error {
 
 	pomFile := filepath.Clean(filepath.Join(baseDir, "pom.xml"))
 
-	logger.Infof("Setting ftl.version in %s to %s", pomFile, ftlVersion)
+	logger.Debugf("Setting ftl.version in %s to %s", pomFile, ftlVersion)
 
 	tree := etree.NewDocument()
 	if err := tree.ReadFromFile(pomFile); err != nil {

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -98,7 +98,7 @@ func (m *moduleMap) RebuildDependentModules(ctx context.Context, sch *schema.Mod
 
 func (d *devCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
 	logger := log.FromContext(ctx)
-	logger.Infof("Watching %s for FTL modules", d.BaseDir)
+	logger.Debugf("Watching %s for FTL modules", d.BaseDir)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -112,7 +112,7 @@ func (d *devCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 	})
 
 	for {
-		logger.Debugf("Scanning %s for FTL module changes", d.BaseDir)
+		logger.Tracef("Scanning %s for FTL module changes", d.BaseDir)
 		delay := d.Watch
 
 		tomls, err := d.getTomls(ctx)

--- a/cmd/ftl/cmd_init.go
+++ b/cmd/ftl/cmd_init.go
@@ -43,15 +43,16 @@ func (i initGoCmd) Run(ctx context.Context, parent *initCmd) error {
 		return fmt.Errorf("module name %q is invalid", i.Name)
 	}
 	logger := log.FromContext(ctx)
-	logger.Infof("Initializing FTL Go module %s in %s", i.Name, i.Dir)
+	logger.Debugf("Initializing FTL Go module %s in %s", i.Name, i.Dir)
 	if err := scaffold(parent.Hermit, goruntime.Files(), i.Dir, i, scaffolder.Exclude("^go.mod$")); err != nil {
 		return err
 	}
 	if err := updateGitIgnore(ctx, i.Dir); err != nil {
 		return err
 	}
-	logger.Infof("Running go mod tidy")
-	return exec.Command(ctx, log.Debug, filepath.Join(i.Dir, i.Name), "go", "mod", "tidy").Run()
+	logger.Debugf("Running go mod tidy")
+
+	return exec.Command(ctx, log.Debug, filepath.Join(i.Dir, i.Name), "go", "mod", "tidy").RunBuffered(ctx)
 }
 
 type initKotlinCmd struct {

--- a/cmd/ftl/cmd_schema_generate.go
+++ b/cmd/ftl/cmd_schema_generate.go
@@ -66,7 +66,7 @@ func (s *schemaGenerateCmd) hotReload(ctx context.Context, client ftlv1connect.C
 	}
 
 	logger := log.FromContext(ctx)
-	logger.Infof("Watching %s", s.Template)
+	logger.Debugf("Watching %s", s.Template)
 
 	if err := watch.AddRecursive(s.Template); err != nil {
 		return err
@@ -109,7 +109,7 @@ func (s *schemaGenerateCmd) hotReload(ctx context.Context, client ftlv1connect.C
 			}
 
 			stream.Close()
-			logger.Infof("Stream disconnected, attempting to reconnect...")
+			logger.Debugf("Stream disconnected, attempting to reconnect...")
 			time.Sleep(s.ReconnectDelay)
 		}
 	})
@@ -123,7 +123,7 @@ func (s *schemaGenerateCmd) hotReload(ctx context.Context, client ftlv1connect.C
 			return wg.Wait()
 
 		case event := <-watch.Event:
-			logger.Infof("Template changed (%s), regenerating modules", event.Path)
+			logger.Debugf("Template changed (%s), regenerating modules", event.Path)
 			if err := s.regenerateModules(logger, previousModules); err != nil {
 				return err
 			}
@@ -150,14 +150,14 @@ func (s *schemaGenerateCmd) regenerateModules(logger *log.Logger, modules []*sch
 			return err
 		}
 	}
-	logger.Infof("Generated %d modules in %s", len(modules), s.Dest)
+	logger.Debugf("Generated %d modules in %s", len(modules), s.Dest)
 	return nil
 }
 
 func makeJSLoggerAdapter(logger *log.Logger) func(args ...any) {
 	return func(args ...any) {
 		strs := slices.Map(args, func(v any) string { return fmt.Sprintf("%v", v) })
-		level := log.Info
+		level := log.Debug
 		if prefix, ok := args[0].(string); ok {
 			switch prefix {
 			case "log:":

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -78,7 +78,7 @@ func main() {
 	signal.Notify(sigch, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-sigch
-		logger.Infof("FTL terminating with signal %s", sig)
+		logger.Debugf("FTL terminating with signal %s", sig)
 		cancel()
 		_ = syscall.Kill(-syscall.Getpid(), sig.(syscall.Signal)) //nolint:forcetypeassert
 		os.Exit(0)

--- a/frontend/local.go
+++ b/frontend/local.go
@@ -19,9 +19,9 @@ var proxy = httputil.NewSingleHostReverseProxy(consoleURL)
 
 func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (http.Handler, error) {
 	logger := log.FromContext(ctx)
-	logger.Infof("Building console...")
+	logger.Debugf("Building console...")
 
-	err := exec.Command(ctx, log.Debug, "frontend", "npm", "install").Run()
+	err := exec.Command(ctx, log.Debug, "frontend", "npm", "install").RunBuffered(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (htt
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("Console started")
+	logger.Infof("Web console available at: %s", consoleURL)
 
 	if allowOrigin == nil {
 		return proxy, nil

--- a/go-runtime/encoding/encoding.go
+++ b/go-runtime/encoding/encoding.go
@@ -21,6 +21,7 @@ var (
 func Marshal(v any) ([]byte, error) {
 	w := &bytes.Buffer{}
 	err := encodeValue(reflect.ValueOf(v), w)
+	fmt.Printf("Marshal: %s\n", w.String())
 	return w.Bytes(), err
 }
 
@@ -68,6 +69,7 @@ func encodeValue(v reflect.Value, w *bytes.Buffer) error {
 		return encodeValue(v.Elem(), w)
 
 	case reflect.Slice:
+		fmt.Printf("slice: %s %v\n", v.Type().Elem().Kind(), v)
 		if v.Type().Elem().Kind() == reflect.Uint8 {
 			return encodeBytes(v, w)
 		}

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -220,9 +220,9 @@ func runTests(t *testing.T, tmpDir string, tests []test) {
 	// Build FTL binary
 	logger := log.Configure(&logWriter{logger: t}, log.Config{Level: log.Debug})
 	ctx := log.ContextWithLogger(context.Background(), logger)
-	logger.Infof("Building ftl")
+	logger.Debugf("Building ftl")
 	binDir := filepath.Join(rootDir, "build", "release")
-	err = exec.Command(ctx, log.Debug, rootDir, filepath.Join(rootDir, "bin", "bit"), "build/release/ftl", "**/*.jar").Run()
+	err = exec.Command(ctx, log.Debug, rootDir, filepath.Join(rootDir, "bin", "bit"), "build/release/ftl", "**/*.jar").RunBuffered(ctx)
 	assert.NoError(t, err)
 
 	controller := rpc.Dial(ftlv1connect.NewControllerServiceClient, "http://localhost:8892", log.Debug)
@@ -525,7 +525,7 @@ func (i itContext) assertWithRetry(t testing.TB, assertion assertion) {
 func startProcess(ctx context.Context, t testing.TB, args ...string) context.Context {
 	t.Helper()
 	ctx, cancel := context.WithCancel(ctx)
-	cmd := exec.Command(ctx, log.Info, "..", args[0], args[1:]...)
+	cmd := exec.Command(ctx, log.Debug, "..", args[0], args[1:]...)
 	err := cmd.Start()
 	assert.NoError(t, err)
 	terminated := make(chan bool)

--- a/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/hotswap/FtlHotswapAgentPlugin.kt
+++ b/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/hotswap/FtlHotswapAgentPlugin.kt
@@ -13,6 +13,6 @@ object FtlHotswapAgentPlugin {
   @JvmStatic
   @OnClassLoadEvent(classNameRegexp = ".*", events = [LoadEvent.REDEFINE])
   fun loaded(ctClass: CtClass) {
-    logger.info("Reloaded " + ctClass.name)
+    logger.debug("Reloaded " + ctClass.name)
   }
 }

--- a/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/registry/Registry.kt
+++ b/kotlin-runtime/ftl-runtime/src/main/kotlin/xyz/block/ftl/registry/Registry.kt
@@ -54,7 +54,7 @@ class Registry(val jvmModuleName: String = defaultJvmModuleName) {
 
   /** Register all Verbs in the JVM package by walking the class graph. */
   fun registerAll() {
-    logger.info("Scanning for Verbs in ${jvmModuleName}...")
+    logger.debug("Scanning for Verbs in ${jvmModuleName}...")
     ClassGraph()
       .enableAllInfo() // Scan classes, methods, fields, annotations
       .acceptPackages(jvmModuleName)
@@ -83,7 +83,7 @@ class Registry(val jvmModuleName: String = defaultJvmModuleName) {
       ftlModuleName = moduleName
     }
 
-    logger.info("      @Verb ${function.name}()")
+    logger.debug("      @Verb ${function.name}()")
     val verbRef = VerbRef(module = ftlModuleName!!, name = verbName)
     val verbHandle = VerbHandle(klass, function)
     if (verbs.containsKey(verbRef)) throw IllegalArgumentException("Duplicate Verb $verbRef")


### PR DESCRIPTION
Fixes #869 

Reduce log levels for `Info` and `Debug`
`Debug -> Trace`
`Info -> Debug`

Also adds a `RunBuffered` to `exec` to allow `Command`s to be run and the output buffered to a circular buffer. The output is printed out at the current log level if an error occurs. The result is a quiet terminal when things go well and context output when things fail.

Some examples:
```
ftl serve --recreate --allow-origins "*"
info: Starting FTL with 1 controller(s) and 0 runner(s)
info:controller0: Web console available at: http://localhost:5173
```

```
ftl build examples/kotlin/ftl-module-api
info: Building kotlin module 'api'
info: Successfully built module 'api' in 7.26s
```

```
ftl deploy examples/go/httpingress
info: Building go module 'httpingress'
info: Successfully built module 'httpingress' in 3.99s
info: Preparing module 'httpingress' for deployment
info: Successfully created deployment httpingress-5792064876
```

```
ftl dev examples/kotlin
info: Building kotlin module 'api'
info: Successfully built module 'api' in 8.85s
info: Preparing module 'api' for deployment
info: Successfully created deployment api-5837eca0af
info: Building kotlin module 'echo'
info: Successfully built module 'echo' in 6.95s
info: Preparing module 'echo' for deployment
info: Successfully created deployment echo-31ad4e0677
info: Building kotlin module 'ad'
info: Successfully built module 'ad' in 7.63s
info: Preparing module 'ad' for deployment
info: Successfully created deployment ad-e75c5b489a
```

And some error examples:
```
ftl dev examples/kotlin/ftl-module-echo
info: Building kotlin module 'echo'
info: r
[INFO]
[INFO] --- exec:3.0.0:exec (default) @ ftl-module-echo ---
Generated module: /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/target/generated-sources/ftl/builtin/BuiltinModuleClient.kt
[INFO]
[INFO] --- build-helper:3.2.0:add-source (default) @ ftl-module-echo ---
[INFO] Source directory: /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/target/generated-sources/ftl added.
[INFO]
[INFO] --- resources:3.3.1:resources (default-resources) @ ftl-module-echo ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/resources
[INFO]
[INFO] --- compiler:3.11.0:compile (default-compile) @ ftl-module-echo ---
[INFO] Nothing to compile - all classes are up to date
[INFO]
[INFO] --- kotlin:1.9.0:compile (compile) @ ftl-module-echo ---
[WARNING] Source root doesn't exist: /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/java
[WARNING] Using experimental Kotlin incremental compilation
[INFO] Non-incremental compilation will be performed: NO_BUILD_HISTORY
[INFO] Kotlin compile iteration: /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt, /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/target/generated-sources/ftl/builtin/BuiltinModuleClient.kt
[INFO] Exit code: COMPILATION_ERROR
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt: (3, 12) Unresolved reference: time
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt: (4, 12) Unresolved reference: time
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt: (20, 28) Not enough information to infer type variable R
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt: (20, 33) Unresolved reference: TimeModuleClient
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt: (20, 51) Unresolved reference: time
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt: (20, 57) Unresolved reference: TimeRequest
[INFO] Compiled 2 Kotlin files using incremental compiler
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  3.369 s
[INFO] Finished at: 2024-02-05T11:59:18-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.jetbrains.kotlin:kotlin-maven-plugin:1.9.0:compile (compile) on project ftl-module-echo: Compilation failure: Compilation failure:
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt:[3,12] Unresolved reference: time
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt:[4,12] Unresolved reference: time
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt:[20,28] Not enough information to infer type variable R
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt:[20,33] Unresolved reference: TimeModuleClient
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt:[20,51] Unresolved reference: time
[ERROR] /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo/src/main/kotlin/ftl/echo/Echo.kt:[20,57] Unresolved reference: TimeRequest
[ERROR] -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

error: Error deploying module /Users/wesbillman/dev/ftl/examples/kotlin/ftl-module-echo. Will retry: failed to build module: exit status 1
info: Building kotlin module 'echo'
```