### PR TITLE
feat: add —log-timestamps option

### DIFF
--- a/internal/log/configure.go
+++ b/internal/log/configure.go
@@ -8,7 +8,7 @@ import (
 type Config struct {
 	Level      Level `help:"Log level." default:"info" env:"LOG_LEVEL"`
 	JSON       bool  `help:"Log in JSON format." env:"LOG_JSON"`
-	Timestamps bool  `help:"Include timing in logs." env:"LOG_TIMESTAMPS"`
+	Timestamps bool  `help:"Include relative timestamps in logs." env:"LOG_TIMESTAMPS"`
 }
 
 // Configure returns a new logger based on the config.

--- a/internal/log/configure.go
+++ b/internal/log/configure.go
@@ -8,7 +8,7 @@ import (
 type Config struct {
 	Level      Level `help:"Log level." default:"info" env:"LOG_LEVEL"`
 	JSON       bool  `help:"Log in JSON format." env:"LOG_JSON"`
-	Timestamps bool  `help:"Include relative timestamps in text logs." env:"LOG_TIMESTAMPS"`
+	Timestamps bool  `help:"Include timestamps in text logs." env:"LOG_TIMESTAMPS"`
 }
 
 // Configure returns a new logger based on the config.

--- a/internal/log/configure.go
+++ b/internal/log/configure.go
@@ -6,8 +6,9 @@ import (
 
 // Config for the logger.
 type Config struct {
-	Level Level `help:"Log level." default:"info" env:"LOG_LEVEL"`
-	JSON  bool  `help:"Log in JSON format." env:"LOG_JSON"`
+	Level      Level `help:"Log level." default:"info" env:"LOG_LEVEL"`
+	JSON       bool  `help:"Log in JSON format." env:"LOG_JSON"`
+	Timestamps bool  `help:"Include timing in logs." env:"LOG_TIMESTAMPS"`
 }
 
 // Configure returns a new logger based on the config.
@@ -16,7 +17,7 @@ func Configure(w io.Writer, cfg Config) *Logger {
 	if cfg.JSON {
 		sink = newJSONSink(w)
 	} else {
-		sink = newPlainSink(w)
+		sink = newPlainSink(w, cfg.Timestamps)
 	}
 	return New(cfg.Level, sink)
 }

--- a/internal/log/configure.go
+++ b/internal/log/configure.go
@@ -8,7 +8,7 @@ import (
 type Config struct {
 	Level      Level `help:"Log level." default:"info" env:"LOG_LEVEL"`
 	JSON       bool  `help:"Log in JSON format." env:"LOG_JSON"`
-	Timestamps bool  `help:"Include relative timestamps in logs." env:"LOG_TIMESTAMPS"`
+	Timestamps bool  `help:"Include relative timestamps in text logs." env:"LOG_TIMESTAMPS"`
 }
 
 // Configure returns a new logger based on the config.

--- a/internal/log/plain.go
+++ b/internal/log/plain.go
@@ -25,18 +25,16 @@ func newPlainSink(w io.Writer, logTime bool) *plainSink {
 		isaTTY = isatty.IsTerminal(f.Fd())
 	}
 	return &plainSink{
-		isaTTY:    isaTTY,
-		w:         w,
-		startTime: time.Now(),
-		logTime:   logTime,
+		isaTTY:  isaTTY,
+		w:       w,
+		logTime: logTime,
 	}
 }
 
 type plainSink struct {
-	isaTTY    bool
-	w         io.Writer
-	startTime time.Time
-	logTime   bool
+	isaTTY  bool
+	w       io.Writer
+	logTime bool
 }
 
 // Log implements Sink
@@ -45,20 +43,7 @@ func (t *plainSink) Log(entry Entry) error {
 
 	// Add timestamp if required
 	if t.logTime {
-		d := entry.Time.Sub(t.startTime)
-		var timestamp string
-		switch {
-		case d < time.Second:
-			timestamp = fmt.Sprintf("%dms", d/time.Millisecond)
-		case d < time.Minute:
-			timestamp = fmt.Sprintf("%ds", d/time.Second)
-		case d < time.Hour:
-			timestamp = fmt.Sprintf("%dm", d/time.Minute)
-		default:
-			timestamp = fmt.Sprintf("%dh", d/time.Hour)
-		}
-
-		prefix += fmt.Sprintf("%5s ", timestamp)
+		prefix += t.startTime.Format(time.TimeOnly) + " "
 	}
 
 	// Add scope if required

--- a/internal/log/plain.go
+++ b/internal/log/plain.go
@@ -43,7 +43,7 @@ func (t *plainSink) Log(entry Entry) error {
 
 	// Add timestamp if required
 	if t.logTime {
-		prefix += t.startTime.Format(time.TimeOnly) + " "
+		prefix += entry.Time.Format(time.TimeOnly) + " "
 	}
 
 	// Add scope if required

--- a/internal/log/plain.go
+++ b/internal/log/plain.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/mattn/go-isatty"
 )
@@ -18,31 +19,57 @@ var colours = map[Level]string{
 
 var _ Sink = (*plainSink)(nil)
 
-func newPlainSink(w io.Writer) *plainSink {
+func newPlainSink(w io.Writer, logTime bool) *plainSink {
 	var isaTTY bool
 	if f, ok := w.(*os.File); ok {
 		isaTTY = isatty.IsTerminal(f.Fd())
 	}
 	return &plainSink{
-		isaTTY: isaTTY,
-		w:      w,
+		isaTTY:    isaTTY,
+		w:         w,
+		startTime: time.Now(),
+		logTime:   logTime,
 	}
 }
 
 type plainSink struct {
-	isaTTY bool
-	w      io.Writer
+	isaTTY    bool
+	w         io.Writer
+	startTime time.Time
+	logTime   bool
 }
 
 // Log implements Sink
 func (t *plainSink) Log(entry Entry) error {
 	var prefix string
+
+	// Add timestamp if required
+	if t.logTime {
+		d := entry.Time.Sub(t.startTime)
+		var timestamp string
+		switch {
+		case d < time.Second:
+			timestamp = fmt.Sprintf("%dms", d/time.Millisecond)
+		case d < time.Minute:
+			timestamp = fmt.Sprintf("%ds", d/time.Second)
+		case d < time.Hour:
+			timestamp = fmt.Sprintf("%dm", d/time.Minute)
+		default:
+			timestamp = fmt.Sprintf("%dh", d/time.Hour)
+		}
+
+		prefix += fmt.Sprintf("%5s ", timestamp)
+	}
+
+	// Add scope if required
 	scope, exists := entry.Attributes[scopeKey]
 	if exists {
-		prefix = entry.Level.String() + ":" + scope + ": "
+		prefix += entry.Level.String() + ":" + scope + ": "
 	} else {
-		prefix = entry.Level.String() + ": "
+		prefix += entry.Level.String() + ": "
 	}
+
+	// Print
 	var err error
 	if t.isaTTY {
 		_, err = fmt.Fprintf(t.w, "%s%s%s\x1b[0m\n", colours[entry.Level], prefix, entry.Message)


### PR DESCRIPTION
#1009
Adding `add --log-timestamps` include timestamps in terminal logs

Example
```
16:26:20 info: Starting FTL with 1 controller(s) and 0 runner(s)
16:26:20 warn: Detected change in +/Users/mtoohey/Code/ftl/examples/go/echo/go.sum, rebuilding...
16:26:20 error: Error deploying module /Users/mtoohey/Code/ftl/examples/go/echo. Will retry: module "time" not found
16:26:20 warn: Detected change in +/Users/mtoohey/Code/ftl/examples/go/time/time.go, rebuilding...
16:26:20 info:time: Building module
```

