### PR TITLE
chore: workflow tweaks

### DIFF
--- a/.github/workflows/workflow-next.yml
+++ b/.github/workflows/workflow-next.yml
@@ -1,16 +1,17 @@
 # This name needs to be kept in sync with the workflow_run event in workflow-roadmap.yml
-name: Add triage label to new issues
+name: Clear triage label when moved to next
 on:
   issues:
     types:
-      - opened
+      - labeled
 jobs:
-  label-issues:
+  clear-triage-label:
+    if: github.event.label.name == 'next'
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - run: gh issue edit "$NUMBER" --add-label triage
+      - run: gh issue edit "$NUMBER" --remove-label triage
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/workflow-roadmap.yml
+++ b/.github/workflows/workflow-roadmap.yml
@@ -14,6 +14,7 @@ on:
     workflows:
       - Add triage label to new issues
       - Clear workflow labels once an issue is assigned
+      - Clear triage label when moved to next
     types: [completed]
 concurrency:
   group: ${{ github.ref }}-workflow-roadmap


### PR DESCRIPTION
- Clear triage label when moved to next
- Only add triage label on new tickets