### PR TITLE
fix: validate deploying module rather than entire schema

### DIFF
--- a/backend/schema/parser.go
+++ b/backend/schema/parser.go
@@ -168,7 +168,7 @@ func ParseString(filename, input string) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Validate(mod)
+	return ValidateSchema(mod)
 }
 
 func ParseModuleString(filename, input string) (*Module, error) {
@@ -184,7 +184,7 @@ func Parse(filename string, r io.Reader) (*Schema, error) {
 	if err != nil {
 		return nil, err
 	}
-	return Validate(mod)
+	return ValidateSchema(mod)
 }
 
 func ParseModule(filename string, r io.Reader) (*Module, error) {

--- a/backend/schema/schema.go
+++ b/backend/schema/schema.go
@@ -141,5 +141,5 @@ func FromProto(s *schemapb.Schema) (*Schema, error) {
 	schema := &Schema{
 		Modules: modules,
 	}
-	return Validate(schema)
+	return ValidateSchema(schema)
 }

--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -154,7 +154,7 @@ Module
 func TestParserRoundTrip(t *testing.T) {
 	actual, err := ParseString("", testSchema.String())
 	assert.NoError(t, err, "%s", testSchema.String())
-	actual, err = Validate(actual)
+	actual, err = ValidateSchema(actual)
 	assert.NoError(t, err)
 	assert.Equal(t, Normalise(testSchema), Normalise(actual))
 }


### PR DESCRIPTION
when deploying a module, we will only validate the deploying module's schema (but do so within the context of the greater schema).

this change prevents issues where a schema error outside of the deploying module prevents the deploy from succeeding—causing issues like #1211. now in combination with the buildengine logic, a change in the upstream module that breaks a downstream module will not prevent the upstream module from deploying (if the module still has a valid standalone schema). the deploy will succeed and then the subsequent deploy triggered for the downstream module will fail if the schema change from its dependency breaks it.

fixes #1211