### PR TITLE
refactor: move logic from cmd/ftl/cmd_build* into buildengine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ dist/
 examples/**/go.work
 examples/**/go.work.sum
 **/_ftl
+buildengine/.gitignore

--- a/buildengine/build.go
+++ b/buildengine/build.go
@@ -2,17 +2,39 @@ package buildengine
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 )
 
 // A Module is a ModuleConfig with its dependencies populated.
 type Module struct {
-	ModuleConfig
+	moduleconfig.ModuleConfig
 	Dependencies []string
 }
 
+// LoadModule loads a module from the given directory.
+//
+// A [Module] includes the module configuration as well as its dependencies
+// extracted from source code.
+func LoadModule(dir string) (Module, error) {
+	config, err := moduleconfig.LoadModuleConfig(dir)
+	if err != nil {
+		return Module{}, err
+	}
+	return UpdateDependencies(config)
+}
+
 // Build a module in the given directory given the schema and module config.
-func Build(ctx context.Context, schema *schema.Schema, config Module) error {
-	panic("not implemented")
+func Build(ctx context.Context /*schema *schema.Schema, */, module Module) error {
+	switch module.Language {
+	case "go":
+		return buildGo(ctx, module)
+
+	case "kotlin":
+		return buildKotlin(ctx, module)
+
+	default:
+		return fmt.Errorf("unknown language %q", module.Language)
+	}
 }

--- a/buildengine/build_go.go
+++ b/buildengine/build_go.go
@@ -1,4 +1,4 @@
-package main
+package buildengine
 
 import (
 	"context"
@@ -10,20 +10,21 @@ import (
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/go-runtime/compile"
+	"github.com/TBD54566975/ftl/internal/rpc"
 )
 
-func (b *buildCmd) buildGo(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
+func buildGo(ctx context.Context, module Module) error {
+	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
 	resp, err := client.GetSchema(ctx, connect.NewRequest(&ftlv1.GetSchemaRequest{}))
 	if err != nil {
 		return err
 	}
 	sch, err := schema.FromProto(resp.Msg.Schema)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to convert schema from proto: %w", err)
 	}
-	if err := compile.Build(ctx, b.ModuleDir, sch); err != nil {
+	if err := compile.Build(ctx, module.Dir, sch); err != nil {
 		return fmt.Errorf("failed to build module: %w", err)
 	}
-
 	return nil
 }

--- a/buildengine/deps.go
+++ b/buildengine/deps.go
@@ -15,10 +15,12 @@ import (
 
 	"golang.design/x/reflect"
 	"golang.org/x/exp/maps"
+
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 )
 
 // UpdateAllDependencies calls UpdateDependencies on each module in the list.
-func UpdateAllDependencies(modules []ModuleConfig) ([]Module, error) {
+func UpdateAllDependencies(modules []moduleconfig.ModuleConfig) ([]Module, error) {
 	out := []Module{}
 	for _, module := range modules {
 		updated, err := UpdateDependencies(module)
@@ -32,7 +34,7 @@ func UpdateAllDependencies(modules []ModuleConfig) ([]Module, error) {
 
 // UpdateDependencies finds the dependencies for an FTL module and returns a
 // Module with those dependencies populated.
-func UpdateDependencies(config ModuleConfig) (Module, error) {
+func UpdateDependencies(config moduleconfig.ModuleConfig) (Module, error) {
 	dependencies, err := extractDependencies(config)
 	if err != nil {
 		return Module{}, err
@@ -41,7 +43,7 @@ func UpdateDependencies(config ModuleConfig) (Module, error) {
 	return Module{ModuleConfig: out, Dependencies: dependencies}, nil
 }
 
-func extractDependencies(config ModuleConfig) ([]string, error) {
+func extractDependencies(config moduleconfig.ModuleConfig) ([]string, error) {
 	switch config.Language {
 	case "go":
 		return extractGoFTLImports(config.Module, config.Dir)

--- a/buildengine/discover.go
+++ b/buildengine/discover.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 )
 
 // DiscoverModules recursively loads all modules under the given directories.
 //
 // If no directories are provided, the current working directory is used.
-func DiscoverModules(dirs ...string) ([]ModuleConfig, error) {
+func DiscoverModules(dirs ...string) ([]moduleconfig.ModuleConfig, error) {
 	if len(dirs) == 0 {
 		cwd, err := os.Getwd()
 		if err != nil {
@@ -18,14 +20,14 @@ func DiscoverModules(dirs ...string) ([]ModuleConfig, error) {
 		}
 		dirs = []string{cwd}
 	}
-	out := []ModuleConfig{}
+	out := []moduleconfig.ModuleConfig{}
 	for _, dir := range dirs {
 		err := WalkDir(dir, func(path string, d fs.DirEntry) error {
 			if filepath.Base(path) != "ftl.toml" {
 				return nil
 			}
 			moduleDir := filepath.Dir(path)
-			config, err := LoadModuleConfig(moduleDir)
+			config, err := moduleconfig.LoadModuleConfig(moduleDir)
 			if err != nil {
 				return err
 			}

--- a/buildengine/discover_test.go
+++ b/buildengine/discover_test.go
@@ -4,12 +4,14 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 )
 
 func TestDiscoverModules(t *testing.T) {
 	modules, err := DiscoverModules("testdata/modules")
 	assert.NoError(t, err)
-	expected := []ModuleConfig{
+	expected := []moduleconfig.ModuleConfig{
 		{
 			Dir:       "testdata/modules/alpha",
 			Language:  "go",

--- a/buildengine/filehash.go
+++ b/buildengine/filehash.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 
 	"github.com/bmatcuk/doublestar/v4"
+
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 )
 
 type FileChangeType rune
@@ -63,7 +65,7 @@ func CompareFileHashes(oldFiles, newFiles FileHashes) (FileChangeType, string, b
 
 // ComputeFileHashes computes the SHA256 hash of all (non-git-ignored) files in
 // the given directory.
-func ComputeFileHashes(config ModuleConfig) (FileHashes, error) {
+func ComputeFileHashes(config moduleconfig.ModuleConfig) (FileHashes, error) {
 	fileHashes := make(FileHashes)
 	err := WalkDir(config.Dir, func(srcPath string, entry fs.DirEntry) error {
 		for _, pattern := range config.Watch {

--- a/buildengine/topological_test.go
+++ b/buildengine/topological_test.go
@@ -4,27 +4,29 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 )
 
 func TestBuildOrder(t *testing.T) {
 	modules := []Module{
 		{
-			ModuleConfig: ModuleConfig{Module: "alpha"},
+			ModuleConfig: moduleconfig.ModuleConfig{Module: "alpha"},
 			Dependencies: []string{"beta", "gamma"},
 		},
 		{
-			ModuleConfig: ModuleConfig{Module: "beta"},
+			ModuleConfig: moduleconfig.ModuleConfig{Module: "beta"},
 			Dependencies: []string{"kappa"},
 		},
 		{
-			ModuleConfig: ModuleConfig{Module: "gamma"},
+			ModuleConfig: moduleconfig.ModuleConfig{Module: "gamma"},
 			Dependencies: []string{"kappa"},
 		},
 		{
-			ModuleConfig: ModuleConfig{Module: "kappa"},
+			ModuleConfig: moduleconfig.ModuleConfig{Module: "kappa"},
 		},
 		{
-			ModuleConfig: ModuleConfig{Module: "delta"},
+			ModuleConfig: moduleconfig.ModuleConfig{Module: "delta"},
 		},
 	}
 
@@ -33,15 +35,15 @@ func TestBuildOrder(t *testing.T) {
 
 	expected := [][]Module{
 		{
-			{ModuleConfig: ModuleConfig{Module: "delta"}},
-			{ModuleConfig: ModuleConfig{Module: "kappa"}},
+			{ModuleConfig: moduleconfig.ModuleConfig{Module: "delta"}},
+			{ModuleConfig: moduleconfig.ModuleConfig{Module: "kappa"}},
 		},
 		{
-			{ModuleConfig: ModuleConfig{Module: "beta"}, Dependencies: []string{"kappa"}},
-			{ModuleConfig: ModuleConfig{Module: "gamma"}, Dependencies: []string{"kappa"}},
+			{ModuleConfig: moduleconfig.ModuleConfig{Module: "beta"}, Dependencies: []string{"kappa"}},
+			{ModuleConfig: moduleconfig.ModuleConfig{Module: "gamma"}, Dependencies: []string{"kappa"}},
 		},
 		{
-			{ModuleConfig: ModuleConfig{Module: "alpha"}, Dependencies: []string{"beta", "gamma"}},
+			{ModuleConfig: moduleconfig.ModuleConfig{Module: "alpha"}, Dependencies: []string{"beta", "gamma"}},
 		},
 	}
 	assert.Equal(t, expected, graph)

--- a/buildengine/watch.go
+++ b/buildengine/watch.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/alecthomas/types/pubsub"
 
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/maps"
 )
@@ -60,7 +61,7 @@ func Watch(ctx context.Context, period time.Duration, dirs ...string) *pubsub.To
 				logger.Tracef("error discovering modules: %v", err)
 				continue
 			}
-			moduleConfigsByDir := maps.FromSlice(moduleConfigs, func(config ModuleConfig) (string, ModuleConfig) {
+			moduleConfigsByDir := maps.FromSlice(moduleConfigs, func(config moduleconfig.ModuleConfig) (string, moduleconfig.ModuleConfig) {
 				return config.Module, config
 			})
 

--- a/buildengine/watch_test.go
+++ b/buildengine/watch_test.go
@@ -1,4 +1,4 @@
-package buildengine
+package buildengine_test
 
 import (
 	"context"
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 
+	. "github.com/TBD54566975/ftl/buildengine"
 	"github.com/TBD54566975/ftl/internal/log"
 )
 

--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/buildengine"
 	"github.com/TBD54566975/ftl/internal/log"
 )
@@ -14,36 +12,22 @@ type buildCmd struct {
 	ModuleDir string `arg:"" help:"Directory containing ftl.toml" type:"existingdir" default:"."`
 }
 
-func (b *buildCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
+func (b *buildCmd) Run(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 
 	startTime := time.Now()
-	// Load the TOML file.
-	var err error
-	config, err := buildengine.LoadModuleConfig(b.ModuleDir)
+
+	module, err := buildengine.LoadModule(b.ModuleDir)
+	if err != nil {
+		return err
+	}
+	logger.Infof("Building %s module '%s'", module.Language, module.Module)
+
+	err = buildengine.Build(ctx, module)
 	if err != nil {
 		return err
 	}
 
-	logger.Infof("Building %s module '%s'", config.Language, config.Module)
-
-	switch config.Language {
-	case "kotlin":
-		err = b.buildKotlin(ctx, config)
-
-	case "go":
-		err = b.buildGo(ctx, client)
-
-	default:
-		return fmt.Errorf("unable to build, unknown language %q", config.Language)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	duration := time.Since(startTime)
-	formattedDuration := fmt.Sprintf("%.2fs", duration.Seconds())
-	logger.Infof("Successfully built module '%s' in %s", config.Module, formattedDuration)
+	logger.Infof("Successfully built module '%s' in %.2fs", module.Module, time.Since(startTime).Seconds())
 	return nil
 }

--- a/cmd/ftl/cmd_deploy.go
+++ b/cmd/ftl/cmd_deploy.go
@@ -16,7 +16,7 @@ import (
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
-	"github.com/TBD54566975/ftl/buildengine"
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/sha256"
 	"github.com/TBD54566975/ftl/internal/slices"
@@ -32,7 +32,7 @@ func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 	logger := log.FromContext(ctx)
 
 	// Load the TOML file.
-	config, err := buildengine.LoadModuleConfig(d.ModuleDir)
+	config, err := moduleconfig.LoadModuleConfig(d.ModuleDir)
 	if err != nil {
 		return err
 	}
@@ -42,7 +42,7 @@ func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 	}
 
 	build := buildCmd{ModuleDir: d.ModuleDir}
-	err = build.Run(ctx, client)
+	err = build.Run(ctx)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (d *deployCmd) checkReadiness(ctx context.Context, client ftlv1connect.Cont
 		}
 	}
 }
-func (d *deployCmd) loadProtoSchema(deployDir string, config buildengine.ModuleConfig) (*schemapb.Module, error) {
+func (d *deployCmd) loadProtoSchema(deployDir string, config moduleconfig.ModuleConfig) (*schemapb.Module, error) {
 	schema := filepath.Join(deployDir, config.Schema)
 	content, err := os.ReadFile(schema)
 	if err != nil {

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"golang.org/x/sync/errgroup"
+
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/buildengine"
 	"github.com/TBD54566975/ftl/common/moduleconfig"
 	"github.com/TBD54566975/ftl/internal/log"
-	"golang.org/x/sync/errgroup"
 )
 
 type moduleFolderInfo struct {

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"golang.org/x/sync/errgroup"
-
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/buildengine"
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 	"github.com/TBD54566975/ftl/internal/log"
+	"golang.org/x/sync/errgroup"
 )
 
 type moduleFolderInfo struct {
@@ -127,7 +127,7 @@ func (d *devCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 
 		for dir := range modules {
 			currentModule := modules[dir]
-			config, err := buildengine.LoadModuleConfig(dir)
+			config, err := moduleconfig.LoadModuleConfig(dir)
 			if err != nil {
 				return err
 			}
@@ -261,7 +261,7 @@ func (d *devCmd) addOrRemoveModules(tomls []string, modules moduleMap) error {
 	for _, toml := range tomls {
 		dir := filepath.Dir(toml)
 		if _, ok := modules[dir]; !ok {
-			config, err := buildengine.LoadModuleConfig(dir)
+			config, err := moduleconfig.LoadModuleConfig(dir)
 			if err != nil {
 				return err
 			}

--- a/cmd/ftl/cmd_init.go
+++ b/cmd/ftl/cmd_init.go
@@ -11,9 +11,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/beevik/etree"
-
 	"github.com/TBD54566975/scaffolder"
+	"github.com/beevik/etree"
 
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/backend/schema/strcase"

--- a/cmd/ftl/cmd_init.go
+++ b/cmd/ftl/cmd_init.go
@@ -11,11 +11,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/TBD54566975/scaffolder"
 	"github.com/beevik/etree"
+
+	"github.com/TBD54566975/scaffolder"
 
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/backend/schema/strcase"
+	"github.com/TBD54566975/ftl/buildengine"
 	goruntime "github.com/TBD54566975/ftl/go-runtime"
 	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/exec"
@@ -90,7 +92,7 @@ func (i initKotlinCmd) Run(ctx context.Context, parent *initCmd) error {
 		return err
 	}
 
-	return setPomProperties(log.FromContext(ctx), i.Dir)
+	return buildengine.SetPOMProperties(ctx, i.Dir)
 }
 
 func updatePom(pomFile, name string) error {

--- a/common/moduleconfig/moduleconfig.go
+++ b/common/moduleconfig/moduleconfig.go
@@ -1,4 +1,4 @@
-package buildengine
+package moduleconfig
 
 import (
 	"fmt"

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -10,6 +10,10 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/TBD54566975/scaffolder"
+	"golang.org/x/mod/modfile"
+	"google.golang.org/protobuf/proto"
+
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/backend/schema/strcase"
@@ -17,9 +21,6 @@ import (
 	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
-	"github.com/TBD54566975/scaffolder"
-	"golang.org/x/mod/modfile"
-	"google.golang.org/protobuf/proto"
 )
 
 type externalModuleContext struct {

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -10,17 +10,16 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/TBD54566975/scaffolder"
-	"golang.org/x/mod/modfile"
-	"google.golang.org/protobuf/proto"
-
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/backend/schema/strcase"
-	"github.com/TBD54566975/ftl/buildengine"
+	"github.com/TBD54566975/ftl/common/moduleconfig"
 	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/scaffolder"
+	"golang.org/x/mod/modfile"
+	"google.golang.org/protobuf/proto"
 )
 
 type externalModuleContext struct {
@@ -67,7 +66,7 @@ func Build(ctx context.Context, moduleDir string, sch *schema.Schema) error {
 		ftlVersion = ftl.Version
 	}
 
-	config, err := buildengine.LoadModuleConfig(moduleDir)
+	config, err := moduleconfig.LoadModuleConfig(moduleDir)
 	if err != nil {
 		return fmt.Errorf("failed to load module config: %w", err)
 	}

--- a/go-runtime/encoding/encoding_test.go
+++ b/go-runtime/encoding/encoding_test.go
@@ -3,10 +3,9 @@ package encoding_test
 import (
 	"testing"
 
-	"github.com/alecthomas/assert/v2"
-
 	. "github.com/TBD54566975/ftl/go-runtime/encoding"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
+	"github.com/alecthomas/assert/v2"
 )
 
 func TestMarshal(t *testing.T) {
@@ -33,6 +32,7 @@ func TestMarshal(t *testing.T) {
 		{name: "OptionPtr", input: struct{ Option *ftl.Option[int] }{&somePtr}, expected: `{"option":42}`},
 		{name: "OptionStruct", input: struct{ Option ftl.Option[inner] }{ftl.Some(inner{"foo"})}, expected: `{"option":{"fooBar":"foo"}}`},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actual, err := Marshal(tt.input)


### PR DESCRIPTION
This is just a pure move, with no logic changes.