### PR TITLE
fix: ftl dev hanging with `--stop` flag

### DIFF
--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -26,9 +26,17 @@ func (d *devCmd) Run(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	if !d.NoServe {
+		if d.ServeCmd.Stop {
+			err := d.ServeCmd.Run(ctx)
+			if err != nil {
+				return err
+			}
+			d.ServeCmd.Stop = false
+		}
 		if d.ServeCmd.isRunning(ctx, client) {
 			return errors.New("FTL is already running")
 		}
+
 		g.Go(func() error {
 			return d.ServeCmd.Run(ctx)
 		})

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -53,7 +53,7 @@ func (s *serveCmd) Run(ctx context.Context) error {
 		if s.Stop {
 			// allow usage of --background and --stop together to "restart" the background process
 			// ignore error here if the process is not running
-			_ = killBackgroundProcess(logger)
+			_ = KillBackgroundServe(logger)
 		}
 
 		runInBackground(logger)
@@ -67,7 +67,7 @@ func (s *serveCmd) Run(ctx context.Context) error {
 	}
 
 	if s.Stop {
-		return killBackgroundProcess(logger)
+		return KillBackgroundServe(logger)
 	}
 
 	if s.isRunning(ctx, client) {
@@ -166,7 +166,7 @@ func runInBackground(logger *log.Logger) {
 	logger.Infof("`ftl serve` running in background with pid: %d", cmd.Process.Pid)
 }
 
-func killBackgroundProcess(logger *log.Logger) error {
+func KillBackgroundServe(logger *log.Logger) error {
 	pidFilePath, err := pidFilePath()
 	if err != nil {
 		logger.Infof("No background process found")


### PR DESCRIPTION
I don't love this flow at the moment given how confusing the `--stop` flag can be to use, but this fixes the issue. Hopefully, as we nail down the ergonomics of how we want this to work we can help to avoid confusion in the future.

Without FTL running:
```sh
ftl dev --stop --recreate examples/go
info: Starting FTL with 1 controller(s)
info:controller0: Web console available at: http://localhost:8892
info:time: Building module
info:time: Deploying module
...
```

If FTL is running in the background:
```sh
ftl dev --stop --recreate examples/go
info: `ftl serve` stopped (pid: 41006)
info: Starting FTL with 1 controller(s)
info:controller0: Web console available at: http://localhost:8892
info:time: Building module
...
``` 