### PR TITLE
feat: use builtin.Empty instead of Unit typealias in Kotlin

### DIFF
--- a/examples/kotlin/ftl-module-api/src/main/kotlin/ftl/api/Api.kt
+++ b/examples/kotlin/ftl-module-api/src/main/kotlin/ftl/api/Api.kt
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonPrimitive
 import com.google.gson.JsonSerializer
+import ftl.builtin.Empty
 import ftl.builtin.HttpRequest
 import ftl.builtin.HttpResponse
 import xyz.block.ftl.*
@@ -17,8 +18,6 @@ data class Todo(
   val title: String,
   val completed: Boolean = false,
 )
-
-typealias GetStatusRequest = Unit
 
 data class GetStatusResponse(
   val status: String,
@@ -59,7 +58,7 @@ class Api {
 
   @Verb
   @HttpIngress(Method.GET, "/api/status")
-  fun status(context: Context, req: HttpRequest<GetStatusRequest>): HttpResponse<GetStatusResponse> {
+  fun status(context: Context, req: HttpRequest<Empty>): HttpResponse<GetStatusResponse> {
     return HttpResponse<GetStatusResponse>(status = 200, headers = mapOf(), body = GetStatusResponse("OK"))
   }
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -96,12 +96,12 @@ func TestHttpIngress(t *testing.T) {
 				httpCall(rd, http.MethodPut, "/users/123", jsonData(t, obj{"postId": "346"}), func(t testing.TB, resp *httpResponse) {
 					assert.Equal(t, 200, resp.status)
 					assert.Equal(t, []string{"Header from FTL"}, resp.headers["Put"])
-					assert.Equal(t, nil, resp.body)
+					assert.Equal(t, map[string]any{}, resp.body)
 				}),
 				httpCall(rd, http.MethodDelete, "/users/123", jsonData(t, obj{}), func(t testing.TB, resp *httpResponse) {
 					assert.Equal(t, 200, resp.status)
 					assert.Equal(t, []string{"Header from FTL"}, resp.headers["Delete"])
-					assert.Equal(t, nil, resp.body)
+					assert.Equal(t, map[string]any{}, resp.body)
 				}),
 
 				httpCall(rd, http.MethodGet, "/html", jsonData(t, obj{}), func(t testing.TB, resp *httpResponse) {

--- a/integration/testdata/go/httpingress/echo.go
+++ b/integration/testdata/go/httpingress/echo.go
@@ -66,10 +66,10 @@ type PutResponse struct{}
 
 //ftl:verb
 //ftl:ingress http PUT /users/{userId}
-func Put(ctx context.Context, req builtin.HttpRequest[PutRequest]) (builtin.HttpResponse[ftl.Unit], error) {
-	return builtin.HttpResponse[ftl.Unit]{
+func Put(ctx context.Context, req builtin.HttpRequest[PutRequest]) (builtin.HttpResponse[builtin.Empty], error) {
+	return builtin.HttpResponse[builtin.Empty]{
 		Headers: map[string][]string{"Put": {"Header from FTL"}},
-		Body:    ftl.Unit{},
+		Body:    builtin.Empty{},
 	}, nil
 }
 
@@ -81,11 +81,11 @@ type DeleteResponse struct{}
 
 //ftl:verb
 //ftl:ingress http DELETE /users/{userId}
-func Delete(ctx context.Context, req builtin.HttpRequest[DeleteRequest]) (builtin.HttpResponse[ftl.Unit], error) {
-	return builtin.HttpResponse[ftl.Unit]{
+func Delete(ctx context.Context, req builtin.HttpRequest[DeleteRequest]) (builtin.HttpResponse[builtin.Empty], error) {
+	return builtin.HttpResponse[builtin.Empty]{
 		Status:  200,
 		Headers: map[string][]string{"Delete": {"Header from FTL"}},
-		Body:    ftl.Unit{},
+		Body:    builtin.Empty{},
 	}, nil
 }
 

--- a/integration/testdata/kotlin/database/Echo.kt
+++ b/integration/testdata/kotlin/database/Echo.kt
@@ -1,20 +1,20 @@
 package ftl.echo
 
+import ftl.builtin.Empty
 import xyz.block.ftl.Context
 import xyz.block.ftl.Verb
 import xyz.block.ftl.Database
 
 data class InsertRequest(val data: String)
-typealias InsertResponse = Unit
 
 val db = Database("testdb")
 
 class Echo {
 
   @Verb
-  fun insert(context: Context, req: InsertRequest): InsertResponse {
+  fun insert(context: Context, req: InsertRequest): Empty {
     persistRequest(req)
-    return InsertResponse
+    return Empty()
   }
 
   fun persistRequest(req: InsertRequest) {

--- a/integration/testdata/kotlin/httpingress/Echo.kt
+++ b/integration/testdata/kotlin/httpingress/Echo.kt
@@ -1,5 +1,6 @@
 package ftl.echo
 
+import ftl.builtin.Empty
 import ftl.builtin.HttpRequest
 import ftl.builtin.HttpResponse
 import kotlin.String
@@ -25,8 +26,8 @@ data class GetResponse(
 )
 
 data class PostRequest(
-  @Alias("user_id") val userID: Int,
-  val postID: Int,
+  @Alias("user_id") val userId: Int,
+  val postId: Int,
 )
 
 data class PostResponse(
@@ -38,14 +39,9 @@ data class PutRequest(
   @Alias("postId") val postID: String,
 )
 
-typealias PutResponse = Unit
-
 data class DeleteRequest(
   @Alias("userId") val userID: String,
 )
-typealias DeleteResponse = Unit
-
-typealias HtmlRequest = Unit
 
 class Echo {
   @Verb
@@ -74,27 +70,27 @@ class Echo {
 
   @Verb
   @HttpIngress(Method.PUT, "/users/{userId}")
-  fun put(context: Context, req: HttpRequest<PutRequest>): HttpResponse<PutResponse> {
-    return HttpResponse<PutResponse>(
+  fun put(context: Context, req: HttpRequest<PutRequest>): HttpResponse<Empty> {
+    return HttpResponse<Empty>(
       status = 200,
       headers = mapOf("Put" to arrayListOf("Header from FTL")),
-      body = PutResponse
+      body = Empty()
     )
   }
 
   @Verb
   @HttpIngress(Method.DELETE, "/users/{userId}")
-  fun delete(context: Context, req: HttpRequest<DeleteRequest>): HttpResponse<DeleteResponse> {
-    return HttpResponse<DeleteResponse>(
+  fun delete(context: Context, req: HttpRequest<DeleteRequest>): HttpResponse<Empty> {
+    return HttpResponse<Empty>(
       status = 200,
       headers = mapOf("Delete" to arrayListOf("Header from FTL")),
-      body = DeleteResponse
+      body = Empty()
     )
   }
 
   @Verb
   @HttpIngress(Method.GET, "/html")
-  fun html(context: Context, req: HttpRequest<HtmlRequest>): HttpResponse<String> {
+  fun html(context: Context, req: HttpRequest<Empty>): HttpResponse<String> {
     return HttpResponse<String>(
       status = 200,
       headers = mapOf("Content-Type" to arrayListOf("text/html; charset=utf-8")),

--- a/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
+++ b/kotlin-runtime/ftl-generator/src/main/kotlin/xyz/block/ftl/generator/ModuleGenerator.kt
@@ -46,9 +46,9 @@ class ModuleGenerator() {
 
     val types = module.decls.mapNotNull { it.data_ }
     types.forEach {
-      if (it.fields.isEmpty()) {
-        file.addTypeAlias(
-          TypeAliasSpec.builder(it.name, Unit::class)
+      if (namespace == "ftl.builtin" && it.name == "Empty") {
+        file.addType(
+          TypeSpec.classBuilder(it.name)
             .addKdoc(it.comments.joinToString("\n"))
             .build()
         )

--- a/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/ContextTest.kt
+++ b/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/ContextTest.kt
@@ -1,5 +1,6 @@
 package xyz.block.ftl
 
+import ftl.builtin.Empty
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
@@ -13,12 +14,10 @@ data class EchoResponse(val text: String)
 class Echo {
   @Verb
   fun echo(context: Context, req: EchoRequest): EchoResponse {
-    val time = context.call(Time::time, TimeRequest)
+    val time = context.call(Time::time, Empty())
     return EchoResponse("Hello ${req.user}, the time is ${time.time}!")
   }
 }
-
-typealias TimeRequest = Unit
 
 data class TimeResponse(val time: OffsetDateTime)
 
@@ -26,7 +25,7 @@ val staticTime = OffsetDateTime.now()
 
 class Time {
   @Verb
-  fun time(context: Context, req: TimeRequest): TimeResponse {
+  fun time(context: Context, req: Empty): TimeResponse {
     return TimeResponse(staticTime)
   }
 }
@@ -43,7 +42,7 @@ class ContextTest {
           expected = EchoResponse("Hello Alice, the time is $staticTime!"),
         ),
         TestCase(
-          invoke = { ctx -> ctx.call(Time::time, TimeRequest) },
+          invoke = { ctx -> ctx.call(Time::time, Empty()) },
           expected = TimeResponse(staticTime),
         ),
       )

--- a/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRuleTest.kt
+++ b/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRuleTest.kt
@@ -30,6 +30,7 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
     val code = """
         package ftl.echo
 
+        import ftl.builtin.Empty
         import ftl.builtin.HttpRequest
         import ftl.builtin.HttpResponse
         import ftl.time.TimeModuleClient
@@ -70,6 +71,11 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
                   headers = mapOf("Get" to arrayListOf("Header from FTL")),
                   body = EchoResponse(messages = listOf(EchoMessage(message = "Hello!")))
                 )
+            }
+
+            @Verb
+            fun empty(context: Context, req: Empty): Empty {
+                return builtin.Empty()
             }
 
             fun callTime(context: Context): TimeResponse {
@@ -235,6 +241,23 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
                 )
               )
             )
+          ),
+        ),
+        Decl(
+          verb = Verb(
+            name = "empty",
+            request = Type(
+              dataRef = DataRef(
+                name = "Empty",
+                module = "builtin"
+              )
+            ),
+            response = Type(
+              dataRef = DataRef(
+                name = "Empty",
+                module = "builtin"
+              )
+            ),
           ),
         )
       )

--- a/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/testdata/dependencies/BuiltinModuleClient.kt
+++ b/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/testdata/dependencies/BuiltinModuleClient.kt
@@ -29,5 +29,7 @@ public data class HttpResponse<Body>(
   public val body: Body,
 )
 
+public class Empty
+
 @Ignore
 public class BuiltinModuleClient()


### PR DESCRIPTION
fixes #878