### PR TITLE
fix: encode op "URI" as base64

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,3 +1,5 @@
+set positional-arguments
+
 # Start a hot-reloading dev cluster
 dev: install-jars
   goreman -logtime=false start


### PR DESCRIPTION
It turns out it's not actually a URI at all, so FTL's parser borks on it.