### PR TITLE
fix: ps cmd should ignore dead runners

### DIFF
--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -162,7 +162,7 @@ SELECT d.min_replicas,
        r.endpoint,
        r.labels AS runner_labels
 FROM deployments d
-         LEFT JOIN runners r on d.id = r.deployment_id AND r.state = 'assigned'
+         LEFT JOIN runners r on d.id = r.deployment_id AND r.state != 'dead'
 WHERE d.min_replicas > 0
 ORDER BY d.name;
 

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -110,7 +110,8 @@ RETURNING deployment_id;
 -- name: KillStaleRunners :one
 WITH matches AS (
     UPDATE runners
-        SET state = 'dead'
+        SET state = 'dead',
+        deployment_id = NULL
         WHERE state <> 'dead' AND last_seen < (NOW() AT TIME ZONE 'utc') - sqlc.arg('timeout')::INTERVAL
         RETURNING 1)
 SELECT COUNT(*)
@@ -120,8 +121,7 @@ FROM matches;
 WITH matches AS (
     UPDATE runners
         SET state = 'dead',
-            deployment_id = NULL,
-            module_name = NULL
+            deployment_id = NULL
         WHERE key = $1
         RETURNING 1)
 SELECT COUNT(*)

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -119,7 +119,9 @@ FROM matches;
 -- name: DeregisterRunner :one
 WITH matches AS (
     UPDATE runners
-        SET state = 'dead'
+        SET state = 'dead',
+            deployment_id = NULL,
+            module_name = NULL
         WHERE key = $1
         RETURNING 1)
 SELECT COUNT(*)

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -160,7 +160,7 @@ SELECT d.min_replicas,
        r.endpoint,
        r.labels AS runner_labels
 FROM deployments d
-         LEFT JOIN runners r on d.id = r.deployment_id
+         LEFT JOIN runners r on d.id = r.deployment_id AND r.state = 'assigned'
 WHERE d.min_replicas > 0
 ORDER BY d.name;
 

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -99,8 +99,7 @@ const deregisterRunner = `-- name: DeregisterRunner :one
 WITH matches AS (
     UPDATE runners
         SET state = 'dead',
-            deployment_id = NULL,
-            module_name = NULL
+            deployment_id = NULL
         WHERE key = $1
         RETURNING 1)
 SELECT COUNT(*)
@@ -1200,7 +1199,8 @@ func (q *Queries) KillStaleControllers(ctx context.Context, timeout time.Duratio
 const killStaleRunners = `-- name: KillStaleRunners :one
 WITH matches AS (
     UPDATE runners
-        SET state = 'dead'
+        SET state = 'dead',
+        deployment_id = NULL
         WHERE state <> 'dead' AND last_seen < (NOW() AT TIME ZONE 'utc') - $1::INTERVAL
         RETURNING 1)
 SELECT COUNT(*)

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -749,7 +749,7 @@ SELECT d.min_replicas,
        r.endpoint,
        r.labels AS runner_labels
 FROM deployments d
-         LEFT JOIN runners r on d.id = r.deployment_id
+         LEFT JOIN runners r on d.id = r.deployment_id AND r.state = 'assigned'
 WHERE d.min_replicas > 0
 ORDER BY d.name
 `

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -750,7 +750,7 @@ SELECT d.min_replicas,
        r.endpoint,
        r.labels AS runner_labels
 FROM deployments d
-         LEFT JOIN runners r on d.id = r.deployment_id AND r.state = 'assigned'
+         LEFT JOIN runners r on d.id = r.deployment_id AND r.state != 'dead'
 WHERE d.min_replicas > 0
 ORDER BY d.name
 `

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -98,7 +98,9 @@ func (q *Queries) CreateIngressRoute(ctx context.Context, arg CreateIngressRoute
 const deregisterRunner = `-- name: DeregisterRunner :one
 WITH matches AS (
     UPDATE runners
-        SET state = 'dead'
+        SET state = 'dead',
+            deployment_id = NULL,
+            module_name = NULL
         WHERE key = $1
         RETURNING 1)
 SELECT COUNT(*)


### PR DESCRIPTION
fixes #1046

Runners that were found to have died (rather than cleanly being killed) end up with deployment_id & module_name not set to null.
Changes:
- removes all dead runners from showing in the `ps` command
- correctly updates `deployment_id` and `module_name` to null in the following cases:
    -  Runner terminates unexpectedly
    -  Runner is stale