### PR TITLE
test: invalid return within external library

### DIFF
--- a/buildengine/testdata/projects/lib/lib.go
+++ b/buildengine/testdata/projects/lib/lib.go
@@ -7,5 +7,5 @@ import (
 )
 
 func CreateEchoResponse(ctx context.Context, req alpha.EchoRequest) alpha.EchoResponse {
-	return alpha.EchoResponse{Message: fmt.Sprintf("Hello, %s!!!", req.Name)}, nil
+	return alpha.EchoResponse{Message: fmt.Sprintf("Hello, %s!!!", req.Name)}
 }


### PR DESCRIPTION
No tests affected as it is only used for dependency & discovery tests