### PR TITLE
feat: run ftl serve as part of ftl dev

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -25,6 +25,7 @@ import (
 	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/rpc"
 	"github.com/TBD54566975/ftl/internal/slices"
 )
 
@@ -41,8 +42,9 @@ type serveCmd struct {
 
 const ftlContainerName = "ftl-db-1"
 
-func (s *serveCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {
+func (s *serveCmd) Run(ctx context.Context) error {
 	logger := log.FromContext(ctx)
+	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
 
 	if s.Background {
 		runInBackground(logger)


### PR DESCRIPTION
Fixes #979 

New help exposes embedded `serve-` flags:
```sh
ftl dev --help

Usage: ftl dev [<base-dir>]

Watch a directory for FTL modules and hot reload them.

Arguments:
  [<base-dir>]    Directory to watch for FTL modules

Flags:
  -h, --help           Show context-sensitive help.
      --version        Show version.
      --config=FILE    Load configuration from TOML file.
      --endpoint=http://127.0.0.1:8892
                       FTL endpoint to bind/connect to ($FTL_ENDPOINT).
      --authenticators=HOST=EXE,…
                       Authenticators to use for FTL endpoints ($FTL_AUTHENTICATORS).

Logging:
  --log-level=info    Log level ($LOG_LEVEL).
  --log-json          Log in JSON format ($LOG_JSON).

Command flags:
      --watch=500ms            Watch template directory at this frequency and regenerate
                               on change.
      --failure-delay=500ms    Delay before retrying a failed deploy.
      --reconnect-delay=1s     Delay before attempting to reconnect to FTL.
      --exit-after-deploy      Exit after all modules are deployed successfully.
      --no-serve               Do not start the FTL server.
      --serve-bind=http://localhost:8892
                               Starting endpoint to bind to and advertise to. Each
                               controller and runner will increment the port by 1
      --serve-allow-origins=SERVE-ALLOW-ORIGINS,...
                               Allow CORS requests to ingress endpoints from these origins
                               ($FTL_CONTROLLER_ALLOW_ORIGIN).
      --serve-db-port=54320    Port to use for the database.
      --serve-recreate         Recreate the database even if it already exists.
  -c, --serve-controllers=1    Number of controllers to start.
  -r, --serve-runners=0        Number of runners to start.
      --serve-background       Run in the background.
      --serve-stop             Stop the running FTL instance.
```

Dev with server and flags
```sh
ftl dev examples/go --serve-recreate

info: Starting FTL with 1 controller(s) and 0 runner(s)
warn: Detected change in +/Users/wesbillman/dev/ftl/examples/go/echo/echo.go, rebuilding...
error: Error deploying module /Users/wesbillman/dev/ftl/examples/go/echo. Will retry: module "time" not found
warn: Detected change in +/Users/wesbillman/dev/ftl/examples/go/time/time.go, rebuilding...
info:time: Building module
info:controller0: Web console available at: http://localhost:5173
info: Preparing module 'time' for deployment
info: Successfully created deployment time-e0368491b5
info:echo: Building module
info: Preparing module 'echo' for deployment
info: Successfully created deployment echo-092543e753
```

Dev without server
```sh
ftl dev examples/go --no-serve

warn: Detected change in +/Users/wesbillman/dev/ftl/examples/go/echo/go.sum, rebuilding...
error: Error deploying module /Users/wesbillman/dev/ftl/examples/go/echo. Will retry: module "time" not found
warn: Detected change in +/Users/wesbillman/dev/ftl/examples/go/time/go.mod, rebuilding...
info:time: Building module
info: Preparing module 'time' for deployment
error: Error deploying module /Users/wesbillman/dev/ftl/examples/go/time. Will retry: unavailable: dial tcp [::1]:8892: connect: connection refused
info:time: Building module
info: Preparing module 'time' for deployment
error: Error deploying module /Users/wesbillman/dev/ftl/examples/go/time. Will retry: unavailable: dial tcp [::1]:8892: connect: connection refused
error: Error deploying module /Users/wesbillman/dev/ftl/examples/go/echo. Will retry: module "time" not found
```
