### PR TITLE
fix: make sure to log spawn errors at log.Error

### DIFF
--- a/backend/common/plugin/spawn.go
+++ b/backend/common/plugin/spawn.go
@@ -142,7 +142,7 @@ func Spawn[Client PingableClient](
 	go func() { cancelWithCause(cmd.Wait()) }()
 
 	go func() {
-		err := log.JSONStreamer(pipe, logger, log.Debug)
+		err := log.JSONStreamer(pipe, logger, log.Error)
 		if err != nil {
 			logger.Errorf(err, "Error streaming plugin logs.")
 		}


### PR DESCRIPTION
Example of an error on `var db = ftl.PostgresDatabase("not_a_db")`

![Screenshot 2024-02-14 at 3 25 52 PM](https://github.com/TBD54566975/ftl/assets/51647/bf0eec33-a1f1-49f9-b9b6-e1b6d060a98f)
