### PR TITLE
chore: fix for local dev rebuilding ftl-runtime.jar on every run

### DIFF
--- a/Bitfile
+++ b/Bitfile
@@ -114,7 +114,7 @@ kotlin-runtime/external-module-template.zip: kotlin-runtime/external-module-temp
   # TODO: Figure out how to make Maven build completely offline. Bizarrely "-o" does not do this.
   build:
     mvn -B -N install
-    mvn -B -pl :ftl-runtime install
+    mvn -Dmaven.test.skip=true -B -pl :ftl-runtime install
   +clean: mvn -B -pl :ftl-runtime clean
 
 %(dirname %{KT_RUNTIME_RUNNER_TEMPLATE_OUT})%:

--- a/backend/controller/scaling/localscaling/devel.go
+++ b/backend/controller/scaling/localscaling/devel.go
@@ -17,7 +17,7 @@ var templateDirOnce sync.Once
 func templateDir(ctx context.Context) string {
 	templateDirOnce.Do(func() {
 		// TODO: Figure out how to make maven build offline
-		err := exec.Command(ctx, log.Debug, internal.GitRoot(""), "bit", "build/template/ftl/jars/ftl-runtime.jar").RunBuffered(ctx)
+		err := exec.Command(ctx, log.Debug, internal.GitRoot(""), "bit", "--level=trace", "build/template/ftl/jars/ftl-runtime.jar").RunBuffered(ctx)
 		if err != nil {
 			panic(err)
 		}

--- a/deployment/db-migrate/schema
+++ b/deployment/db-migrate/schema
@@ -1,1 +1,1 @@
-../../backend/controller/internal/sql/schema
+../../backend/controller/sql/schema

--- a/frontend/local.go
+++ b/frontend/local.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/cors"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -21,7 +22,7 @@ func Server(ctx context.Context, timestamp time.Time, publicURL *url.URL, allowO
 	logger := log.FromContext(ctx)
 	logger.Debugf("Building console...")
 
-	err := exec.Command(ctx, log.Debug, "frontend", "npm", "install").RunBuffered(ctx)
+	err := exec.Command(ctx, log.Debug, internal.GitRoot(""), "bit", "frontend/**/*").RunBuffered(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This was occurring because frontend/local.go was calling `npm install` explicitly on every run, resulting in changes to the frontend that invalidated some of the dependencies of the JAR file.

The fix is to use `bit` to build the frontend as well, resulting in its dependency cache being correct.