### PR TITLE
refactor: differentiate between symbols and declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,16 @@ jobs:
       - name: golangci-lint
         run: golangci-lint run --out-format github-actions ./...
       - name: go-check-sumtype
-        run: go-check-sumtype ./... | to-annotation
+        shell: bash
+        run: go-check-sumtype ./... 2>&1 | to-annotation
       - name: actionlint
+        shell: bash
         run: actionlint --oneline | to-annotation
       # Too annoying to disable individual warnings
       # - name: staticcheck
       #   run: staticcheck ./...
       - name: shellcheck
+        shell: bash
         run: shellcheck -f gcc -e SC2016 scripts/* | to-annotation
   proto-breaking:
     name: Proto Breaking Change Check
@@ -82,6 +85,7 @@ jobs:
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
       - name: Proto Breaking Change Check
+        shell: bash
         run: buf breaking --against 'https://github.com/TBD54566975/ftl.git#branch=main' | to-annotation
   console:
     name: Console

--- a/backend/controller/console.go
+++ b/backend/controller/console.go
@@ -89,10 +89,7 @@ func (c *ConsoleService) GetModules(ctx context.Context, req *connect.Request[pb
 					Schema: schema.DataFromProto(d).String(),
 				})
 
-			case *schema.Bool, *schema.Bytes, *schema.Database, *schema.Float,
-				*schema.Int, *schema.Module, *schema.String, *schema.Time,
-				*schema.Unit, *schema.Any, *schema.TypeParameter, *schema.Enum,
-				*schema.Config, *schema.Secret:
+			case *schema.Database, *schema.Enum, *schema.Config, *schema.Secret:
 			}
 		}
 

--- a/backend/controller/ingress/ingress.go
+++ b/backend/controller/ingress/ingress.go
@@ -94,7 +94,7 @@ func getBodyField(ref *schema.Ref, sch *schema.Schema) (*schema.Field, error) {
 	return bodyField, nil
 }
 
-func validateValue(fieldType schema.Type, path path, value any, sch *schema.Schema) error {
+func validateValue(fieldType schema.Type, path path, value any, sch *schema.Schema) error { //nolint:maintidx
 	var typeMatches bool
 	switch fieldType := fieldType.(type) {
 	case *schema.Any:
@@ -222,6 +222,9 @@ func validateValue(fieldType schema.Type, path path, value any, sch *schema.Sche
 			if !typeMatches {
 				return fmt.Errorf("%s is not a valid variant of enum %s", value, fieldType)
 			}
+
+		case *schema.Config, *schema.Database, *schema.Secret:
+
 		}
 
 	case *schema.Bytes:

--- a/backend/schema/any.go
+++ b/backend/schema/any.go
@@ -13,11 +13,12 @@ type Any struct {
 }
 
 var _ Type = (*Any)(nil)
+var _ Symbol = (*Any)(nil)
 
 func (a *Any) Position() Position     { return a.Pos }
 func (*Any) schemaChildren() []Node   { return nil }
 func (*Any) schemaType()              {}
-func (*Any) schemaDecl()              {}
+func (*Any) schemaSymbol()            {}
 func (*Any) String() string           { return "Any" }
 func (a *Any) ToProto() proto.Message { return &schemapb.Any{Pos: posToProto(a.Pos)} }
 func (*Any) GetName() string          { return "" }

--- a/backend/schema/bool.go
+++ b/backend/schema/bool.go
@@ -13,12 +13,12 @@ type Bool struct {
 }
 
 var _ Type = (*Bool)(nil)
-var _ Decl = (*Bool)(nil)
+var _ Symbol = (*Bool)(nil)
 
 func (b *Bool) Position() Position     { return b.Pos }
 func (*Bool) schemaChildren() []Node   { return nil }
 func (*Bool) schemaType()              {}
-func (*Bool) schemaDecl()              {}
+func (*Bool) schemaSymbol()            {}
 func (*Bool) String() string           { return "Bool" }
 func (b *Bool) ToProto() proto.Message { return &schemapb.Bool{Pos: posToProto(b.Pos)} }
 func (*Bool) GetName() string          { return "" }

--- a/backend/schema/bytes.go
+++ b/backend/schema/bytes.go
@@ -13,12 +13,12 @@ type Bytes struct {
 }
 
 var _ Type = (*Bytes)(nil)
-var _ Decl = (*Bytes)(nil)
+var _ Symbol = (*Bytes)(nil)
 
 func (b *Bytes) Position() Position     { return b.Pos }
 func (*Bytes) schemaChildren() []Node   { return nil }
 func (*Bytes) schemaType()              {}
-func (*Bytes) schemaDecl()              {}
+func (*Bytes) schemaSymbol()            {}
 func (*Bytes) String() string           { return "Bytes" }
 func (b *Bytes) ToProto() proto.Message { return &schemapb.Bytes{Pos: posToProto(b.Pos)} }
 func (*Bytes) GetName() string          { return "" }

--- a/backend/schema/config.go
+++ b/backend/schema/config.go
@@ -16,6 +16,7 @@ type Config struct {
 }
 
 var _ Decl = (*Config)(nil)
+var _ Symbol = (*Config)(nil)
 
 func (s *Config) GetName() string    { return s.Name }
 func (s *Config) Position() Position { return s.Pos }
@@ -30,8 +31,8 @@ func (s *Config) ToProto() protoreflect.ProtoMessage {
 }
 
 func (s *Config) schemaChildren() []Node { return []Node{s.Type} }
-
-func (s *Config) schemaDecl() {}
+func (s *Config) schemaDecl()            {}
+func (s *Config) schemaSymbol()          {}
 
 func ConfigFromProto(p *schemapb.Config) *Config {
 	return &Config{

--- a/backend/schema/data.go
+++ b/backend/schema/data.go
@@ -22,12 +22,13 @@ type Data struct {
 }
 
 var _ Decl = (*Data)(nil)
+var _ Symbol = (*Data)(nil)
 var _ Scoped = (*Data)(nil)
 
 func (d *Data) Scope() Scope {
 	scope := Scope{}
 	for _, t := range d.TypeParameters {
-		scope[t.Name] = ModuleDecl{Decl: t}
+		scope[t.Name] = ModuleDecl{Symbol: t}
 	}
 	return scope
 }
@@ -120,7 +121,7 @@ func (d *Data) Monomorphise(ref *Ref) (*Data, error) {
 			Metadata, *MetadataCalls, *MetadataDatabases, *MetadataIngress,
 			*MetadataAlias, *Module, *Schema, *String, *Time, Type, *TypeParameter,
 			*Unit, *Verb, *Enum, *EnumVariant,
-			Value, *IntValue, *StringValue:
+			Value, *IntValue, *StringValue, Symbol:
 		}
 		return next()
 	})
@@ -132,6 +133,7 @@ func (d *Data) Monomorphise(ref *Ref) (*Data, error) {
 
 func (d *Data) Position() Position { return d.Pos }
 func (*Data) schemaDecl()          {}
+func (*Data) schemaSymbol()        {}
 func (d *Data) schemaChildren() []Node {
 	children := make([]Node, 0, len(d.Fields)+len(d.Metadata))
 	for _, t := range d.TypeParameters {

--- a/backend/schema/database.go
+++ b/backend/schema/database.go
@@ -17,9 +17,11 @@ type Database struct {
 }
 
 var _ Decl = (*Database)(nil)
+var _ Symbol = (*Database)(nil)
 
 func (d *Database) Position() Position     { return d.Pos }
 func (*Database) schemaDecl()              {}
+func (*Database) schemaSymbol()            {}
 func (d *Database) schemaChildren() []Node { return nil }
 func (d *Database) String() string {
 	w := &strings.Builder{}

--- a/backend/schema/enum.go
+++ b/backend/schema/enum.go
@@ -19,6 +19,7 @@ type Enum struct {
 }
 
 var _ Decl = (*Enum)(nil)
+var _ Symbol = (*Enum)(nil)
 
 func (e *Enum) Position() Position { return e.Pos }
 
@@ -32,7 +33,8 @@ func (e *Enum) String() string {
 	fmt.Fprint(w, "}")
 	return w.String()
 }
-func (*Enum) schemaDecl() {}
+func (*Enum) schemaDecl()   {}
+func (*Enum) schemaSymbol() {}
 func (e *Enum) schemaChildren() []Node {
 	children := make([]Node, 1+len(e.Variants))
 	children[0] = e.Type

--- a/backend/schema/float.go
+++ b/backend/schema/float.go
@@ -13,12 +13,12 @@ type Float struct {
 }
 
 var _ Type = (*Float)(nil)
-var _ Decl = (*Float)(nil)
+var _ Symbol = (*Float)(nil)
 
 func (f *Float) Position() Position     { return f.Pos }
 func (*Float) schemaChildren() []Node   { return nil }
 func (*Float) schemaType()              {}
-func (*Float) schemaDecl()              {}
+func (*Float) schemaSymbol()            {}
 func (*Float) String() string           { return "Float" }
 func (f *Float) ToProto() proto.Message { return &schemapb.Float{Pos: posToProto(f.Pos)} }
 func (*Float) GetName() string          { return "" }

--- a/backend/schema/int.go
+++ b/backend/schema/int.go
@@ -13,10 +13,10 @@ type Int struct {
 }
 
 var _ Type = (*Int)(nil)
-var _ Decl = (*Int)(nil)
+var _ Symbol = (*Int)(nil)
 
 func (i *Int) Position() Position     { return i.Pos }
-func (*Int) schemaDecl()              {}
+func (*Int) schemaSymbol()            {}
 func (*Int) schemaChildren() []Node   { return nil }
 func (*Int) schemaType()              {}
 func (*Int) String() string           { return "Int" }

--- a/backend/schema/jsonschema.go
+++ b/backend/schema/jsonschema.go
@@ -159,7 +159,7 @@ func nodeToJSSchema(node Node, dataRefs map[RefKey]*Ref) *jsonschema.Schema {
 	case Decl, *Field, Metadata, *MetadataCalls, *MetadataDatabases, *MetadataIngress,
 		*MetadataAlias, IngressPathComponent, *IngressPathLiteral, *IngressPathParameter, *Module,
 		*Schema, Type, *Database, *Verb, *Enum, *EnumVariant,
-		Value, *StringValue, *IntValue, *Config, *Secret:
+		Value, *StringValue, *IntValue, *Config, *Secret, Symbol:
 		panic(fmt.Sprintf("unsupported node type %T", node))
 
 	default:

--- a/backend/schema/module.go
+++ b/backend/schema/module.go
@@ -24,7 +24,7 @@ type Module struct {
 }
 
 var _ Node = (*Module)(nil)
-var _ Decl = (*Module)(nil)
+var _ Symbol = (*Module)(nil)
 var _ sql.Scanner = (*Module)(nil)
 var _ driver.Valuer = (*Module)(nil)
 
@@ -63,8 +63,8 @@ func (m *Module) Scope() Scope {
 		case *Secret:
 			scope[d.Name] = ModuleDecl{m, d}
 
-		case *Bool, *Bytes, *Database, *Float, *Int, *Module, *String, *Time,
-			*Unit, *Any, *TypeParameter:
+		case *Database:
+			scope[d.Name] = ModuleDecl{m, d}
 		}
 	}
 	return scope
@@ -76,40 +76,14 @@ func (m *Module) Resolve(ref Ref) *ModuleDecl {
 		return nil
 	}
 	for _, d := range m.Decls {
-		switch d := d.(type) {
-		case *Data:
-			if d.Name == ref.Name {
-				return &ModuleDecl{m, d}
-			}
-
-		case *Verb:
-			if d.Name == ref.Name {
-				return &ModuleDecl{m, d}
-			}
-
-		case *Enum:
-			if d.Name == ref.Name {
-				return &ModuleDecl{m, d}
-			}
-
-		case *Config:
-			if d.Name == ref.Name {
-				return &ModuleDecl{m, d}
-			}
-
-		case *Secret:
-			if d.Name == ref.Name {
-				return &ModuleDecl{m, d}
-			}
-
-		case *Bool, *Bytes, *Database, *Float, *Int, *Module, *String, *Time,
-			*Unit, *Any, *TypeParameter:
+		if d.GetName() == ref.Name {
+			return &ModuleDecl{m, d}
 		}
 	}
 	return nil
 }
 
-func (m *Module) schemaDecl()        {}
+func (m *Module) schemaSymbol()      {}
 func (m *Module) Position() Position { return m.Pos }
 func (m *Module) schemaChildren() []Node {
 	children := make([]Node, 0, len(m.Decls))

--- a/backend/schema/normalise.go
+++ b/backend/schema/normalise.go
@@ -130,7 +130,7 @@ func Normalise[T Node](n T) T {
 		c.Pos = zero
 		c.Type = Normalise(c.Type)
 
-	case Decl, Metadata, IngressPathComponent, Type, Value: // Can never occur in reality, but here to satisfy the sum-type check.
+	case Symbol, Decl, Metadata, IngressPathComponent, Type, Value: // Can never occur in reality, but here to satisfy the sum-type check.
 		panic("??")
 	}
 	return ni.(T) //nolint:forcetypeassert

--- a/backend/schema/parser.go
+++ b/backend/schema/parser.go
@@ -118,11 +118,23 @@ type Value interface {
 	schemaValueType() Type
 }
 
-// Decl represents a type declaration in the schema grammar.
+// Symbol represents a symbol in the schema grammar.
+//
+// A Symbol is a named type that can be referenced by other types. This includes
+// user defined data types such as data structures and enums, and builtin types.
+//
+//sumtype:decl
+type Symbol interface {
+	Node
+	GetName() string
+	schemaSymbol()
+}
+
+// Decl represents user-defined data types in the schema grammar.
 //
 //sumtype:decl
 type Decl interface {
-	Node
+	Symbol
 	GetName() string
 	schemaDecl()
 }

--- a/backend/schema/protobuf_enc.go
+++ b/backend/schema/protobuf_enc.go
@@ -43,9 +43,6 @@ func declListToProto(nodes []Decl) []*schemapb.Decl {
 
 		case *Secret:
 			v = &schemapb.Decl_Secret{Secret: n.ToProto().(*schemapb.Secret)}
-
-		case *Bool, *Bytes, *Float, *Int, *Module, *String, *Time, *Unit, *Any,
-			*TypeParameter:
 		}
 		out[i] = &schemapb.Decl{Value: v}
 	}

--- a/backend/schema/secret.go
+++ b/backend/schema/secret.go
@@ -16,6 +16,7 @@ type Secret struct {
 }
 
 var _ Decl = (*Secret)(nil)
+var _ Symbol = (*Secret)(nil)
 
 func (s *Secret) GetName() string    { return s.Name }
 func (s *Secret) Position() Position { return s.Pos }
@@ -31,7 +32,8 @@ func (s *Secret) ToProto() protoreflect.ProtoMessage {
 
 func (s *Secret) schemaChildren() []Node { return []Node{s.Type} }
 
-func (s *Secret) schemaDecl() {}
+func (s *Secret) schemaDecl()   {}
+func (s *Secret) schemaSymbol() {}
 
 func SecretFromProto(p *schemapb.Secret) *Secret {
 	return &Secret{

--- a/backend/schema/string.go
+++ b/backend/schema/string.go
@@ -13,12 +13,12 @@ type String struct {
 }
 
 var _ Type = (*String)(nil)
-var _ Decl = (*String)(nil)
+var _ Symbol = (*String)(nil)
 
 func (s *String) Position() Position     { return s.Pos }
 func (*String) schemaChildren() []Node   { return nil }
 func (*String) schemaType()              {}
-func (*String) schemaDecl()              {}
+func (*String) schemaSymbol()            {}
 func (*String) String() string           { return "String" }
 func (s *String) ToProto() proto.Message { return &schemapb.String{Pos: posToProto(s.Pos)} }
 func (*String) GetName() string          { return "" }

--- a/backend/schema/time.go
+++ b/backend/schema/time.go
@@ -13,12 +13,12 @@ type Time struct {
 }
 
 var _ Type = (*Time)(nil)
-var _ Decl = (*Time)(nil)
+var _ Symbol = (*Time)(nil)
 
 func (t *Time) Position() Position     { return t.Pos }
 func (*Time) schemaChildren() []Node   { return nil }
 func (*Time) schemaType()              {}
-func (*Time) schemaDecl()              {}
+func (*Time) schemaSymbol()            {}
 func (*Time) String() string           { return "Time" }
 func (t *Time) ToProto() proto.Message { return &schemapb.Time{Pos: posToProto(t.Pos)} }
 func (*Time) GetName() string          { return "" }

--- a/backend/schema/typeparameter.go
+++ b/backend/schema/typeparameter.go
@@ -12,7 +12,7 @@ type TypeParameter struct {
 	Name string `parser:"@Ident" protobuf:"2"`
 }
 
-var _ Decl = (*TypeParameter)(nil)
+var _ Symbol = (*TypeParameter)(nil)
 
 func (t *TypeParameter) Position() Position { return t.Pos }
 func (t *TypeParameter) String() string     { return t.Name }
@@ -20,7 +20,7 @@ func (t *TypeParameter) ToProto() protoreflect.ProtoMessage {
 	return &schemapb.TypeParameter{Pos: posToProto(t.Pos), Name: t.Name}
 }
 func (t *TypeParameter) schemaChildren() []Node { return nil }
-func (t *TypeParameter) schemaDecl()            {}
+func (t *TypeParameter) schemaSymbol()          {}
 func (t *TypeParameter) GetName() string        { return t.Name }
 
 func typeParametersToSchema(s []*schemapb.TypeParameter) []*TypeParameter {

--- a/backend/schema/unit.go
+++ b/backend/schema/unit.go
@@ -13,11 +13,11 @@ type Unit struct {
 }
 
 var _ Type = (*Unit)(nil)
-var _ Decl = (*Unit)(nil)
+var _ Symbol = (*Unit)(nil)
 
 func (u *Unit) Position() Position                 { return u.Pos }
 func (u *Unit) schemaType()                        {}
-func (u *Unit) schemaDecl()                        {}
+func (u *Unit) schemaSymbol()                      {}
 func (u *Unit) String() string                     { return "Unit" }
 func (u *Unit) ToProto() protoreflect.ProtoMessage { return &schemapb.Unit{Pos: posToProto(u.Pos)} }
 func (u *Unit) schemaChildren() []Node             { return nil }

--- a/backend/schema/validate.go
+++ b/backend/schema/validate.go
@@ -21,14 +21,14 @@ var (
 	// We don't need Array/Map/Ref here because there are no
 	// keywords associated with these types.
 	primitivesScope = Scope{
-		"Int":    ModuleDecl{Decl: &Int{}},
-		"Float":  ModuleDecl{Decl: &Float{}},
-		"String": ModuleDecl{Decl: &String{}},
-		"Bytes":  ModuleDecl{Decl: &Bytes{}},
-		"Bool":   ModuleDecl{Decl: &Bool{}},
-		"Time":   ModuleDecl{Decl: &Time{}},
-		"Unit":   ModuleDecl{Decl: &Unit{}},
-		"Any":    ModuleDecl{Decl: &Any{}},
+		"Int":    ModuleDecl{Symbol: &Int{}},
+		"Float":  ModuleDecl{Symbol: &Float{}},
+		"String": ModuleDecl{Symbol: &String{}},
+		"Bytes":  ModuleDecl{Symbol: &Bytes{}},
+		"Bool":   ModuleDecl{Symbol: &Bool{}},
+		"Time":   ModuleDecl{Symbol: &Time{}},
+		"Unit":   ModuleDecl{Symbol: &Unit{}},
+		"Any":    ModuleDecl{Symbol: &Any{}},
 	}
 )
 
@@ -100,7 +100,7 @@ func Validate(schema *Schema) (*Schema, error) {
 			switch n := n.(type) {
 			case *Ref:
 				if mdecl := scopes.Resolve(*n); mdecl != nil {
-					switch decl := mdecl.Decl.(type) {
+					switch decl := mdecl.Symbol.(type) {
 					case *Verb, *Enum:
 						if mdecl.Module != nil {
 							n.Module = mdecl.Module.Name
@@ -120,7 +120,7 @@ func Validate(schema *Schema) (*Schema, error) {
 
 					case *TypeParameter:
 					default:
-						merr = append(merr, fmt.Errorf("%s: invalid reference %q at %q", n.Pos, n, mdecl.Decl.Position()))
+						merr = append(merr, fmt.Errorf("%s: invalid reference %q at %q", n.Pos, n, mdecl.Symbol.Position()))
 
 					}
 				} else {
@@ -161,7 +161,7 @@ func Validate(schema *Schema) (*Schema, error) {
 				*Int, *Map, Metadata, *MetadataCalls, *MetadataDatabases,
 				*MetadataIngress, *MetadataAlias, *Module, *Optional, *Schema,
 				*String, *Time, Type, *Unit, *Any, *TypeParameter, *EnumVariant,
-				Value, *IntValue, *StringValue, *Config, *Secret:
+				Value, *IntValue, *StringValue, *Config, *Secret, Symbol:
 			}
 			return next()
 		})
@@ -208,7 +208,7 @@ func ValidateModule(module *Module) error {
 		switch n := n.(type) {
 		case *Ref:
 			if mdecl := scopes.Resolve(*n); mdecl != nil {
-				switch decl := mdecl.Decl.(type) {
+				switch decl := mdecl.Symbol.(type) {
 				case *Verb, *Enum:
 					n.Module = mdecl.Module.Name
 					if len(n.TypeParameters) != 0 {
@@ -285,7 +285,7 @@ func ValidateModule(module *Module) error {
 			IngressPathComponent, *IngressPathLiteral, *IngressPathParameter, *Optional,
 			*Unit, *Any, *TypeParameter, *Enum, *EnumVariant, *IntValue, *StringValue:
 
-		case Type, Metadata, Decl, Value: // Union types.
+		case Symbol, Type, Metadata, Decl, Value: // Union types.
 		}
 		return next()
 	})

--- a/backend/schema/verb.go
+++ b/backend/schema/verb.go
@@ -20,20 +20,12 @@ type Verb struct {
 	Metadata []Metadata `parser:"@@*" protobuf:"6"`
 }
 
-// verb mySink(Req) Unit
-// verb mySource(Unit) Req
-//
-// func MySource(context.Context) (Req, error) {}
-//
-// func Checkout(ctx context.Context, req CheckoutRequest) (CheckoutResponse, error) {
-//    addresses, err := ftl.Call(ctx, GetAddress, req.User)
-//    addresses, err := ftl.Call(ctx, GetAddress, GetAddressRequest{User: req.User})
-// 	  return CheckoutResponse{}, nil
-
 var _ Decl = (*Verb)(nil)
+var _ Symbol = (*Verb)(nil)
 
 func (v *Verb) Position() Position { return v.Pos }
 func (v *Verb) schemaDecl()        {}
+func (v *Verb) schemaSymbol()      {}
 func (v *Verb) schemaChildren() []Node {
 	children := make([]Node, 2+len(v.Metadata))
 	children[0] = v.Request

--- a/buildengine/build_kotlin.go
+++ b/buildengine/build_kotlin.go
@@ -9,11 +9,10 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/TBD54566975/scaffolder"
 	"github.com/beevik/etree"
 	sets "github.com/deckarep/golang-set/v2"
 	"golang.org/x/exp/maps"
-
-	"github.com/TBD54566975/scaffolder"
 
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/schema"

--- a/buildengine/build_kotlin.go
+++ b/buildengine/build_kotlin.go
@@ -9,10 +9,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/TBD54566975/scaffolder"
 	"github.com/beevik/etree"
 	sets "github.com/deckarep/golang-set/v2"
 	"golang.org/x/exp/maps"
+
+	"github.com/TBD54566975/scaffolder"
 
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/schema"
@@ -183,7 +184,7 @@ func genType(module *schema.Module, t schema.Type) string {
 			Name:   t.Name,
 		})
 		if decl != nil {
-			if data, ok := decl.Decl.(*schema.Data); ok {
+			if data, ok := decl.Symbol.(*schema.Data); ok {
 				if len(data.Fields) == 0 {
 					return "ftl.builtin.Empty"
 				}


### PR DESCRIPTION
Previously the two were conflated such that builtin types were treated as declarations, making some type switches much more verbose than necessary. The Decl type was also used to resolve types during symbol resolution, now the Symbol type is used for that, more closely matching its intended purpose.

Also fix a bug where linters weren't failing CI.