### PR TITLE
fix: update url output for the console

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -86,7 +86,7 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 			_, _ = w.Write([]byte("Console not installed."))
 		})
 	} else {
-		consoleHandler, err = frontend.Server(ctx, config.ContentTime, config.ConsoleURL)
+		consoleHandler, err = frontend.Server(ctx, config.ContentTime, config.Bind, config.ConsoleURL)
 		if err != nil {
 			return err
 		}

--- a/frontend/local.go
+++ b/frontend/local.go
@@ -14,10 +14,10 @@ import (
 	"github.com/TBD54566975/ftl/internal/log"
 )
 
-var consoleURL, _ = url.Parse("http://localhost:5173")
-var proxy = httputil.NewSingleHostReverseProxy(consoleURL)
+var proxyURL, _ = url.Parse("http://localhost:5173")
+var proxy = httputil.NewSingleHostReverseProxy(proxyURL)
 
-func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (http.Handler, error) {
+func Server(ctx context.Context, timestamp time.Time, publicURL *url.URL, allowOrigin *url.URL) (http.Handler, error) {
 	logger := log.FromContext(ctx)
 	logger.Debugf("Building console...")
 
@@ -30,7 +30,7 @@ func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (htt
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("Web console available at: %s", consoleURL)
+	logger.Infof("Web console available at: %s", publicURL.String())
 
 	if allowOrigin == nil {
 		return proxy, nil

--- a/frontend/release.go
+++ b/frontend/release.go
@@ -22,7 +22,7 @@ import (
 //go:embed all:dist
 var build embed.FS
 
-func Server(ctx context.Context, timestamp time.Time, allowOrigin *url.URL) (http.Handler, error) {
+func Server(ctx context.Context, timestamp time.Time, publicURL *url.URL, allowOrigin *url.URL) (http.Handler, error) {
 	dir, err := fs.Sub(build, "dist")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I think a recent update to the buf connect stuff might have surfaced an issue with using `http://localhost:5173` for the console.