### PR TITLE
feat(go-runtime): use new configuration/secret system

### DIFF
--- a/Bitfile
+++ b/Bitfile
@@ -111,6 +111,7 @@ kotlin-runtime/external-module-template.zip: kotlin-runtime/external-module-temp
   -clean
 
 %{KT_RUNTIME_OUT}: %{KT_RUNTIME_IN} %{PROTO_IN}
+  # TODO: Figure out how to make Maven build completely offline. Bizarrely "-o" does not do this.
   build:
     mvn -B -N install
     mvn -B -pl :ftl-runtime install

--- a/backend/controller/scaling/localscaling/devel.go
+++ b/backend/controller/scaling/localscaling/devel.go
@@ -16,8 +16,8 @@ var templateDirOnce sync.Once
 
 func templateDir(ctx context.Context) string {
 	templateDirOnce.Do(func() {
-		cmd := exec.Command(ctx, log.Debug, internal.GitRoot(""), "bit", "build/template/ftl/jars/ftl-runtime.jar")
-		err := cmd.Run()
+		// TODO: Figure out how to make maven build offline
+		err := exec.Command(ctx, log.Debug, internal.GitRoot(""), "bit", "build/template/ftl/jars/ftl-runtime.jar").RunBuffered(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -27,6 +27,7 @@ import (
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/common/plugin"
+	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/download"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/model"
@@ -218,6 +219,7 @@ func (s *Service) Deploy(ctx context.Context, req *connect.Request[ftlv1.DeployR
 		ftlv1connect.NewVerbServiceClient,
 		plugin.WithEnvars(
 			"FTL_ENDPOINT="+s.config.ControllerEndpoint.String(),
+			"FTL_CONFIG="+filepath.Join(internal.GitRoot(""), "ftl-project.toml"),
 			"FTL_OBSERVABILITY_ENDPOINT="+s.config.ControllerEndpoint.String(),
 		),
 	)

--- a/cmd/ftl/cmd_secret.go
+++ b/cmd/ftl/cmd_secret.go
@@ -7,39 +7,19 @@ import (
 	"io"
 	"os"
 
-	"github.com/alecthomas/kong"
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
 
 	"github.com/TBD54566975/ftl/common/configuration"
 )
 
-type mutableSecretProviderMixin struct {
-	configuration.InlineProvider
-	configuration.KeychainProvider
-	configuration.EnvarProvider[configuration.EnvarTypeSecrets]
-	configuration.OnePasswordProvider
-}
-
-func (s *mutableSecretProviderMixin) newSecretsManager(ctx context.Context, resolver configuration.Resolver) (*configuration.Manager, error) {
-	return configuration.New(ctx, resolver, []configuration.Provider{
-		s.InlineProvider, s.KeychainProvider, s.EnvarProvider, s.OnePasswordProvider,
-	})
-}
-
 type secretCmd struct {
-	configuration.ProjectConfigResolver[configuration.FromSecrets]
+	configuration.DefaultSecretsMixin
 
 	List  secretListCmd  `cmd:"" help:"List secrets."`
 	Get   secretGetCmd   `cmd:"" help:"Get a secret."`
 	Set   secretSetCmd   `cmd:"" help:"Set a secret."`
 	Unset secretUnsetCmd `cmd:"" help:"Unset a secret."`
-}
-
-func (s *secretCmd) newSecretsManager(ctx context.Context) (*configuration.Manager, error) {
-	mp := mutableSecretProviderMixin{}
-	_ = kong.ApplyDefaults(&mp)
-	return mp.newSecretsManager(ctx, s.ProjectConfigResolver)
 }
 
 func (s *secretCmd) Help() string {
@@ -58,7 +38,7 @@ type secretListCmd struct {
 }
 
 func (s *secretListCmd) Run(ctx context.Context, scmd *secretCmd) error {
-	sm, err := scmd.newSecretsManager(ctx)
+	sm, err := scmd.NewSecretsManager(ctx)
 	if err != nil {
 		return err
 	}
@@ -104,7 +84,7 @@ Returns a JSON-encoded secret value.
 }
 
 func (s *secretGetCmd) Run(ctx context.Context, scmd *secretCmd) error {
-	sm, err := scmd.newSecretsManager(ctx)
+	sm, err := scmd.NewSecretsManager(ctx)
 	if err != nil {
 		return err
 	}
@@ -124,14 +104,12 @@ func (s *secretGetCmd) Run(ctx context.Context, scmd *secretCmd) error {
 }
 
 type secretSetCmd struct {
-	mutableSecretProviderMixin
-
 	JSON bool              `help:"Assume input value is JSON."`
 	Ref  configuration.Ref `arg:"" help:"Secret reference in the form [<module>.]<name>."`
 }
 
 func (s *secretSetCmd) Run(ctx context.Context, scmd *secretCmd) error {
-	sm, err := s.newSecretsManager(ctx, scmd.ProjectConfigResolver)
+	sm, err := scmd.NewSecretsManager(ctx)
 	if err != nil {
 		return err
 	}
@@ -168,13 +146,11 @@ func (s *secretSetCmd) Run(ctx context.Context, scmd *secretCmd) error {
 }
 
 type secretUnsetCmd struct {
-	mutableSecretProviderMixin
-
 	Ref configuration.Ref `arg:"" help:"Secret reference in the form [<module>.]<name>."`
 }
 
 func (s *secretUnsetCmd) Run(ctx context.Context, scmd *secretCmd) error {
-	sm, err := s.newSecretsManager(ctx, scmd.ProjectConfigResolver)
+	sm, err := scmd.NewSecretsManager(ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -32,6 +32,7 @@ import (
 type serveCmd struct {
 	Bind           *url.URL      `help:"Starting endpoint to bind to and advertise to. Each controller and runner will increment the port by 1" default:"http://localhost:8892"`
 	AllowOrigins   []*url.URL    `help:"Allow CORS requests to ingress endpoints from these origins." env:"FTL_CONTROLLER_ALLOW_ORIGIN"`
+	NoConsole      bool          `help:"Disable the console."`
 	DBPort         int           `help:"Port to use for the database." default:"54320"`
 	Recreate       bool          `help:"Recreate the database even if it already exists." default:"false"`
 	Controllers    int           `short:"c" help:"Number of controllers to start." default:"1"`
@@ -98,6 +99,7 @@ func (s *serveCmd) Run(ctx context.Context) error {
 			Bind:         controllerAddresses[i],
 			DSN:          dsn,
 			AllowOrigins: s.AllowOrigins,
+			NoConsole:    s.NoConsole,
 		}
 		if err := kong.ApplyDefaults(&config); err != nil {
 			return err

--- a/common/configuration/1password.go
+++ b/common/configuration/1password.go
@@ -17,9 +17,9 @@ type OnePasswordProvider struct {
 	OnePassword bool `name:"op" help:"Write 1Password secret references - does not write to 1Password." group:"Provider:" xor:"configwriter"`
 }
 
-var _ MutableProvider = OnePasswordProvider{}
+var _ MutableProvider[Secrets] = OnePasswordProvider{}
 
-func (o OnePasswordProvider) Key() string                               { return "op" }
+func (o OnePasswordProvider) Key() Secrets                              { return "op" }
 func (o OnePasswordProvider) Delete(ctx context.Context, ref Ref) error { return nil }
 
 func (o OnePasswordProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {

--- a/common/configuration/api.go
+++ b/common/configuration/api.go
@@ -1,4 +1,17 @@
-// Package configuration is a generic configuration and secret management API.
+// Package configuration is the FTL configuration and secret management API.
+//
+// The full design is documented [here].
+//
+// A [Manager] is the high-level interface to storing, listing, and retrieving
+// secrets and configuration. A [Resolver] is the next layer, mapping
+// names to a storage location key such as environment variables, keychain, etc.
+// The [Provider] is the final layer, responsible for actually storing and
+// retrieving values in concrete storage.
+//
+// A constructed [Manager] and its providers are parametric on either secrets or
+// configuration and thus cannot be used interchangeably.
+//
+// [here]: https://hackmd.io/@ftl/S1e6YVEuq6
 package configuration
 
 import (
@@ -70,14 +83,14 @@ type Resolver interface {
 }
 
 // Provider is a generic interface for storing and retrieving configuration and secrets.
-type Provider interface {
-	Key() string
+type Provider[R Role] interface {
+	Key() R
 	Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error)
 }
 
 // A MutableProvider is a Provider that can update configuration.
-type MutableProvider interface {
-	Provider
+type MutableProvider[R Role] interface {
+	Provider[R]
 	// Writer returns true if this provider should be used to store configuration.
 	//
 	// Only one provider should return true.

--- a/common/configuration/context.go
+++ b/common/configuration/context.go
@@ -1,0 +1,37 @@
+package configuration
+
+import "context"
+
+type contextKeySecrets struct{}
+
+type contextKeyConfig struct{}
+
+// ContextWithSecrets adds a secrets manager to the given context.
+func ContextWithSecrets(ctx context.Context, secretsManager *Manager[Secrets]) context.Context {
+	return context.WithValue(ctx, contextKeySecrets{}, secretsManager)
+}
+
+// SecretsFromContext retrieves the secrets configuration.Manager previously
+// added to the context with [ContextWithConfig].
+func SecretsFromContext(ctx context.Context) *Manager[Secrets] {
+	s, ok := ctx.Value(contextKeySecrets{}).(*Manager[Secrets])
+	if !ok {
+		panic("no secrets manager in context")
+	}
+	return s
+}
+
+// ContextWithConfig adds a configuration manager to the given context.
+func ContextWithConfig(ctx context.Context, configManager *Manager[Configuration]) context.Context {
+	return context.WithValue(ctx, contextKeyConfig{}, configManager)
+}
+
+// ConfigFromContext retrieves the configuration.Manager previously added to the
+// context with [ContextWithConfig].
+func ConfigFromContext(ctx context.Context) *Manager[Configuration] {
+	m, ok := ctx.Value(contextKeyConfig{}).(*Manager[Configuration])
+	if !ok {
+		panic("no configuration manager in context")
+	}
+	return m
+}

--- a/common/configuration/defaults.go
+++ b/common/configuration/defaults.go
@@ -1,0 +1,63 @@
+package configuration
+
+import (
+	"context"
+
+	"github.com/alecthomas/kong"
+)
+
+// NewConfigurationManager constructs a new [Manager] with the default providers for configuration.
+func NewConfigurationManager(ctx context.Context, configPath string) (*Manager[Configuration], error) {
+	conf := DefaultConfigMixin{
+		ProjectConfigResolver: ProjectConfigResolver[Configuration]{
+			Config: configPath,
+		},
+	}
+	_ = kong.ApplyDefaults(&conf)
+	return conf.NewConfigurationManager(ctx)
+}
+
+// DefaultConfigMixin is a Kong mixin that provides the default configuration manager.
+type DefaultConfigMixin struct {
+	ProjectConfigResolver[Configuration]
+	InlineProvider[Configuration]
+	EnvarProvider[Configuration]
+}
+
+// NewConfigurationManager creates a new configuration manager with the default configuration providers.
+func (d DefaultConfigMixin) NewConfigurationManager(ctx context.Context) (*Manager[Configuration], error) {
+	return New(ctx, &d.ProjectConfigResolver, []Provider[Configuration]{
+		d.InlineProvider,
+		d.EnvarProvider,
+	})
+}
+
+// NewSecretsManager constructs a new [Manager] with the default providers for secrets.
+func NewSecretsManager(ctx context.Context, configPath string) (*Manager[Secrets], error) {
+	conf := DefaultSecretsMixin{
+		ProjectConfigResolver: ProjectConfigResolver[Secrets]{
+			Config: configPath,
+		},
+	}
+	_ = kong.ApplyDefaults(&conf)
+	return conf.NewSecretsManager(ctx)
+}
+
+// DefaultSecretsMixin is a Kong mixin that provides the default secrets manager.
+type DefaultSecretsMixin struct {
+	ProjectConfigResolver[Secrets]
+	InlineProvider[Secrets]
+	EnvarProvider[Secrets]
+	KeychainProvider
+	OnePasswordProvider
+}
+
+// NewSecretsManager creates a new secrets manager with the default secret providers.
+func (d DefaultSecretsMixin) NewSecretsManager(ctx context.Context) (*Manager[Secrets], error) {
+	return New(ctx, &d.ProjectConfigResolver, []Provider[Secrets]{
+		d.InlineProvider,
+		d.EnvarProvider,
+		d.KeychainProvider,
+		d.OnePasswordProvider,
+	})
+}

--- a/common/configuration/inline.go
+++ b/common/configuration/inline.go
@@ -8,17 +8,17 @@ import (
 )
 
 // InlineProvider is a configuration provider that stores configuration in its key.
-type InlineProvider struct {
+type InlineProvider[R Role] struct {
 	Inline bool `help:"Write values inline in the configuration file." group:"Provider:" xor:"configwriter"`
 }
 
-var _ MutableProvider = InlineProvider{}
+var _ MutableProvider[Configuration] = InlineProvider[Configuration]{}
 
-func (InlineProvider) Key() string { return "inline" }
+func (InlineProvider[R]) Key() R { return "inline" }
 
-func (i InlineProvider) Writer() bool { return i.Inline }
+func (i InlineProvider[R]) Writer() bool { return i.Inline }
 
-func (InlineProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
+func (InlineProvider[R]) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
 	data, err := base64.RawStdEncoding.DecodeString(key.Host)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base64 data in inline configuration: %w", err)
@@ -26,11 +26,11 @@ func (InlineProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, 
 	return data, nil
 }
 
-func (InlineProvider) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+func (InlineProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
 	b64 := base64.RawStdEncoding.EncodeToString(value)
 	return &url.URL{Scheme: "inline", Host: b64}, nil
 }
 
-func (InlineProvider) Delete(ctx context.Context, ref Ref) error {
+func (InlineProvider[R]) Delete(ctx context.Context, ref Ref) error {
 	return nil
 }

--- a/common/configuration/keychain.go
+++ b/common/configuration/keychain.go
@@ -14,9 +14,9 @@ type KeychainProvider struct {
 	Keychain bool `help:"Write to the system keychain." group:"Provider:" xor:"configwriter"`
 }
 
-var _ MutableProvider = KeychainProvider{}
+var _ MutableProvider[Secrets] = KeychainProvider{}
 
-func (k KeychainProvider) Key() string { return "keychain" }
+func (k KeychainProvider) Key() Secrets { return "keychain" }
 
 func (k KeychainProvider) Writer() bool { return k.Keychain }
 

--- a/common/configuration/testdata/ftl-project.toml
+++ b/common/configuration/testdata/ftl-project.toml
@@ -1,5 +1,10 @@
 [global]
+[global.secrets]
+baz = "envar://baz"
+foo = "inline://ImJhciI"
+mutable = "keychain://mutable"
+
 [global.configuration]
 baz = "envar://baz"
 foo = "inline://ImJhciI"
-keychain = "keychain://keychain"
+mutable = "inline://ImhlbGxvIg"

--- a/examples/go/echo/echo.go
+++ b/examples/go/echo/echo.go
@@ -12,6 +12,8 @@ import (
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 )
 
+var defaultName = ftl.Config[string]("default")
+
 // An echo request.
 type EchoRequest struct {
 	Name ftl.Option[string] `json:"name"`
@@ -30,5 +32,5 @@ func Echo(ctx context.Context, req EchoRequest) (EchoResponse, error) {
 	if err != nil {
 		return EchoResponse{}, err
 	}
-	return EchoResponse{Message: fmt.Sprintf("Hello, %s!!! It is %s!", req.Name.Default("anonymous"), tresp.Time)}, nil
+	return EchoResponse{Message: fmt.Sprintf("Hello, %s!!! It is %s!", req.Name.Default(defaultName.Get(ctx)), tresp.Time)}, nil
 }

--- a/examples/go/echo/go.mod
+++ b/examples/go/echo/go.mod
@@ -10,7 +10,10 @@ require (
 	connectrpc.com/connect v1.15.0 // indirect
 	connectrpc.com/grpcreflect v1.2.0 // indirect
 	connectrpc.com/otelconnect v0.7.0 // indirect
+	github.com/BurntSushi/toml v1.3.2 // indirect
+	github.com/TBD54566975/scaffolder v0.8.0 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
+	github.com/alecthomas/kong v0.8.1 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
 	github.com/alecthomas/types v0.13.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect

--- a/examples/go/echo/go.sum
+++ b/examples/go/echo/go.sum
@@ -4,10 +4,16 @@ connectrpc.com/grpcreflect v1.2.0 h1:Q6og1S7HinmtbEuBvARLNwYmTbhEGRpHDhqrPNlmK+U
 connectrpc.com/grpcreflect v1.2.0/go.mod h1:nwSOKmE8nU5u/CidgHtPYk1PFI3U9ignz7iDMxOYkSY=
 connectrpc.com/otelconnect v0.7.0 h1:ZH55ZZtcJOTKWWLy3qmL4Pam4RzRWBJFOqTPyAqCXkY=
 connectrpc.com/otelconnect v0.7.0/go.mod h1:Bt2ivBymHZHqxvo4HkJ0EwHuUzQN6k2l0oH+mp/8nwc=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/TBD54566975/scaffolder v0.8.0 h1:DWl1K3dWcLsOPAYGQGPQXtffrml6XCB0tF05JdpMqZU=
+github.com/TBD54566975/scaffolder v0.8.0/go.mod h1:Ab/jbQ4q8EloYL0nbkdh2DVvkGc4nxr1OcIbdMpTxxg=
 github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
 github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
+github.com/alecthomas/kong v0.8.1 h1:acZdn3m4lLRobeh3Zi2S2EpnXTd1mOL6U7xVml+vfkY=
+github.com/alecthomas/kong v0.8.1/go.mod h1:n1iCIO2xS46oE8ZfYCNDqdR0b0wZNrXAIAqro/2132U=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=

--- a/ftl-project.toml
+++ b/ftl-project.toml
@@ -1,0 +1,6 @@
+[global]
+
+[modules]
+  [modules.echo]
+    [modules.echo.configuration]
+      default = "inline://ImFub255bW91cyI"

--- a/go-runtime/compile/build-template/_ftl.tmpl/go/main/go.mod.tmpl
+++ b/go-runtime/compile/build-template/_ftl.tmpl/go/main/go.mod.tmpl
@@ -5,3 +5,7 @@ go {{ .GoVersion }}
 {{ if ne .FTLVersion "" }}
 require github.com/TBD54566975/ftl v{{ .FTLVersion }}
 {{ end }}
+
+{{- range .Replacements }}
+replace {{ .Old }} => {{ .New }}
+{{- end }}

--- a/go-runtime/compile/external-module-template/_ftl/go/modules/go.mod.tmpl
+++ b/go-runtime/compile/external-module-template/_ftl/go/modules/go.mod.tmpl
@@ -1,3 +1,11 @@
 module ftl
 
 go {{ .GoVersion }}
+
+{{ if ne .FTLVersion "" }}
+require github.com/TBD54566975/ftl v{{ .FTLVersion }}
+{{ end }}
+
+{{- range .Replacements }}
+replace {{ .Old }} => {{ .New }}
+{{- end }}

--- a/go-runtime/ftl/config.go
+++ b/go-runtime/ftl/config.go
@@ -1,11 +1,12 @@
 package ftl
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"os"
 	"runtime"
 	"strings"
+
+	"github.com/TBD54566975/ftl/common/configuration"
 )
 
 // ConfigType is a type that can be used as a configuration value.
@@ -28,16 +29,11 @@ func (c *ConfigValue[T]) String() string {
 }
 
 // Get returns the value of the configuration key from FTL.
-func (c *ConfigValue[T]) Get() (out T) {
-	value, ok := os.LookupEnv(fmt.Sprintf("FTL_CONFIG_%s_%s", strings.ToUpper(c.module), strings.ToUpper(c.name)))
-	if !ok {
-		value, ok = os.LookupEnv(fmt.Sprintf("FTL_CONFIG_%s", strings.ToUpper(c.name)))
-		if !ok {
-			return out
-		}
-	}
-	if err := json.Unmarshal([]byte(value), &out); err != nil {
-		panic(fmt.Errorf("failed to parse %s value %q: %w", c, value, err))
+func (c *ConfigValue[T]) Get(ctx context.Context) (out T) {
+	cm := configuration.ConfigFromContext(ctx)
+	err := cm.Get(ctx, configuration.NewRef(c.module, c.name), &out)
+	if err != nil {
+		panic(fmt.Errorf("failed to get %s: %w", c, err))
 	}
 	return
 }

--- a/go-runtime/ftl/config_test.go
+++ b/go-runtime/ftl/config_test.go
@@ -1,17 +1,24 @@
 package ftl
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/common/configuration"
+	"github.com/TBD54566975/ftl/internal/log"
 )
 
 func TestConfig(t *testing.T) {
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	cm, err := configuration.NewConfigurationManager(ctx, "testdata/ftl-project.toml")
+	assert.NoError(t, err)
+	ctx = configuration.ContextWithConfig(ctx, cm)
 	type C struct {
 		One string
 		Two string
 	}
-	t.Setenv("FTL_CONFIG_TESTING_TEST", `{"one": "one", "two": "two"}`)
 	config := Config[C]("test")
-	assert.Equal(t, C{"one", "two"}, config.Get())
+	assert.Equal(t, C{"one", "two"}, config.Get(ctx))
 }

--- a/go-runtime/ftl/secrets.go
+++ b/go-runtime/ftl/secrets.go
@@ -1,10 +1,10 @@
 package ftl
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"os"
-	"strings"
+
+	"github.com/TBD54566975/ftl/common/configuration"
 )
 
 // SecretType is a type that can be used as a secret value.
@@ -27,16 +27,10 @@ func (s *SecretValue[Type]) String() string {
 }
 
 // Get returns the value of the secret from FTL.
-func (s *SecretValue[Type]) Get() (out Type) {
-	value, ok := os.LookupEnv(fmt.Sprintf("FTL_SECRET_%s_%s", strings.ToUpper(s.module), strings.ToUpper(s.name)))
-	if !ok {
-		value, ok = os.LookupEnv(fmt.Sprintf("FTL_SECRET_%s", strings.ToUpper(s.name)))
-		if !ok {
-			return out
-		}
-	}
-	if err := json.Unmarshal([]byte(value), &out); err != nil {
-		panic(fmt.Errorf("failed to parse %s: %w", s, err))
+func (s *SecretValue[Type]) Get(ctx context.Context) (out Type) {
+	sm := configuration.SecretsFromContext(ctx)
+	if err := sm.Get(ctx, configuration.NewRef(s.module, s.name), &out); err != nil {
+		panic(fmt.Errorf("failed to get %s: %w", s, err))
 	}
 	return
 }

--- a/go-runtime/ftl/secrets_test.go
+++ b/go-runtime/ftl/secrets_test.go
@@ -1,17 +1,24 @@
 package ftl
 
 import (
+	"context"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/common/configuration"
+	"github.com/TBD54566975/ftl/internal/log"
 )
 
 func TestSecret(t *testing.T) {
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	sm, err := configuration.NewSecretsManager(ctx, "testdata/ftl-project.toml")
+	assert.NoError(t, err)
+	ctx = configuration.ContextWithSecrets(ctx, sm)
 	type C struct {
 		One string
 		Two string
 	}
-	t.Setenv("FTL_SECRET_TESTING_TEST", `{"one": "one", "two": "two"}`)
-	config := Secret[C]("test")
-	assert.Equal(t, C{"one", "two"}, config.Get())
+	config := Secret[C]("secret")
+	assert.Equal(t, C{"one", "two"}, config.Get(ctx))
 }

--- a/go-runtime/ftl/testdata/ftl-project.toml
+++ b/go-runtime/ftl/testdata/ftl-project.toml
@@ -1,0 +1,8 @@
+[global]
+
+[modules]
+  [modules.testing]
+    [modules.testing.configuration]
+      test = "inline://eyJvbmUiOiJvbmUiLCJ0d28iOiJ0d28ifQ"
+    [modules.testing.secrets]
+      secret = "inline://eyJvbmUiOiJvbmUiLCJ0d28iOiJ0d28ifQ"

--- a/internal/observability/client.go
+++ b/internal/observability/client.go
@@ -19,18 +19,18 @@ import (
 
 const schemaURL = semconv.SchemaURL
 
-type exportOTELFlag bool
+type ExportOTELFlag bool
 
-// Default behaviour of Kong is to use strconv.ParseBool, but we want to be less strict.
-func (e *exportOTELFlag) UnmarshalText(text []byte) error {
+func (e *ExportOTELFlag) UnmarshalText(text []byte) error {
+	// Default behaviour of Kong is to use strconv.ParseBool, but we want to be less strict.
 	v := strings.ToLower(string(text))
-	*e = exportOTELFlag(!(v == "false" || v == "0" || v == "no" || v == ""))
+	*e = ExportOTELFlag(!(v == "false" || v == "0" || v == "no" || v == ""))
 	return nil
 }
 
 type Config struct {
 	LogLevel   log.Level      `default:"error" help:"OTEL log level." env:"FTL_O11Y_LOG_LEVEL"`
-	ExportOTEL exportOTELFlag `help:"Export observability data to OTEL." env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
+	ExportOTEL ExportOTELFlag `help:"Export observability data to OTEL." env:"OTEL_EXPORTER_OTLP_ENDPOINT"`
 }
 
 func Init(ctx context.Context, serviceName, serviceVersion string, config Config) error {

--- a/scripts/autofmt
+++ b/scripts/autofmt
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Run go mod tidy on all modules
-find . -name 'go.mod' ! -path '*/.ftl/*' ! -path '*/scaffolding/*' -print0 | xargs -0 dirname | while read -r dir; do (echo "Tidying Go module in '$dir'..."; cd "$dir" && go mod tidy); done
+find . -name 'go.mod' ! -path '*/_*/*' ! -path '*/.ftl/*' ! -path '*/scaffolding/*' -print0 | xargs -0 dirname | while read -r dir; do (echo "Tidying Go module in '$dir'..."; cd "$dir" && go mod tidy); done
 
 echo "Formatting Go..."
 # shellcheck disable=SC2207


### PR DESCRIPTION
This allows secrets/config to be dynamically updated in most cases (the envar provider being a notable exception).

```
🐚 ~/dev/ftl $ ftl config set echo.default --inline "anonymous"
🐚 ~/dev/ftl $ ftl config get echo.default
"anonymous"
🐚 ~/dev/ftl $ ftl call echo.echo       aat/configuration-go-runtime
{"message":"Hello, anonymous!!! It is 2024-03-03 07:45:21.237088 +1000 AEST!"}
🐚 ~/dev/ftl $ ftl config set echo.default --inline "Anne"
🐚 ~/dev/ftl $ ftl config get echo.default
"Anne"
🐚 ~/dev/ftl $ ftl call echo.echo
{"message":"Hello, Anne!!! It is 2024-03-03 07:44:52.2176 +1000 AEST!"}
```

I also refactored the `configuration` package such that managers and providers are tied to their role by a type parameter.

Finally, I made a few tweaks to allow FTL to largely work offline:

- Propagate `replace` directives from Go modules into the generated main and external-module `go.mod` files.
- Add `--[no-]console` flag that allows building of the console to be skipped.
- TODO: Figure out how put maven builds into offline mode