### PR TITLE
chore: allow manual cache update in GH actions

### DIFF
--- a/.github/workflows/writecache.yml
+++ b/.github/workflows/writecache.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 concurrency:
   group: ${{ github.ref }}-writecache
   cancel-in-progress: true


### PR DESCRIPTION
sort of testing a hypothesis, but i suspect the build cache needs to be rebuilt against [this](https://github.com/TBD54566975/ftl/pull/1117) branch in order for [this](https://github.com/TBD54566975/ftl/actions/runs/8370343139/job/22939654513) to pass 