### PR TITLE
chore: clean up module and library logs

### DIFF
--- a/buildengine/build.go
+++ b/buildengine/build.go
@@ -58,7 +58,7 @@ func buildExternalLibrary(ctx context.Context, sch *schema.Schema, lib ExternalL
 			return err
 		}
 	default:
-		return fmt.Errorf("unknown language %q for %s", lib.Language, lib)
+		return fmt.Errorf("unknown language %q for library %q", lib.Language, lib.Config().Key)
 	}
 
 	logger.Infof("Generated stubs [%s] for %v", strings.Join(imported, ", "), lib)

--- a/buildengine/build_go.go
+++ b/buildengine/build_go.go
@@ -10,14 +10,14 @@ import (
 
 func buildGoModule(ctx context.Context, sch *schema.Schema, module Module) error {
 	if err := compile.Build(ctx, module.Dir, sch); err != nil {
-		return fmt.Errorf("failed to build %q: %w", module, err)
+		return fmt.Errorf("failed to build module %q: %w", module.Config().Key, err)
 	}
 	return nil
 }
 
 func buildGoLibrary(ctx context.Context, sch *schema.Schema, lib ExternalLibrary) error {
 	if err := compile.GenerateStubsForExternalLibrary(ctx, lib.Dir, sch); err != nil {
-		return fmt.Errorf("failed to generate stubs for %q: %w", lib, err)
+		return fmt.Errorf("failed to generate stubs for library %q: %w", lib.Config().Key, err)
 	}
 	return nil
 }

--- a/buildengine/build_kotlin.go
+++ b/buildengine/build_kotlin.go
@@ -59,7 +59,7 @@ func buildKotlinModule(ctx context.Context, sch *schema.Schema, module Module) e
 	logger.Debugf("Using build command '%s'", module.Build)
 	err := exec.Command(ctx, log.Debug, module.Dir, "bash", "-c", module.Build).RunBuffered(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to build module %s: %w", module.Module, err)
+		return fmt.Errorf("failed to build module %q: %w", module.Module, err)
 	}
 
 	return nil
@@ -67,7 +67,7 @@ func buildKotlinModule(ctx context.Context, sch *schema.Schema, module Module) e
 
 func buildKotlinLibrary(ctx context.Context, sch *schema.Schema, lib ExternalLibrary) error {
 	if err := generateExternalModules(ctx, &lib, sch); err != nil {
-		return fmt.Errorf("unable to generate external modules for %v: %w", lib, err)
+		return fmt.Errorf("unable to generate external modules for %q: %w", lib.Config().Key, err)
 	}
 	return nil
 }

--- a/buildengine/deps.go
+++ b/buildengine/deps.go
@@ -23,7 +23,7 @@ import (
 // Project with those dependencies populated.
 func UpdateDependencies(ctx context.Context, project Project) (Project, error) {
 	logger := log.FromContext(ctx)
-	logger.Debugf("Extracting dependencies for %s", project)
+	logger.Debugf("Extracting dependencies for %s %q", project.TypeString(), project.Config().Key)
 	dependencies, err := extractDependencies(project)
 	if err != nil {
 		return Project(&Module{}), err

--- a/buildengine/project.go
+++ b/buildengine/project.go
@@ -18,7 +18,7 @@ type Project interface {
 
 	Config() ProjectConfig
 	CopyWithDependencies([]string) Project
-	String() string
+	TypeString() string
 }
 
 type ProjectConfig struct {
@@ -56,8 +56,8 @@ func (m Module) CopyWithDependencies(dependencies []string) Project {
 	return Project(module)
 }
 
-func (m Module) String() string {
-	return "module " + m.ModuleConfig.Module
+func (m Module) TypeString() string {
+	return "module"
 }
 
 // ExternalLibrary represents a library that makes use of FTL modules, but is not itself an FTL module
@@ -95,8 +95,8 @@ func (e ExternalLibrary) CopyWithDependencies(dependencies []string) Project {
 	return Project(lib)
 }
 
-func (e ExternalLibrary) String() string {
-	return "library " + e.Dir
+func (e ExternalLibrary) TypeString() string {
+	return "library"
 }
 
 // ProjectKey is a unique identifier for the project (ie: a module name or a library path)

--- a/buildengine/watch.go
+++ b/buildengine/watch.go
@@ -64,7 +64,7 @@ func Watch(ctx context.Context, period time.Duration, moduleDirs []string, exter
 			for _, existingProject := range existingProjects {
 				existingConfig := existingProject.Project.Config()
 				if _, haveProject := projectsByDir[existingConfig.Dir]; !haveProject {
-					logger.Debugf("removed %s", existingProject.Project)
+					logger.Debugf("removed %s %q", existingProject.Project.TypeString(), existingProject.Project.Config().Key)
 					topic.Publish(WatchEventProjectRemoved{Project: existingProject.Project})
 					delete(existingProjects, existingConfig.Dir)
 				}
@@ -85,12 +85,12 @@ func Watch(ctx context.Context, period time.Duration, moduleDirs []string, exter
 					if equal {
 						continue
 					}
-					logger.Debugf("changed %s: %c%s", project, changeType, path)
+					logger.Debugf("changed %s %q: %c%s", project.TypeString(), project.Config().Key, changeType, path)
 					topic.Publish(WatchEventProjectChanged{Project: existingProject.Project, Change: changeType, Path: path})
 					existingProjects[config.Dir] = projectHashes{Hashes: hashes, Project: existingProject.Project}
 					continue
 				}
-				logger.Debugf("added %s", project)
+				logger.Debugf("added %s %q", project.TypeString(), project.Config().Key)
 				topic.Publish(WatchEventProjectAdded{Project: project})
 				existingProjects[config.Dir] = projectHashes{Hashes: hashes, Project: project}
 			}

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -175,7 +175,7 @@ func Build(ctx context.Context, moduleDir string, sch *schema.Schema) error {
 func GenerateStubsForExternalLibrary(ctx context.Context, dir string, schema *schema.Schema) error {
 	goModFile, replacements, err := goModFileWithReplacements(filepath.Join(dir, "go.mod"))
 	if err != nil {
-		return fmt.Errorf("failed to propagate replacements for library %s: %w", dir, err)
+		return fmt.Errorf("failed to propagate replacements for library %q: %w", dir, err)
 	}
 
 	ftlVersion := ""


### PR DESCRIPTION
Fixing some logs/errors so they are no longer printed like this one:
```
...failed to build "module circle": failed to extract module...
```