### PR TITLE
feat: pass kotlin build errors to the language server

### DIFF
--- a/backend/schema/errors.go
+++ b/backend/schema/errors.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"errors"
 	"fmt"
+
+	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 )
 
 type Error struct {
@@ -12,8 +14,32 @@ type Error struct {
 	Err       error    `protobuf:"-"` // Wrapped error, if any
 }
 
+func errorFromProto(e *schemapb.Error) *Error {
+	return &Error{
+		Pos:       posFromProto(e.Pos),
+		Msg:       e.Msg,
+		EndColumn: int(e.EndColumn),
+	}
+}
+
+func errorsFromProto(errs []*schemapb.Error) []*Error {
+	var out []*Error
+	for _, pb := range errs {
+		s := errorFromProto(pb)
+		out = append(out, s)
+	}
+	return out
+}
+
 type ErrorList struct {
-	Errors []Error `json:"errors" protobuf:"1"`
+	Errors []*Error `json:"errors" protobuf:"1"`
+}
+
+// ErrorListFromProto converts a protobuf ErrorList to an ErrorList.
+func ErrorListFromProto(e *schemapb.ErrorList) *ErrorList {
+	return &ErrorList{
+		Errors: errorsFromProto(e.Errors),
+	}
 }
 
 func (e Error) Error() string { return fmt.Sprintf("%s-%d: %s", e.Pos, e.EndColumn, e.Msg) }

--- a/buildengine/build_go_test.go
+++ b/buildengine/build_go_test.go
@@ -125,7 +125,7 @@ func Nothing(context.Context) error {
 		buildDir:  "_ftl",
 		sch:       sch,
 	}
-	testBuild(t, bctx, []assertion{
+	testBuild(t, bctx, false, []assertion{
 		assertGeneratedModule("go/modules/other/external_module.go", expected),
 	})
 }
@@ -174,7 +174,7 @@ func Call(context.Context, Req) (Resp, error) {
 		buildDir:  "_ftl",
 		sch:       sch,
 	}
-	testBuild(t, bctx, []assertion{
+	testBuild(t, bctx, false, []assertion{
 		assertGeneratedModule("go/modules/test/external_module.go", expected),
 	})
 }

--- a/buildengine/build_test.go
+++ b/buildengine/build_test.go
@@ -23,22 +23,28 @@ type assertion func(t testing.TB, bctx buildContext) error
 func testBuild(
 	t *testing.T,
 	bctx buildContext,
+	expectFail bool,
 	assertions []assertion,
 ) {
 	t.Helper()
 	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{}))
-	module, err := LoadModule(bctx.moduleDir)
+	abs, err := filepath.Abs(bctx.moduleDir)
+	assert.NoError(t, err, "Error getting absolute path for module directory")
+	module, err := LoadModule(abs)
 	assert.NoError(t, err)
-
 	err = Build(ctx, bctx.sch, module)
-	assert.NoError(t, err)
+	if expectFail {
+		assert.Error(t, err)
+	} else {
+		assert.NoError(t, err)
+	}
 
 	for _, a := range assertions {
 		err = a(t, bctx)
 		assert.NoError(t, err)
 	}
 
-	err = os.RemoveAll(bctx.buildDir)
+	err = os.RemoveAll(filepath.Join(bctx.moduleDir, bctx.buildDir))
 	assert.NoError(t, err, "Error removing build directory")
 }
 
@@ -51,6 +57,27 @@ func assertGeneratedModule(generatedModulePath string, expectedContent string) a
 		fileContent, err := os.ReadFile(output)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedContent, string(fileContent))
+		return nil
+	}
+}
+
+func assertBuildProtoErrors(msgs ...string) assertion {
+	return func(t testing.TB, bctx buildContext) error {
+		t.Helper()
+		errorList, err := loadProtoErrors(filepath.Join(bctx.moduleDir, bctx.buildDir))
+		assert.NoError(t, err, "Error loading proto errors")
+
+		expected := make([]*schema.Error, 0, len(msgs))
+		for _, msg := range msgs {
+			expected = append(expected, &schema.Error{Msg: msg})
+		}
+
+		// normalize results
+		for _, e := range errorList.Errors {
+			e.EndColumn = 0
+		}
+
+		assert.Equal(t, errorList.Errors, expected, assert.Exclude[schema.Position]())
 		return nil
 	}
 }

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -2,7 +2,6 @@ package exec
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec" //nolint:depguard
 	"syscall"
@@ -59,7 +58,7 @@ func (c *Cmd) RunBuffered(ctx context.Context) error {
 
 	err := c.Run()
 	if err != nil {
-		fmt.Printf("%s", outputBuffer.Bytes())
+		log.FromContext(ctx).Infof("%s", outputBuffer.Bytes())
 		return err
 	}
 

--- a/lsp/lsp.go
+++ b/lsp/lsp.go
@@ -79,7 +79,6 @@ func (s *Server) post(err error) {
 
 	// Deduplicate and associate by filename.
 	for _, subErr := range ftlErrors.UnwrapAll(err) {
-		//TODO: Need a way to pass structured errors from other runtimes like kotlin. This won't work for them.
 		var ce schema.Error
 		if errors.As(subErr, &ce) {
 			filename := ce.Pos.Filename


### PR DESCRIPTION
although we've temporarily suspended development on the kotlin runtime, this was a useful proof-of-concept to demonstrate how we can build non-Go runtimes to interact with the language server

fixes #1123
fixes #1159


<img width="1436" alt="Screenshot 2024-04-04 at 3 23 15 PM" src="https://github.com/TBD54566975/ftl/assets/72891690/a8cb7605-08bf-4b44-a819-239c08ddfa3f">
