### PR TITLE
fix: add imports for type parameter datarefs

### DIFF
--- a/backend/schema/module.go
+++ b/backend/schema/module.go
@@ -149,6 +149,14 @@ func (m *Module) Imports() []string {
 			if n.Module != "" && n.Module != m.Name {
 				imports[n.Module] = true
 			}
+			// add imports for type parameters DataRefs as well
+			for _, p := range n.TypeParameters {
+				if p, ok := p.(*DataRef); ok {
+					if p.Module != "" && p.Module != m.Name {
+						imports[p.Module] = true
+					}
+				}
+			}
 
 		case *VerbRef:
 			if n.Module != "" && n.Module != m.Name {

--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -55,15 +55,19 @@ func normaliseString(s string) string {
 func TestImports(t *testing.T) {
 	input := `
 	module test {
+		data Generic<T> {
+			value T
+		}
 		data Data {
 			ref other.Data
 			ref another.Data
+			ref Generic<new.Data>
 		}
 	}
 	`
 	schema, err := ParseModuleString("", input)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"another", "other"}, schema.Imports())
+	assert.Equal(t, []string{"another", "new", "other"}, schema.Imports())
 }
 
 func TestVisit(t *testing.T) {


### PR DESCRIPTION
They were missing in the code gen for clients