### PR TITLE
chore: update deploy command to work inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ftl init kotlin . alice
 
 ### Deploy and test the module
 ```sh
-ftl deploy ftl-module-alice
+ftl deploy alice
 ftl call alice.echo '{"name": "Mic"}'
 ```
 


### PR DESCRIPTION
## Summary

I struggled to get the example working from the main README, this should fix that. As it now corresponds to the module initialised in the sample step. 

Error being...

```
Usage: ftl deploy <dirs> ... [flags]
Run "ftl deploy --help" for more information.

ftl: error: <dirs> ...: stat /....../tf-module-alice: no such file or directory
```