### PR TITLE
fix: linters weren't failing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,16 @@ jobs:
       - name: golangci-lint
         run: golangci-lint run --out-format github-actions ./...
       - name: go-check-sumtype
-        run: go-check-sumtype ./... | to-annotation
+        shell: bash
+        run: go-check-sumtype ./... 2>&1 | to-annotation
       - name: actionlint
+        shell: bash
         run: actionlint --oneline | to-annotation
       # Too annoying to disable individual warnings
       # - name: staticcheck
       #   run: staticcheck ./...
       - name: shellcheck
+        shell: bash
         run: shellcheck -f gcc -e SC2016 scripts/* | to-annotation
   proto-breaking:
     name: Proto Breaking Change Check
@@ -82,6 +85,7 @@ jobs:
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
       - name: Proto Breaking Change Check
+        shell: bash
         run: buf breaking --against 'https://github.com/TBD54566975/ftl.git#branch=main' | to-annotation
   console:
     name: Console


### PR DESCRIPTION
This was because GHA doesn't enable `-o pipefail` by default unless `bash` is explicitly selected as the shell.