### PR TITLE
chore: group declarations when printing module

### DIFF
--- a/backend/schema/module.go
+++ b/backend/schema/module.go
@@ -112,7 +112,7 @@ func (m *Module) String() string {
 	// print decls with spacing rules
 	typeSpacingRules := map[reflect.Type]spacingRule{
 		reflect.TypeOf(&Config{}):   {gapWithinType: false},
-		reflect.TypeOf(&Secret{}):   {gapWithinType: false, skipGapAfterTypes: []reflect.Type{reflect.TypeOf(&Secret{})}},
+		reflect.TypeOf(&Secret{}):   {gapWithinType: false, skipGapAfterTypes: []reflect.Type{reflect.TypeOf(&Config{})}},
 		reflect.TypeOf(&Database{}): {gapWithinType: false},
 		reflect.TypeOf(&Enum{}):     {gapWithinType: true},
 		reflect.TypeOf(&Data{}):     {gapWithinType: true},

--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -20,7 +20,6 @@ func TestSchemaString(t *testing.T) {
 // A comment
 module todo {
   config configValue String
-
   secret secretValue String
 
   database testdb

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -44,7 +44,6 @@ func TestExtractModuleSchema(t *testing.T) {
 	actual = schema.Normalise(actual)
 	expected := `module one {
   config configValue one.Config
-
   secret secretValue String
 
   enum Color(String) {


### PR DESCRIPTION
https://github.com/TBD54566975/ftl/issues/1089

Ordering and spacing is the following (example has 2 of each declaration type)
```
{
   config
   config
   secret
   secret

   database
   database

   enum

   enum

   data

   data

   verb

   verb
}
```

Full example:
```
module echo {
  config default String
  config default2 String
  secret default3 String
  secret default3 String

  // An echo request.
  data EchoRequest {
    name String? +alias json "name"
    inner echo.EchoRequest2 +alias json "inner"
  }

  data EchoRequest2 {
    name String? +alias json "name"
  }

  data EchoResponse {
    message String +alias json "message"
    inner echo.EchoResponse2 +alias json "inner"
  }

  data EchoResponse2 {
    message String +alias json "message"
  }

  // Echo returns a greeting with the current time.
  verb echo(echo.EchoRequest) echo.EchoResponse  
      +calls time.time

  verb echo2(echo.EchoRequest) echo.EchoResponse  
      +calls time.time
}
```