### PR TITLE
fix: update go.work.tmpl to use .GoVersion rather than hard-coded version

### DIFF
--- a/go-runtime/compile/build-template/go.work.tmpl
+++ b/go-runtime/compile/build-template/go.work.tmpl
@@ -1,4 +1,4 @@
-go 1.21.6
+go {{ .GoVersion }}
 
 use (
 	.


### PR DESCRIPTION
removes harcoded go version in autogenerated `go.work` files