### PR TITLE
fix: make sure client is in context before building

### DIFF
--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"time"
 
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/buildengine"
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/rpc"
 )
 
 type buildCmd struct {
 	ModuleDir string `arg:"" help:"Directory containing ftl.toml" type:"existingdir" default:"."`
 }
 
-func (b *buildCmd) Run(ctx context.Context) error {
+func (b *buildCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
 	logger := log.FromContext(ctx)
 
 	startTime := time.Now()
@@ -23,6 +25,7 @@ func (b *buildCmd) Run(ctx context.Context) error {
 	}
 	logger.Infof("Building %s module '%s'", module.Language, module.Module)
 
+	ctx = rpc.ContextWithClient(ctx, client)
 	err = buildengine.Build(ctx, module)
 	if err != nil {
 		return err

--- a/cmd/ftl/cmd_deploy.go
+++ b/cmd/ftl/cmd_deploy.go
@@ -42,7 +42,7 @@ func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 	}
 
 	build := buildCmd{ModuleDir: d.ModuleDir}
-	err = build.Run(ctx)
+	err = build.Run(ctx, client)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Local dev and integration tests were failing with this error:

```sh
panic: no RPC client in context

goroutine 1 [running]:
github.com/TBD54566975/ftl/internal/rpc.ClientFromContext[...]({0x101cb1038, 0x140005171d0?})
	/Users/wesbillman/dev/ftl/internal/rpc/context.go:173 +0x88
github.com/TBD54566975/ftl/buildengine.buildGo({0x101cb1038, 0x140005171d0}, {{{0x14000156f60, 0x2a}, {0x140005206d8, 0x2}, {0x140005206dc, 0x4}, {0x140005206e0, 0x4}, ...}, ...})
	/Users/wesbillman/dev/ftl/buildengine/build_go.go:17 +0x34
....
```

@alecthomas I'm not sure if you had another idea for setting the client on the context here, but wanted to get things passing again, so did this for now :)