### PR TITLE
fix(go-runtime): remove duplicate positional information in errors

### DIFF
--- a/go-runtime/compile/errors.go
+++ b/go-runtime/compile/errors.go
@@ -1,0 +1,40 @@
+package compile
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+
+	"github.com/TBD54566975/ftl/backend/schema"
+)
+
+type Error struct {
+	Msg string
+	Pos schema.Position
+	Err error // Wrapped error, if any
+}
+
+func (e Error) Error() string { return fmt.Sprintf("%s: %s", e.Pos, e.Msg) }
+func (e Error) Unwrap() error { return e.Err }
+
+func errorf(node ast.Node, format string, args ...any) Error {
+	return Error{Msg: fmt.Sprintf(format, args...), Pos: goPosToSchemaPos(node.Pos())}
+}
+
+func wrapf(node ast.Node, err error, format string, args ...any) Error {
+	if format == "" {
+		format = "%s"
+	} else {
+		format += ": %s"
+	}
+	// Propagate existing error position if available
+	var pos schema.Position
+	if perr := (Error{}); errors.As(err, &perr) {
+		pos = perr.Pos
+		args = append(args, perr.Msg)
+	} else {
+		pos = goPosToSchemaPos(node.Pos())
+		args = append(args, err)
+	}
+	return Error{Msg: fmt.Sprintf(format, args...), Pos: pos, Err: err}
+}

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -3,6 +3,8 @@ package compile
 import (
 	"go/ast"
 	"go/types"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -174,4 +176,10 @@ func TestParseBasicTypes(t *testing.T) {
 
 func normaliseString(s string) string {
 	return strings.TrimSpace(strings.Join(slices.Map(strings.Split(s, "\n"), strings.TrimSpace), "\n"))
+}
+
+func TestErrorReporting(t *testing.T) {
+	pwd, _ := os.Getwd()
+	_, _, err := ExtractModuleSchema("testdata/failing")
+	assert.EqualError(t, err, filepath.Join(pwd, `testdata/failing/failing.go`)+`:15:2: call must have exactly three arguments`)
 }

--- a/go-runtime/compile/testdata/failing/failing.go
+++ b/go-runtime/compile/testdata/failing/failing.go
@@ -1,0 +1,17 @@
+//ftl:module failing
+package failing
+
+import (
+	"context"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl"
+)
+
+type Request struct{}
+type Response struct{}
+
+//ftl:verb
+func FailingVerb(ctx context.Context, req Request) (Response, error) {
+	ftl.Call(ctx, "failing", "failingVerb", req)
+	return Response{}, nil
+}


### PR DESCRIPTION
Previously:

```
/Users/alec/dev/ftl/go-runtime/compile/testdata/failing/failing.go:2:1: 
/Users/alec/dev/ftl/go-runtime/compile/testdata/failing/failing.go:14:1: 
/Users/alec/dev/ftl/go-runtime/compile/testdata/failing/failing.go:14:70: 
/Users/alec/dev/ftl/go-runtime/compile/testdata/failing/failing.go:15:2: 
/Users/alec/dev/ftl/go-runtime/compile/testdata/failing/failing.go:15:2: 
/Users/alec/dev/ftl/go-runtime/compile/testdata/failing/failing.go:15:2: call must have exactly three arguments
```

Now:

```
/Users/alec/dev/ftl/go-runtime/compile/testdata/failing/failing.go:15:2: call must have exactly three arguments
```

Fixes #1062 