### PR TITLE
feat: implement the core build engine

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /frontend/src/protos/**/* linguist-generated=true
 go.sum linguist-generated=true
+go.work.sum linguist-generated=true

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,8 @@ generated_ftl_module.go
 dist/
 examples/**/go.work
 examples/**/go.work.sum
+testdata/**/go.work
+testdata/**/go.work.sum
 **/_ftl
 buildengine/.gitignore
+go.work*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,3 +132,5 @@ issues:
     - 'should have comment \(or a comment on this block\) or be unexported'
     - caseOrder
     - unused-parameter
+    - "^loopclosure:"
+    - 'shadow: declaration of "ctx" shadows declaration at'

--- a/backend/controller/dal/dal_test.go
+++ b/backend/controller/dal/dal_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -22,8 +21,7 @@ import (
 
 //nolint:maintidx
 func TestDAL(t *testing.T) {
-	logger := log.Configure(os.Stderr, log.Config{Level: log.Debug})
-	ctx := log.ContextWithLogger(context.Background(), logger)
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	conn := sqltest.OpenForTesting(ctx, t)
 	dal, err := New(ctx, conn)
 	assert.NoError(t, err)

--- a/backend/controller/scheduledtask/scheduledtask_test.go
+++ b/backend/controller/scheduledtask/scheduledtask_test.go
@@ -2,7 +2,6 @@ package scheduledtask
 
 import (
 	"context"
-	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -19,7 +18,7 @@ import (
 
 func TestCron(t *testing.T) {
 	t.Parallel()
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{Level: log.Debug}))
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	ctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 

--- a/backend/schema/module.go
+++ b/backend/schema/module.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -173,6 +174,15 @@ func (m *Module) ToProto() proto.Message {
 		Comments: m.Comments,
 		Decls:    declListToProto(m.Decls),
 	}
+}
+
+// ModuleFromProtoFile loads a module from the given proto-encoded file.
+func ModuleFromProtoFile(filename string) (*Module, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return ModuleFromBytes(data)
 }
 
 // ModuleFromProto converts a protobuf Module to a Module and validates it.

--- a/buildengine/build.go
+++ b/buildengine/build.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/common/moduleconfig"
+	"github.com/TBD54566975/ftl/internal/log"
 )
 
 // A Module is a ModuleConfig with its dependencies populated.
@@ -17,22 +19,25 @@ type Module struct {
 //
 // A [Module] includes the module configuration as well as its dependencies
 // extracted from source code.
-func LoadModule(dir string) (Module, error) {
+func LoadModule(ctx context.Context, dir string) (Module, error) {
 	config, err := moduleconfig.LoadModuleConfig(dir)
 	if err != nil {
 		return Module{}, err
 	}
-	return UpdateDependencies(config)
+	return UpdateDependencies(ctx, config)
 }
 
 // Build a module in the given directory given the schema and module config.
-func Build(ctx context.Context /*schema *schema.Schema, */, module Module) error {
+func Build(ctx context.Context, sch *schema.Schema, module Module) error {
+	logger := log.FromContext(ctx).Scope(module.Module)
+	ctx = log.ContextWithLogger(ctx, logger)
+	logger.Infof("Building module")
 	switch module.Language {
 	case "go":
-		return buildGo(ctx, module)
+		return buildGo(ctx, sch, module)
 
 	case "kotlin":
-		return buildKotlin(ctx, module)
+		return buildKotlin(ctx, sch, module)
 
 	default:
 		return fmt.Errorf("unknown language %q", module.Language)

--- a/buildengine/build_go.go
+++ b/buildengine/build_go.go
@@ -4,25 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"connectrpc.com/connect"
-
-	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
-	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/go-runtime/compile"
-	"github.com/TBD54566975/ftl/internal/rpc"
 )
 
-func buildGo(ctx context.Context, module Module) error {
-	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
-	resp, err := client.GetSchema(ctx, connect.NewRequest(&ftlv1.GetSchemaRequest{}))
-	if err != nil {
-		return err
-	}
-	sch, err := schema.FromProto(resp.Msg.Schema)
-	if err != nil {
-		return fmt.Errorf("failed to convert schema from proto: %w", err)
-	}
+func buildGo(ctx context.Context, sch *schema.Schema, module Module) error {
 	if err := compile.Build(ctx, module.Dir, sch); err != nil {
 		return fmt.Errorf("failed to build module: %w", err)
 	}

--- a/buildengine/build_kotlin.go
+++ b/buildengine/build_kotlin.go
@@ -9,11 +9,12 @@ import (
 	"github.com/beevik/etree"
 
 	"github.com/TBD54566975/ftl"
+	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
 )
 
-func buildKotlin(ctx context.Context, module Module) error {
+func buildKotlin(ctx context.Context, _ *schema.Schema, module Module) error {
 	logger := log.FromContext(ctx)
 
 	if err := SetPOMProperties(ctx, filepath.Join(module.Dir, "..")); err != nil {

--- a/buildengine/discover.go
+++ b/buildengine/discover.go
@@ -1,6 +1,7 @@
 package buildengine
 
 import (
+	"context"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -12,7 +13,7 @@ import (
 // DiscoverModules recursively loads all modules under the given directories.
 //
 // If no directories are provided, the current working directory is used.
-func DiscoverModules(dirs ...string) ([]moduleconfig.ModuleConfig, error) {
+func DiscoverModules(ctx context.Context, dirs ...string) ([]moduleconfig.ModuleConfig, error) {
 	if len(dirs) == 0 {
 		cwd, err := os.Getwd()
 		if err != nil {

--- a/buildengine/discover_test.go
+++ b/buildengine/discover_test.go
@@ -1,15 +1,18 @@
 package buildengine
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
 
 	"github.com/TBD54566975/ftl/common/moduleconfig"
+	"github.com/TBD54566975/ftl/internal/log"
 )
 
 func TestDiscoverModules(t *testing.T) {
-	modules, err := DiscoverModules("testdata/modules")
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	modules, err := DiscoverModules(ctx, "testdata/modules")
 	assert.NoError(t, err)
 	expected := []moduleconfig.ModuleConfig{
 		{

--- a/buildengine/engine.go
+++ b/buildengine/engine.go
@@ -1,0 +1,266 @@
+package buildengine
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/alecthomas/types/eventsource"
+	"github.com/alecthomas/types/pubsub"
+	"github.com/jpillora/backoff"
+	"golang.design/x/reflect"
+	"golang.org/x/exp/maps"
+	"golang.org/x/sync/errgroup"
+
+	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/TBD54566975/ftl/internal/rpc"
+)
+
+// Engine for building a set of modules.
+type Engine struct {
+	modules          map[string]Module
+	controllerSchema *eventsource.EventSource[map[string]*schema.Module]
+	updateSchema     *pubsub.Topic[*schema.Module]
+	cancel           func()
+}
+
+// New constructs a new [Engine].
+//
+// Completely offline builds are possible if the full dependency graph is
+// locally available. If the FTL controller is available, it will be used to
+// pull in missing schemas.
+func New(ctx context.Context, client ftlv1connect.ControllerServiceClient) (*Engine, error) {
+	engine := &Engine{
+		modules:          map[string]Module{},
+		controllerSchema: eventsource.New[map[string]*schema.Module](),
+		updateSchema:     pubsub.New[*schema.Module](),
+	}
+	engine.controllerSchema.Store(map[string]*schema.Module{
+		"builtin": schema.Builtins(),
+	})
+	ctx, cancel := context.WithCancel(ctx)
+	engine.cancel = cancel
+	schemaSync := engine.startSchemaSync(ctx)
+	if client == nil {
+		return engine, nil
+	}
+	go rpc.RetryStreamingServerStream(ctx, backoff.Backoff{Max: time.Second}, &ftlv1.PullSchemaRequest{}, client.PullSchema, schemaSync)
+	return engine, nil
+}
+
+// Sync module schema changes from the FTL controller, as well as from manual
+// updates, and merge them into a single schema map.
+func (e *Engine) startSchemaSync(ctx context.Context) func(ctx context.Context, msg *ftlv1.PullSchemaResponse) error {
+	mu := sync.Mutex{}
+	schemas := map[string]*schema.Module{}
+
+	schemaUpdates := e.updateSchema.SubscribeSync(nil)
+
+	// Update the event source with new schemas manually added to the Engine.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case update := <-schemaUpdates:
+				mu.Lock()
+				schemas[update.Msg.Name] = update.Msg
+				clone := reflect.DeepCopy(schemas)
+				mu.Unlock()
+				e.controllerSchema.PublishSync(clone)
+				update.Ack()
+			}
+		}
+	}()
+	// Sync module schema changes from the controller into the schema event source.
+	return func(ctx context.Context, msg *ftlv1.PullSchemaResponse) error {
+		var clone map[string]*schema.Module
+		switch msg.ChangeType {
+		case ftlv1.DeploymentChangeType_DEPLOYMENT_ADDED, ftlv1.DeploymentChangeType_DEPLOYMENT_CHANGED:
+			sch, err := schema.ModuleFromProto(msg.Schema)
+			if err == nil {
+				return err
+			}
+			mu.Lock()
+			schemas[sch.Name] = sch
+			clone = reflect.DeepCopy(schemas)
+			mu.Unlock()
+
+		case ftlv1.DeploymentChangeType_DEPLOYMENT_REMOVED:
+			mu.Lock()
+			delete(schemas, msg.ModuleName)
+			clone = reflect.DeepCopy(schemas)
+			mu.Unlock()
+		}
+		e.controllerSchema.PublishSync(clone)
+		return nil
+	}
+}
+
+// Close stops the Engine's schema sync.
+func (e *Engine) Close() error {
+	e.cancel()
+	return nil
+}
+
+// Graph returns the dependency graph for the given modules.
+//
+// If no modules are provided, the entire graph is returned. An error is returned if
+// any dependencies are missing.
+func (e *Engine) Graph(modules ...string) (map[string][]string, error) {
+	out := map[string][]string{}
+	if len(modules) == 0 {
+		modules = maps.Keys(e.modules)
+	}
+	for _, name := range modules {
+		if err := e.buildGraph(name, out); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (e *Engine) buildGraph(name string, out map[string][]string) error {
+	var deps []string
+	if module, ok := e.modules[name]; ok {
+		deps = module.Dependencies
+	} else if sch, ok := e.controllerSchema.Load()[name]; ok {
+		deps = sch.Imports()
+	} else {
+		return fmt.Errorf("module %q not found", name)
+	}
+	out[name] = deps
+	for _, dep := range deps {
+		if err := e.buildGraph(dep, out); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Add a directory of local modules to the engine.
+//
+// Existing modules will be replaced. A local module will take precedence over
+// any schema from the FTL cluster, building as required.
+func (e *Engine) Add(ctx context.Context, dir string) error {
+	configs, err := DiscoverModules(ctx, dir)
+	if err != nil {
+		return err
+	}
+	modules, err := UpdateAllDependencies(ctx, configs...)
+	if err != nil {
+		return err
+	}
+	for _, module := range modules {
+		e.modules[module.Module] = module
+	}
+	return nil
+}
+
+// Import manually imports a schema for a module as if it were retrieved from
+// the FTL controller.
+func (e *Engine) Import(ctx context.Context, schema *schema.Module) {
+	e.updateSchema.PublishSync(schema)
+}
+
+// Build attempts to build the specified modules, or all local modules if none are provided.
+func (e *Engine) Build(ctx context.Context, modules ...string) error {
+	mustBuild := map[string]bool{}
+	if len(modules) == 0 {
+		modules = maps.Keys(e.modules)
+	}
+	for _, name := range modules {
+		module, ok := e.modules[name]
+		if !ok {
+			return fmt.Errorf("module %q not found", module)
+		}
+		// Update dependencies before building.
+		var err error
+		module, err = UpdateDependencies(ctx, module.ModuleConfig)
+		if err != nil {
+			return err
+		}
+		e.modules[name] = module
+		mustBuild[name] = true
+	}
+	graph, err := e.Graph(modules...)
+	if err != nil {
+		return err
+	}
+	built := map[string]*schema.Module{
+		"builtin": schema.Builtins(),
+	}
+	topology := TopologicalSort(graph)
+	for _, group := range topology {
+		// Collect schemas to be inserted into "built" map for subsequent groups.
+		schemas := make(chan *schema.Module, len(group))
+		wg, ctx := errgroup.WithContext(ctx)
+		wg.SetLimit(runtime.NumCPU())
+		for _, name := range group {
+			wg.Go(func() error {
+				if mustBuild[name] {
+					return e.build(ctx, name, built, schemas)
+				}
+				return e.mustSchema(ctx, name, built, schemas)
+			})
+		}
+		err := wg.Wait()
+		if err != nil {
+			return err
+		}
+		// Now this group is built, collect al the schemas.
+		close(schemas)
+		for sch := range schemas {
+			built[sch.Name] = sch
+		}
+	}
+	return nil
+}
+
+// Publish either the schema from the FTL controller, or from a local build.
+func (e *Engine) mustSchema(ctx context.Context, name string, built map[string]*schema.Module, schemas chan<- *schema.Module) error {
+	if sch, ok := e.controllerSchema.Load()[name]; ok {
+		schemas <- sch
+		return nil
+	}
+	return e.build(ctx, name, built, schemas)
+}
+
+// Build a module and publish its schema.
+//
+// Assumes that all dependencies have been built and are available in "built".
+func (e *Engine) build(ctx context.Context, name string, built map[string]*schema.Module, schemas chan<- *schema.Module) error {
+	combined := map[string]*schema.Module{}
+	gatherShemas(built, e.modules, e.modules[name], combined)
+	sch := &schema.Schema{Modules: maps.Values(combined)}
+	module := e.modules[name]
+	err := Build(ctx, sch, module)
+	if err != nil {
+		return err
+	}
+	moduleSchema, err := schema.ModuleFromProtoFile(filepath.Join(module.Dir, module.DeployDir, module.Schema))
+	if err != nil {
+		return fmt.Errorf("load schema %s: %w", name, err)
+	}
+	schemas <- moduleSchema
+	return nil
+}
+
+// Construct a combined schema for a module and its transitive dependencies.
+func gatherShemas(
+	moduleSchemas map[string]*schema.Module,
+	modules map[string]Module,
+	module Module,
+	out map[string]*schema.Module,
+) {
+	for _, dep := range modules[module.Module].Dependencies {
+		out[dep] = moduleSchemas[dep]
+		gatherShemas(moduleSchemas, modules, modules[dep], out)
+	}
+}

--- a/buildengine/engine_test.go
+++ b/buildengine/engine_test.go
@@ -1,0 +1,62 @@
+package buildengine_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/TBD54566975/ftl/buildengine"
+	"github.com/TBD54566975/ftl/internal/log"
+)
+
+func TestEngine(t *testing.T) {
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	engine, err := buildengine.New(ctx, nil)
+	assert.NoError(t, err)
+
+	defer engine.Close()
+
+	// Explicitly add only two of the modules.
+	err = engine.Add(ctx, "testdata/modules/alpha")
+	assert.NoError(t, err)
+	err = engine.Add(ctx, "testdata/modules/another")
+	assert.NoError(t, err)
+
+	// Import the schema from the third module, simulating a remote schema.
+	otherSchema := &schema.Module{
+		Name: "other",
+		Decls: []schema.Decl{
+			&schema.Data{
+				Name: "EchoRequest",
+				Fields: []*schema.Field{
+					{Name: "name", Type: &schema.Optional{Type: &schema.String{}}, JSONAlias: "name"},
+				},
+			},
+			&schema.Data{
+				Name: "EchoResponse",
+				Fields: []*schema.Field{
+					{Name: "message", Type: &schema.String{}, JSONAlias: "message"},
+				},
+			},
+			&schema.Verb{
+				Name:     "echo",
+				Request:  &schema.DataRef{Module: "other", Name: "EchoRequest"},
+				Response: &schema.DataRef{Module: "other", Name: "EchoResponse"},
+			},
+		},
+	}
+	engine.Import(ctx, otherSchema)
+
+	expected := map[string][]string{
+		"alpha":   {"another", "other"},
+		"another": {},
+		"other":   {},
+	}
+	graph, err := engine.Graph()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, graph)
+	err = engine.Build(ctx, "alpha")
+	assert.NoError(t, err)
+}

--- a/buildengine/testdata/modules/alpha/alpha.go
+++ b/buildengine/testdata/modules/alpha/alpha.go
@@ -20,6 +20,6 @@ type EchoResponse struct {
 
 //ftl:verb
 func Echo(ctx context.Context, req EchoRequest) (EchoResponse, error) {
-	other.Other()
+	ftl.Call(ctx, other.Echo, other.EchoRequest{})
 	return EchoResponse{Message: fmt.Sprintf("Hello, %s!", req.Name.Default("anonymous"))}, nil
 }

--- a/buildengine/testdata/modules/alpha/go.mod
+++ b/buildengine/testdata/modules/alpha/go.mod
@@ -1,4 +1,4 @@
-module ftl/root
+module ftl/alpha
 
 go 1.22.0
 

--- a/buildengine/testdata/modules/alpha/pkg/pkg.go
+++ b/buildengine/testdata/modules/alpha/pkg/pkg.go
@@ -1,7 +1,12 @@
 package pkg
 
-import "ftl/another"
+import (
+	"context"
+	"ftl/another"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl"
+)
 
 func Pkg() {
-    another.Another()
+	ftl.Call(context.Background(), another.Echo, another.EchoRequest{})
 }

--- a/buildengine/topological_test.go
+++ b/buildengine/topological_test.go
@@ -4,47 +4,21 @@ import (
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-
-	"github.com/TBD54566975/ftl/common/moduleconfig"
 )
 
-func TestBuildOrder(t *testing.T) {
-	modules := []Module{
-		{
-			ModuleConfig: moduleconfig.ModuleConfig{Module: "alpha"},
-			Dependencies: []string{"beta", "gamma"},
-		},
-		{
-			ModuleConfig: moduleconfig.ModuleConfig{Module: "beta"},
-			Dependencies: []string{"kappa"},
-		},
-		{
-			ModuleConfig: moduleconfig.ModuleConfig{Module: "gamma"},
-			Dependencies: []string{"kappa"},
-		},
-		{
-			ModuleConfig: moduleconfig.ModuleConfig{Module: "kappa"},
-		},
-		{
-			ModuleConfig: moduleconfig.ModuleConfig{Module: "delta"},
-		},
+func TestTopologicalSort(t *testing.T) {
+	graph := map[string][]string{
+		"alpha": {"beta", "gamma"},
+		"beta":  {"kappa"},
+		"gamma": {"kappa"},
+		"kappa": {},
+		"delta": {},
 	}
-
-	graph, err := BuildOrder(modules)
-	assert.NoError(t, err)
-
-	expected := [][]Module{
-		{
-			{ModuleConfig: moduleconfig.ModuleConfig{Module: "delta"}},
-			{ModuleConfig: moduleconfig.ModuleConfig{Module: "kappa"}},
-		},
-		{
-			{ModuleConfig: moduleconfig.ModuleConfig{Module: "beta"}, Dependencies: []string{"kappa"}},
-			{ModuleConfig: moduleconfig.ModuleConfig{Module: "gamma"}, Dependencies: []string{"kappa"}},
-		},
-		{
-			{ModuleConfig: moduleconfig.ModuleConfig{Module: "alpha"}, Dependencies: []string{"beta", "gamma"}},
-		},
+	topo := TopologicalSort(graph)
+	expected := [][]string{
+		{"delta", "kappa"},
+		{"beta", "gamma"},
+		{"alpha"},
 	}
-	assert.Equal(t, expected, graph)
+	assert.Equal(t, expected, topo)
 }

--- a/buildengine/watch.go
+++ b/buildengine/watch.go
@@ -56,7 +56,7 @@ func Watch(ctx context.Context, period time.Duration, dirs ...string) *pubsub.To
 			}
 
 			// Find all modules in the given directories.
-			moduleConfigs, err := DiscoverModules(dirs...)
+			moduleConfigs, err := DiscoverModules(ctx, dirs...)
 			if err != nil {
 				logger.Tracef("error discovering modules: %v", err)
 				continue
@@ -94,7 +94,7 @@ func Watch(ctx context.Context, period time.Duration, dirs ...string) *pubsub.To
 					continue
 				}
 
-				module, err := UpdateDependencies(config)
+				module, err := UpdateDependencies(ctx, config)
 				if err != nil {
 					continue
 				}

--- a/buildengine/watch_test.go
+++ b/buildengine/watch_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestWatch(t *testing.T) {
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{}))
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
 
 	dir := t.TempDir()
 

--- a/cmd/ftl/cmd_deploy.go
+++ b/cmd/ftl/cmd_deploy.go
@@ -41,8 +41,8 @@ func (d *deployCmd) Run(ctx context.Context, client ftlv1connect.ControllerServi
 		return fmt.Errorf("no deploy paths defined in config")
 	}
 
-	build := buildCmd{ModuleDir: d.ModuleDir}
-	err = build.Run(ctx, client)
+	build := buildCmd{Dirs: []string{d.ModuleDir}}
+	err = build.Run(ctx)
 	if err != nil {
 		return err
 	}

--- a/common/moduleconfig/moduleconfig.go
+++ b/common/moduleconfig/moduleconfig.go
@@ -18,16 +18,22 @@ type ModuleKotlinConfig struct{}
 //
 // Module config files are currently TOML.
 type ModuleConfig struct {
-	Dir string `toml:"-"` // Directory the module config was loaded from.
+	// Dir is the root of the module.
+	Dir string `toml:"-"`
 
-	Language  string   `toml:"language"`
-	Realm     string   `toml:"realm"`
-	Module    string   `toml:"module"`
-	Build     string   `toml:"build"`
-	Deploy    []string `toml:"deploy"`
-	DeployDir string   `toml:"deploy-dir"`
-	Schema    string   `toml:"schema"`
-	Watch     []string `toml:"watch"`
+	Language string `toml:"language"`
+	Realm    string `toml:"realm"`
+	Module   string `toml:"module"`
+	// Build is the command to build the module.
+	Build string `toml:"build"`
+	// Deploy is the list of files to deploy relative to the DeployDir.
+	Deploy []string `toml:"deploy"`
+	// DeployDir is the directory to deploy from, relative to the module directory.
+	DeployDir string `toml:"deploy-dir"`
+	// Schema is the name of the schema file relative to the DeployDir.
+	Schema string `toml:"schema"`
+	// Watch is the list of files to watch for changes.
+	Watch []string `toml:"watch"`
 
 	Go     ModuleGoConfig     `toml:"go,optional"`
 	Kotlin ModuleKotlinConfig `toml:"kotlin,optional"`

--- a/examples/go/echo/go.mod
+++ b/examples/go/echo/go.mod
@@ -12,7 +12,7 @@ require (
 	connectrpc.com/otelconnect v0.7.0 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
-	github.com/alecthomas/types v0.11.0 // indirect
+	github.com/alecthomas/types v0.12.1 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
@@ -35,7 +35,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.23.1 // indirect
 	golang.design/x/reflect v0.0.0-20220504060917-02c43be63f3b // indirect
 	golang.org/x/crypto v0.19.0 // indirect
-	golang.org/x/exp v0.0.0-20240213143201-ec583247a57a // indirect
+	golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 // indirect
 	golang.org/x/mod v0.15.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect

--- a/examples/go/echo/go.sum
+++ b/examples/go/echo/go.sum
@@ -12,8 +12,8 @@ github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6i
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/alecthomas/types v0.11.0 h1:UybdMsCk9Vdb0j/cuNL6SfiB5w/HgtKGuKi9on8dKt0=
-github.com/alecthomas/types v0.11.0/go.mod h1:fIOGnLeeUJXe1AAVofQmMaEMWLxY9bK4QxTLGIo30PA=
+github.com/alecthomas/types v0.12.1 h1:W2GwVQUv5kND435RyLS4G6rrJQUbbY67E6l0JV2wEHU=
+github.com/alecthomas/types v0.12.1/go.mod h1:fIOGnLeeUJXe1AAVofQmMaEMWLxY9bK4QxTLGIo30PA=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/bool64/dev v0.2.31 h1:OS57EqYaYe2M/2bw9uhDCIFiZZwywKFS/4qMLN6JUmQ=
@@ -104,8 +104,8 @@ golang.design/x/reflect v0.0.0-20220504060917-02c43be63f3b h1:lkOPTy76R9NZ6FeDQW
 golang.design/x/reflect v0.0.0-20220504060917-02c43be63f3b/go.mod h1:QXG482h3unP32W/YwIPOc+09bvY447B7T+iLjC/JPcA=
 golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/exp v0.0.0-20240213143201-ec583247a57a h1:HinSgX1tJRX3KsL//Gxynpw5CTOAIPhgL4W8PNiIpVE=
-golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
+golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/mod v0.15.0 h1:SernR4v+D55NyBH2QiEQrlBAnj1ECL6AGrA5+dPaMY8=
 golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -3,12 +3,11 @@ package ftltest
 
 import (
 	"context"
-	"os"
 
 	"github.com/TBD54566975/ftl/internal/log"
 )
 
 // Context suitable for use in testing FTL verbs.
 func Context() context.Context {
-	return log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{Level: log.Trace}))
+	return log.ContextWithNewDefaultLogger(context.Background())
 }

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/alecthomas/kong v0.8.1
 	github.com/alecthomas/kong-toml v0.1.0
 	github.com/alecthomas/participle/v2 v2.1.1
-	github.com/alecthomas/types v0.11.0
+	github.com/alecthomas/types v0.12.1
 	github.com/amacneil/dbmate/v2 v2.12.0
 	github.com/beevik/etree v1.3.0
 	github.com/bmatcuk/doublestar/v4 v4.6.1

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6i
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
 github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/alecthomas/types v0.11.0 h1:UybdMsCk9Vdb0j/cuNL6SfiB5w/HgtKGuKi9on8dKt0=
-github.com/alecthomas/types v0.11.0/go.mod h1:fIOGnLeeUJXe1AAVofQmMaEMWLxY9bK4QxTLGIo30PA=
+github.com/alecthomas/types v0.12.1 h1:W2GwVQUv5kND435RyLS4G6rrJQUbbY67E6l0JV2wEHU=
+github.com/alecthomas/types v0.12.1/go.mod h1:fIOGnLeeUJXe1AAVofQmMaEMWLxY9bK4QxTLGIo30PA=
 github.com/alessio/shellescape v1.4.2 h1:MHPfaU+ddJ0/bYWpgIeUnQUqKrlJ1S7BfEYPM4uEoM0=
 github.com/alessio/shellescape v1.4.2/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/amacneil/dbmate/v2 v2.12.0 h1:2F/Fu/lScBhsQ8UgPg/UPM4QtBBpieZWntDJYaAkGHo=
@@ -217,8 +217,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/exp v0.0.0-20240213143201-ec583247a57a h1:HinSgX1tJRX3KsL//Gxynpw5CTOAIPhgL4W8PNiIpVE=
-golang.org/x/exp v0.0.0-20240213143201-ec583247a57a/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/exp v0.0.0-20240222234643-814bf88cf225 h1:LfspQV/FYTatPTr/3HzIcmiUFH7PGP+OQ6mgDYo3yuQ=
 golang.org/x/exp v0.0.0-20240222234643-814bf88cf225/go.mod h1:CxmFvTBINI24O/j8iY7H1xHzx2i4OsyguNBmN/uPtqc=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=

--- a/internal/log/api.go
+++ b/internal/log/api.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"context"
+	"os"
 )
 
 type Sink interface {
@@ -62,4 +63,8 @@ func FromContext(ctx context.Context) *Logger {
 // FromContext to retrieve it.
 func ContextWithLogger(ctx context.Context, logger *Logger) context.Context {
 	return context.WithValue(ctx, contextKey{}, logger)
+}
+
+func ContextWithNewDefaultLogger(ctx context.Context) context.Context {
+	return ContextWithLogger(ctx, Configure(os.Stderr, Config{Level: Debug}))
 }

--- a/internal/rpc/context.go
+++ b/internal/rpc/context.go
@@ -76,7 +76,7 @@ func WithRequestName(ctx context.Context, key model.RequestName) context.Context
 }
 
 func DefaultClientOptions(level log.Level) []connect.ClientOption {
-	interceptors := []connect.Interceptor{MetadataInterceptor(level), otelInterceptor()}
+	interceptors := []connect.Interceptor{MetadataInterceptor(log.Debug), otelInterceptor()}
 	if ftl.Version != "dev" {
 		interceptors = append(interceptors, versionInterceptor{})
 	}
@@ -87,7 +87,7 @@ func DefaultClientOptions(level log.Level) []connect.ClientOption {
 }
 
 func DefaultHandlerOptions() []connect.HandlerOption {
-	interceptors := []connect.Interceptor{MetadataInterceptor(log.Error), otelInterceptor()}
+	interceptors := []connect.Interceptor{MetadataInterceptor(log.Debug), otelInterceptor()}
 	if ftl.Version != "dev" {
 		interceptors = append(interceptors, versionInterceptor{})
 	}
@@ -103,9 +103,11 @@ func otelInterceptor() connect.Interceptor {
 }
 
 // MetadataInterceptor propagates FTL metadata through servers and clients.
-func MetadataInterceptor(level log.Level) connect.Interceptor {
+//
+// "errorLevel" is the level at which errors will be logged
+func MetadataInterceptor(errorLevel log.Level) connect.Interceptor {
 	return &metadataInterceptor{
-		errorLevel: level,
+		errorLevel: errorLevel,
 	}
 }
 


### PR DESCRIPTION
This brings all of the existing buildengine utilities together into a single system that unifies schema changes from the FTL controller with local modules, supporting both online and completely offline builds.

Builds are run in parallel, with dependencies preferencing schemas from other local modules first, then falling back on schemas from the FTL controller.

Dynamic module watching will be implemented in a followup.

Fixes #961 
Fixes #985