### PR TITLE
fix: template directories must be ignored by Go

### DIFF
--- a/kotlin-runtime/external-module-template/go.mod
+++ b/kotlin-runtime/external-module-template/go.mod
@@ -1,0 +1,3 @@
+module ignore
+
+go 1.22.0


### PR DESCRIPTION
`|` is not supported in filenames retrieved by the Go toolchain, as Windows doesn't allow it in filenames. As we're zipping these files, this isn't a concern for us, but it's still prevented by Go. To work around this we create a dummy `go.mod` file which Go interprets as a separate module and thus ignores.

Ask me how I figured this out?

Fixes #991