### PR TITLE
fix: add query for getting deployments with replicas

### DIFF
--- a/backend/controller/console.go
+++ b/backend/controller/console.go
@@ -41,7 +41,7 @@ func (*ConsoleService) Ping(context.Context, *connect.Request[ftlv1.PingRequest]
 }
 
 func (c *ConsoleService) GetModules(ctx context.Context, req *connect.Request[pbconsole.GetModulesRequest]) (*connect.Response[pbconsole.GetModulesResponse], error) {
-	deployments, err := c.dal.GetActiveDeployments(ctx)
+	deployments, err := c.dal.GetDeploymentsWithMinReplicas(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/controller/dal/dal.go
+++ b/backend/controller/dal/dal.go
@@ -741,6 +741,26 @@ func (d *DAL) GetActiveDeployments(ctx context.Context) ([]Deployment, error) {
 	})
 }
 
+func (d *DAL) GetDeploymentsWithMinReplicas(ctx context.Context) ([]Deployment, error) {
+	rows, err := d.db.GetDeploymentsWithMinReplicas(ctx)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil
+		}
+		return nil, translatePGError(err)
+	}
+	return slices.MapErr(rows, func(in sql.GetDeploymentsWithMinReplicasRow) (Deployment, error) {
+		return Deployment{
+			Key:         in.Deployment.Key,
+			Module:      in.ModuleName,
+			Language:    in.Language,
+			MinReplicas: int(in.Deployment.MinReplicas),
+			Schema:      in.Deployment.Schema,
+			CreatedAt:   in.Deployment.CreatedAt,
+		}, nil
+	})
+}
+
 func (d *DAL) GetActiveDeploymentSchemas(ctx context.Context) ([]*schema.Module, error) {
 	rows, err := d.db.GetActiveDeploymentSchemas(ctx)
 	if err != nil {

--- a/backend/controller/sql/models.go
+++ b/backend/controller/sql/models.go
@@ -271,6 +271,7 @@ type Runner struct {
 
 type Topic struct {
 	ID        int64
+	Key       interface{}
 	CreatedAt time.Time
 	ModuleID  int64
 	Name      string
@@ -286,6 +287,7 @@ type TopicEvent struct {
 
 type TopicSubscriber struct {
 	ID                   int64
+	Key                  interface{}
 	CreatedAt            time.Time
 	TopicSubscriptionsID int64
 	DeploymentID         int64
@@ -294,6 +296,7 @@ type TopicSubscriber struct {
 
 type TopicSubscription struct {
 	ID        int64
+	Key       interface{}
 	CreatedAt time.Time
 	TopicID   int64
 	Name      string

--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -37,6 +37,7 @@ type Querier interface {
 	GetDeploymentsNeedingReconciliation(ctx context.Context) ([]GetDeploymentsNeedingReconciliationRow, error)
 	// Get all deployments that have artefacts matching the given digests.
 	GetDeploymentsWithArtefacts(ctx context.Context, digests [][]byte, schema []byte, count int64) ([]GetDeploymentsWithArtefactsRow, error)
+	GetDeploymentsWithMinReplicas(ctx context.Context) ([]GetDeploymentsWithMinReplicasRow, error)
 	GetExistingDeploymentForModule(ctx context.Context, name string) (GetExistingDeploymentForModuleRow, error)
 	GetIdleRunners(ctx context.Context, labels []byte, limit int64) ([]Runner, error)
 	// Get the runner endpoints corresponding to the given ingress route.

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -152,6 +152,13 @@ WHERE min_replicas > 0 AND r.state = 'assigned'
 GROUP BY d.id, m.name, m.language
 HAVING COUNT(r.id) > 0;
 
+-- name: GetDeploymentsWithMinReplicas :many
+SELECT sqlc.embed(d), m.name AS module_name, m.language
+FROM deployments d
+  INNER JOIN modules m on d.module_id = m.id
+WHERE min_replicas > 0
+ORDER BY d.key;
+
 -- name: GetActiveDeploymentSchemas :many
 SELECT key, schema FROM deployments WHERE min_replicas > 0;
 


### PR DESCRIPTION
Fixes #1200 

This introduces a new query to get deployments with `min_replicas > 0`. We could also modify some other existing queries if that's preferred.