### PR TITLE
chore: improve ingress schema validation

### DIFF
--- a/backend/schema/any.go
+++ b/backend/schema/any.go
@@ -21,4 +21,4 @@ func (*Any) schemaType()              {}
 func (*Any) schemaSymbol()            {}
 func (*Any) String() string           { return "Any" }
 func (a *Any) ToProto() proto.Message { return &schemapb.Any{Pos: posToProto(a.Pos)} }
-func (*Any) GetName() string          { return "" }
+func (*Any) GetName() string          { return "Any" }

--- a/backend/schema/array.go
+++ b/backend/schema/array.go
@@ -13,10 +13,12 @@ type Array struct {
 }
 
 var _ Type = (*Array)(nil)
+var _ Symbol = (*Array)(nil)
 
 func (a *Array) Position() Position     { return a.Pos }
 func (a *Array) schemaChildren() []Node { return []Node{a.Element} }
-func (*Array) schemaType()              {}
+func (a *Array) schemaType()            {}
+func (a *Array) schemaSymbol()          {}
 func (a *Array) String() string         { return "[" + a.Element.String() + "]" }
 
 func (a *Array) ToProto() proto.Message {

--- a/backend/schema/bool.go
+++ b/backend/schema/bool.go
@@ -21,4 +21,4 @@ func (*Bool) schemaType()              {}
 func (*Bool) schemaSymbol()            {}
 func (*Bool) String() string           { return "Bool" }
 func (b *Bool) ToProto() proto.Message { return &schemapb.Bool{Pos: posToProto(b.Pos)} }
-func (*Bool) GetName() string          { return "" }
+func (*Bool) GetName() string          { return "Bool" }

--- a/backend/schema/bytes.go
+++ b/backend/schema/bytes.go
@@ -21,4 +21,4 @@ func (*Bytes) schemaType()              {}
 func (*Bytes) schemaSymbol()            {}
 func (*Bytes) String() string           { return "Bytes" }
 func (b *Bytes) ToProto() proto.Message { return &schemapb.Bytes{Pos: posToProto(b.Pos)} }
-func (*Bytes) GetName() string          { return "" }
+func (*Bytes) GetName() string          { return "Bytes" }

--- a/backend/schema/data.go
+++ b/backend/schema/data.go
@@ -121,7 +121,7 @@ func (d *Data) Monomorphise(ref *Ref) (*Data, error) {
 			Metadata, *MetadataCalls, *MetadataDatabases, *MetadataIngress,
 			*MetadataAlias, *Module, *Schema, *String, *Time, Type, *TypeParameter,
 			*Unit, *Verb, *Enum, *EnumVariant,
-			Value, *IntValue, *StringValue, Symbol:
+			Value, *IntValue, *StringValue, Symbol, Named:
 		}
 		return next()
 	})

--- a/backend/schema/float.go
+++ b/backend/schema/float.go
@@ -21,4 +21,4 @@ func (*Float) schemaType()              {}
 func (*Float) schemaSymbol()            {}
 func (*Float) String() string           { return "Float" }
 func (f *Float) ToProto() proto.Message { return &schemapb.Float{Pos: posToProto(f.Pos)} }
-func (*Float) GetName() string          { return "" }
+func (*Float) GetName() string          { return "Float" }

--- a/backend/schema/int.go
+++ b/backend/schema/int.go
@@ -21,4 +21,4 @@ func (*Int) schemaChildren() []Node   { return nil }
 func (*Int) schemaType()              {}
 func (*Int) String() string           { return "Int" }
 func (i *Int) ToProto() proto.Message { return &schemapb.Int{Pos: posToProto(i.Pos)} }
-func (*Int) GetName() string          { return "" }
+func (*Int) GetName() string          { return "Int" }

--- a/backend/schema/jsonschema.go
+++ b/backend/schema/jsonschema.go
@@ -164,7 +164,7 @@ func nodeToJSSchema(node Node, refs map[RefKey]*Ref) *jsonschema.Schema {
 	case Decl, *Field, Metadata, *MetadataCalls, *MetadataDatabases, *MetadataIngress,
 		*MetadataAlias, IngressPathComponent, *IngressPathLiteral, *IngressPathParameter, *Module,
 		*Schema, Type, *Database, *Verb, *EnumVariant,
-		Value, *StringValue, *IntValue, *Config, *Secret, Symbol:
+		Value, *StringValue, *IntValue, *Config, *Secret, Symbol, Named:
 		panic(fmt.Sprintf("unsupported node type %T", node))
 
 	default:

--- a/backend/schema/map.go
+++ b/backend/schema/map.go
@@ -16,10 +16,12 @@ type Map struct {
 }
 
 var _ Type = (*Map)(nil)
+var _ Symbol = (*Map)(nil)
 
 func (m *Map) Position() Position     { return m.Pos }
 func (m *Map) schemaChildren() []Node { return []Node{m.Key, m.Value} }
 func (*Map) schemaType()              {}
+func (*Map) schemaSymbol()            {}
 func (m *Map) String() string         { return fmt.Sprintf("{%s: %s}", m.Key.String(), m.Value.String()) }
 
 func (m *Map) ToProto() proto.Message {

--- a/backend/schema/normalise.go
+++ b/backend/schema/normalise.go
@@ -130,7 +130,7 @@ func Normalise[T Node](n T) T {
 		c.Pos = zero
 		c.Type = Normalise(c.Type)
 
-	case Symbol, Decl, Metadata, IngressPathComponent, Type, Value: // Can never occur in reality, but here to satisfy the sum-type check.
+	case Named, Symbol, Decl, Metadata, IngressPathComponent, Type, Value: // Can never occur in reality, but here to satisfy the sum-type check.
 		panic("??")
 	}
 	return ni.(T) //nolint:forcetypeassert

--- a/backend/schema/optional.go
+++ b/backend/schema/optional.go
@@ -14,10 +14,12 @@ type Optional struct {
 }
 
 var _ Type = (*Optional)(nil)
+var _ Symbol = (*Optional)(nil)
 
 func (o *Optional) Position() Position     { return o.Pos }
 func (o *Optional) String() string         { return o.Type.String() + "?" }
 func (*Optional) schemaType()              {}
+func (*Optional) schemaSymbol()            {}
 func (o *Optional) schemaChildren() []Node { return []Node{o.Type} }
 func (o *Optional) ToProto() proto.Message {
 	return &schemapb.Optional{Pos: posToProto(o.Pos), Type: typeToProto(o.Type)}

--- a/backend/schema/parser.go
+++ b/backend/schema/parser.go
@@ -127,8 +127,13 @@ type Value interface {
 //sumtype:decl
 type Symbol interface {
 	Node
-	GetName() string
 	schemaSymbol()
+}
+
+// A Named symbol in the grammar.
+type Named interface {
+	Symbol
+	GetName() string
 }
 
 // Decl represents user-defined data types in the schema grammar.

--- a/backend/schema/string.go
+++ b/backend/schema/string.go
@@ -21,4 +21,4 @@ func (*String) schemaType()              {}
 func (*String) schemaSymbol()            {}
 func (*String) String() string           { return "String" }
 func (s *String) ToProto() proto.Message { return &schemapb.String{Pos: posToProto(s.Pos)} }
-func (*String) GetName() string          { return "" }
+func (*String) GetName() string          { return "String" }

--- a/backend/schema/time.go
+++ b/backend/schema/time.go
@@ -21,4 +21,4 @@ func (*Time) schemaType()              {}
 func (*Time) schemaSymbol()            {}
 func (*Time) String() string           { return "Time" }
 func (t *Time) ToProto() proto.Message { return &schemapb.Time{Pos: posToProto(t.Pos)} }
-func (*Time) GetName() string          { return "" }
+func (*Time) GetName() string          { return "Time" }

--- a/backend/schema/typeresolver_test.go
+++ b/backend/schema/typeresolver_test.go
@@ -1,0 +1,41 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestTypeResolver(t *testing.T) {
+	module, err := ParseModuleString("", `
+		module test {
+			data Request<T> {
+				t T
+			}
+			verb test(Request<String>) Empty
+		}
+	`)
+	assert.NoError(t, err)
+	scopes := NewScopes()
+	scopes = scopes.PushScope(module.Scope())
+
+	// Resolve a builtin.
+	actualInt, _ := ResolveAs[*Int](scopes, Ref{Name: "Int"})
+	assert.NotZero(t, actualInt)
+	assert.Equal(t, &Int{}, actualInt, assert.Exclude[Position]())
+
+	// Resolve a generic data structure.
+	actualData, _ := ResolveAs[*Data](scopes, Ref{Module: "test", Name: "Request"})
+	assert.NotZero(t, actualData)
+	expectedData := &Data{
+		Name:           "Request",
+		TypeParameters: []*TypeParameter{{Name: "T"}},
+		Fields:         []*Field{{Name: "t", Type: &Ref{Name: "T"}}},
+	}
+	assert.Equal(t, expectedData, actualData, assert.Exclude[Position]())
+
+	// Resolve a type parameter.
+	scopes = scopes.PushScope(actualData.Scope())
+	actualTP, _ := ResolveAs[*TypeParameter](scopes, Ref{Name: "T"})
+	assert.Equal(t, actualTP, &TypeParameter{Name: "T"}, assert.Exclude[Position]())
+}

--- a/backend/schema/unit.go
+++ b/backend/schema/unit.go
@@ -21,4 +21,4 @@ func (u *Unit) schemaSymbol()                      {}
 func (u *Unit) String() string                     { return "Unit" }
 func (u *Unit) ToProto() protoreflect.ProtoMessage { return &schemapb.Unit{Pos: posToProto(u.Pos)} }
 func (u *Unit) schemaChildren() []Node             { return nil }
-func (u *Unit) GetName() string                    { return "" }
+func (u *Unit) GetName() string                    { return "Unit" }

--- a/backend/schema/validate_test.go
+++ b/backend/schema/validate_test.go
@@ -1,0 +1,162 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/internal/errors"
+	"github.com/TBD54566975/ftl/internal/slices"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		errs   []string
+	}{
+		{name: "TwoModuleCycle",
+			schema: `
+				module one {
+					verb one(Empty) Empty
+						+calls two.two
+				}
+
+				module two {
+					verb two(Empty) Empty
+						+calls one.one
+				}
+				`,
+			errs: []string{"found cycle in dependencies: two -> one -> two"}},
+		{name: "ThreeModulesNoCycle",
+			schema: `
+				module one {
+					verb one(Empty) Empty
+						+calls two.two
+				}
+
+				module two {
+					verb two(Empty) Empty
+						+calls three.three
+				}
+
+				module three {
+					verb three(Empty) Empty
+				}
+				`},
+		{name: "ThreeModulesCycle",
+			schema: `
+				module one {
+					verb one(Empty) Empty
+						+calls two.two
+				}
+
+				module two {
+					verb two(Empty) Empty
+						+calls three.three
+				}
+
+				module three {
+					verb three(Empty) Empty
+						+calls one.one
+				}
+				`,
+			errs: []string{"found cycle in dependencies: two -> three -> one -> two"}},
+		{name: "TwoModuleCycleDiffVerbs",
+			schema: `
+				module one {
+					verb a(Empty) Empty
+						+calls two.a
+					verb b(Empty) Empty
+				}
+
+				module two {
+					verb a(Empty) Empty
+						+calls one.b
+				}
+				`,
+			errs: []string{"found cycle in dependencies: two -> one -> two"}},
+		{name: "SelfReference",
+			schema: `
+				module one {
+					verb a(Empty) Empty
+						+calls one.b
+
+					verb b(Empty) Empty
+						+calls one.a
+				}
+			`},
+		{name: "ValidIngressRequestType",
+			schema: `
+				module one {
+					verb a(HttpRequest<Empty>) HttpResponse<Empty, Empty>
+						+ingress http GET /a
+				}
+			`},
+		{name: "InvalidIngressRequestType",
+			schema: `
+				module one {
+					verb a(Empty) Empty
+						+ingress http GET /a
+				}
+			`,
+			errs: []string{
+				"3:13: ingress verb a: request type Empty must be builtin.HttpRequest",
+				"3:20: ingress verb a: response type Empty must be builtin.HttpRequest",
+			}},
+		{name: "IngressBodyTypes",
+			schema: `
+				module one {
+					verb bytes(HttpRequest<Bytes>) HttpResponse<Bytes, Bytes>
+						+ingress http GET /bytes
+					verb string(HttpRequest<String>) HttpResponse<String, String>
+						+ingress http GET /string
+					verb data(HttpRequest<Empty>) HttpResponse<Empty, Empty>
+						+ingress http GET /data
+
+					// Invalid types.
+					verb int(HttpRequest<Int>) HttpResponse<Int, Int>
+						+ingress http GET /int
+					verb bool(HttpRequest<Bool>) HttpResponse<Bool, Bool>
+						+ingress http GET /bool
+					verb any(HttpRequest<Any>) HttpResponse<Any, Any>
+						+ingress http GET /any
+					verb path(HttpRequest<String>) HttpResponse<String, String>
+						+ingress http GET /path/{invalid}
+					verb pathMissing(HttpRequest<Path>) HttpResponse<String, String>
+						+ingress http GET /path/{missing}
+					verb pathFound(HttpRequest<Path>) HttpResponse<String, String>
+						+ingress http GET /path/{parameter}
+
+					data Path {
+						parameter String
+					}
+				}
+			`,
+			errs: []string{
+				"11:15: ingress verb int: request type HttpRequest<Int> must have a body of type Bytes, String or Data, not Int",
+				"11:33: ingress verb int: response type HttpResponse<Int, Int> must have a body of type Bytes, String or Data, not Int",
+				"13:16: ingress verb bool: request type HttpRequest<Bool> must have a body of type Bytes, String or Data, not Bool",
+				"13:35: ingress verb bool: response type HttpResponse<Bool, Bool> must have a body of type Bytes, String or Data, not Bool",
+				"15:15: ingress verb any: request type HttpRequest<Any> must have a body of type Bytes, String or Data, not Any",
+				"15:33: ingress verb any: response type HttpResponse<Any, Any> must have a body of type Bytes, String or Data, not Any",
+				"18:31: ingress verb path: cannot use path parameter \"invalid\" with request type String, expected Data type",
+				"20:7: duplicate http ingress GET /path/{} for 21:6:\"pathFound\" and 19:6:\"pathMissing\"",
+				"20:31: ingress verb pathMissing: request type Path does not contain a field corresponding to the parameter \"missing\"",
+				"22:7: duplicate http ingress GET /path/{} for 17:6:\"path\" and 21:6:\"pathFound\"",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseString("", test.schema)
+			if test.errs == nil {
+				assert.NoError(t, err)
+			} else {
+				errs := slices.Map(errors.UnwrapAll(err), func(e error) string { return e.Error() })
+				assert.Equal(t, test.errs, errs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This vastly improves ingress schema validation, ensuring that the request/response body types are valid, and that if path parameters are used the request body is a data structure with a corresponding field.

cc @lifeizhou-ap