### PR TITLE
feat: filter schemas by name

### DIFF
--- a/cmd/ftl/cmd_schema.go
+++ b/cmd/ftl/cmd_schema.go
@@ -1,7 +1,7 @@
 package main
 
 type schemaCmd struct {
-	Get      getSchemaCmd      `default:"" cmd:"" help:"Retrieve the cluster FTL schema."`
+	Get      getSchemaCmd      `cmd:"" help:"Retrieve the cluster FTL schema."`
 	Protobuf schemaProtobufCmd `cmd:"" help:"Generate protobuf schema mirroring the FTL schema structure."`
 	Generate schemaGenerateCmd `cmd:"" help:"Stream the schema from the cluster and generate files from the template."`
 	Import   schemaImportCmd   `cmd:"" help:"Import messages to the FTL schema."`

--- a/cmd/ftl/cmd_schema.go
+++ b/cmd/ftl/cmd_schema.go
@@ -1,7 +1,7 @@
 package main
 
 type schemaCmd struct {
-	Get      getSchemaCmd      `cmd:"" help:"Retrieve the cluster FTL schema."`
+	Get      getSchemaCmd      `default:"" cmd:"" help:"Retrieve the cluster FTL schema."`
 	Protobuf schemaProtobufCmd `cmd:"" help:"Generate protobuf schema mirroring the FTL schema structure."`
 	Generate schemaGenerateCmd `cmd:"" help:"Stream the schema from the cluster and generate files from the template."`
 	Import   schemaImportCmd   `cmd:"" help:"Import messages to the FTL schema."`

--- a/cmd/ftl/cmd_schema_get.go
+++ b/cmd/ftl/cmd_schema_get.go
@@ -18,7 +18,7 @@ import (
 
 type getSchemaCmd struct {
 	Protobuf bool     `help:"Output the schema as binary protobuf."`
-	Modules  []string `arg:"" help:"Modules to include" type:"string" optional:""`
+	Modules  []string `help:"Modules to include" type:"string" optional:""`
 }
 
 func (g *getSchemaCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceClient) error {


### PR DESCRIPTION
https://github.com/TBD54566975/ftl/issues/1090

```
ftl schema get --modules <modules>
eg: ftl schema get --modules time,echo
```
Allows filtering of schemas to the named modules.
If the input includes a module that was not found, it is returned as an error

The behaviour for these remains the same:
```
ftl schema
ftl schema get
```