### PR TITLE
fix: JSON aliases can be any string, not just identifiers

### DIFF
--- a/backend/controller/ingress/alias_test.go
+++ b/backend/controller/ingress/alias_test.go
@@ -12,11 +12,11 @@ func TestTransformFromAliasedFields(t *testing.T) {
 	schemaText := `
 		module test {
 			data Inner {
-				waz String alias json foo
+				waz String alias json "foo"
 			}
 
 			data Test {
-				scalar String alias json bar
+				scalar String alias json "bar"
 				inner Inner
 				array [Inner]
 				map {String: Inner}
@@ -72,11 +72,11 @@ func TestTransformToAliasedFields(t *testing.T) {
 	schemaText := `
 		module test {
 			data Inner {
-				waz String alias json foo
+				waz String alias json "foo"
 			}
 
 			data Test {
-				scalar String alias json bar
+				scalar String alias json "bar"
 				inner Inner
 				array [Inner]
 				map {String: Inner}

--- a/backend/schema/field.go
+++ b/backend/schema/field.go
@@ -15,7 +15,7 @@ type Field struct {
 	Comments  []string `parser:"@Comment*" protobuf:"3"`
 	Name      string   `parser:"@Ident" protobuf:"2"`
 	Type      Type     `parser:"@@" protobuf:"4"`
-	JSONAlias string   `parser:"('alias' 'json' @Ident)?" protobuf:"5"`
+	JSONAlias string   `parser:"('alias' 'json' @String)?" protobuf:"5"`
 }
 
 var _ Node = (*Field)(nil)
@@ -25,7 +25,7 @@ func (f *Field) schemaChildren() []Node { return []Node{f.Type} }
 func (f *Field) String() string {
 	jsonAlias := ""
 	if f.JSONAlias != "" {
-		jsonAlias = fmt.Sprintf(" alias json %s", f.JSONAlias)
+		jsonAlias = fmt.Sprintf(" alias json %q", f.JSONAlias)
 	}
 	w := &strings.Builder{}
 	fmt.Fprint(w, encodeComments(f.Comments))

--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -20,11 +20,11 @@ func TestSchemaString(t *testing.T) {
 // A comment
 module todo {
   data CreateRequest {
-    name {String: String}? alias json rqn
+    name {String: String}? alias json "rqn"
   }
 
   data CreateResponse {
-    name [String] alias json rsn
+    name [String] alias json "rsn"
   }
 
   data DestroyRequest {
@@ -340,10 +340,10 @@ func TestParseModule(t *testing.T) {
 // A comment
 module todo {
   data CreateRequest {
-    name {String: String}? alias json rqn
+    name {String: String}? alias json "rqn"
   }
   data CreateResponse {
-    name [String] alias json rsn
+    name [String] alias json "rsn"
   }
   data DestroyRequest {
     // A comment

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -32,7 +32,7 @@ func TestExtractModuleSchema(t *testing.T) {
     nested one.Nested
     optional one.Nested?
     time Time
-    user two.User alias json u
+    user two.User alias json "u"
     bytes Bytes
   }
 


### PR DESCRIPTION
eg. "foo:bar:waz"