### PR TITLE
fix: kotlin schema extractor fixes

### DIFF
--- a/examples/kotlin/pom.xml
+++ b/examples/kotlin/pom.xml
@@ -184,6 +184,7 @@
                         <disableDefaultRuleSets>true</disableDefaultRuleSets>
                         <classPath>${generated.classpath}</classPath>
                         <jvmTarget>${java.version}</jvmTarget>
+                        <jdkHome>${java.home}</jdkHome>
                         <config>${project.build.directory}/detekt.yml</config>
                         <plugins>
                             <plugin>

--- a/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRuleTest.kt
+++ b/kotlin-runtime/ftl-runtime/src/test/kotlin/xyz/block/ftl/schemaextractor/ExtractSchemaRuleTest.kt
@@ -54,7 +54,11 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
       /**
        * Request to echo a message.
        */
-      data class EchoRequest<T>(val t: T, val name: String, @Alias("stf") val stuff: Any)
+      data class EchoRequest<T>(
+        val t: T,
+        val name: String,
+        @Alias("stf") val stuff: Any,
+       )
       data class EchoResponse(val messages: List<EchoMessage>)
 
       /**
@@ -81,6 +85,8 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
       fun callTime(context: Context): TimeResponse {
         context.call(::empty, builtin.Empty())
         context.call(::other, builtin.Empty())
+        // commented out call is ignored:
+        //context.call(::foo, builtin.Empty())
         return context.call(::verb, builtin.Empty())
       }
     """
@@ -114,15 +120,19 @@ internal class ExtractSchemaRuleTest(private val env: KotlinCoreEnvironment) {
               Field(
                 name = "metadata",
                 type = Type(
-                  map = Map(
-                    key = Type(string = xyz.block.ftl.v1.schema.String()),
-                    value_ = Type(
-                      dataRef = DataRef(
-                        name = "MapValue",
-                        module = "echo"
+                  optional = Optional(
+                    type = Type(
+                      map = Map(
+                        key = Type(string = xyz.block.ftl.v1.schema.String()),
+                        value_ = Type(
+                          dataRef = DataRef(
+                            name = "MapValue",
+                            module = "echo"
+                          )
+                        )
                       )
                     )
-                  )
+                  ),
                 )
               ),
             ),

--- a/kotlin-runtime/scaffolding/pom.xml
+++ b/kotlin-runtime/scaffolding/pom.xml
@@ -185,6 +185,7 @@
                         <disableDefaultRuleSets>true</disableDefaultRuleSets>
                         <classPath>${generated.classpath}</classPath>
                         <jvmTarget>${java.version}</jvmTarget>
+                        <jdkHome>${java.home}</jdkHome>
                         <config>${project.build.directory}/detekt.yml</config>
                         <plugins>
                             <plugin>


### PR DESCRIPTION
fixes #938
fixes #934
fixes #929

This change fixes the java class resolution issue in module POMs, but I still unfortunately haven't figured out how to do the same for unit tests run from `kotlin-runtime/ftl-runtime`. So, the change was validated locally instead of in unit tests.

with the given Echo.kt:
```
package ftl.echo

import ftl.builtin.Empty
import xyz.block.ftl.Context
import xyz.block.ftl.Verb
import java.time.OffsetDateTime
import java.util.ArrayList
import java.util.HashMap

class InvalidInput(val field: String) : Exception()

data class EchoRequest(val name: String?)
data class EchoResponse(
  val message: String,
  val time: OffsetDateTime? = null,
  val arrayList: ArrayList<Empty> = ArrayList(),
  val hashMap: HashMap<String, String> = HashMap()
)
 
@Throws(InvalidInput::class)
@Verb
fun echo(context: Context, req: EchoRequest): EchoResponse {
  return EchoResponse(message = "Hello, ${req.name ?: "anonymous"}!")
}
```

<img width="642" alt="Screenshot 2024-02-14 at 4 11 10 PM" src="https://github.com/TBD54566975/ftl/assets/72891690/7cb0ecc7-7061-4e48-adc9-c9b9c9dc57a1">
