### PR TITLE
feat: produce errors.pb during go schema extraction

### DIFF
--- a/backend/schema/validate.go
+++ b/backend/schema/validate.go
@@ -9,13 +9,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/alecthomas/participle/v2"
-	"github.com/alecthomas/types/optional"
-	"golang.org/x/exp/maps"
-
 	"github.com/TBD54566975/ftl/internal/cron"
 	"github.com/TBD54566975/ftl/internal/errors"
 	dc "github.com/TBD54566975/ftl/internal/reflect"
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/types/optional"
 )
 
 var (
@@ -353,14 +351,7 @@ func cleanErrors(merr []error) []error {
 	if len(merr) == 0 {
 		return nil
 	}
-	// Deduplicate.
-	set := map[string]error{}
-	for _, err := range merr {
-		for _, subErr := range errors.UnwrapAll(err) {
-			set[strings.TrimSpace(subErr.Error())] = subErr
-		}
-	}
-	merr = maps.Values(set)
+	merr = errors.DeduplicateErrors(merr)
 	// Sort by position.
 	sort.Slice(merr, func(i, j int) bool {
 		var ipe, jpe participle.Error

--- a/buildengine/build_go_test.go
+++ b/buildengine/build_go_test.go
@@ -1,14 +1,9 @@
 package buildengine
 
 import (
-	"context"
-	"os"
 	"testing"
 
-	"github.com/alecthomas/assert/v2"
-
 	"github.com/TBD54566975/ftl/backend/schema"
-	"github.com/TBD54566975/ftl/internal/log"
 )
 
 func TestGenerateGoModule(t *testing.T) {
@@ -183,17 +178,12 @@ func TestExternalType(t *testing.T) {
 	if testing.Short() {
 		t.SkipNow()
 	}
-	moduleDir := "testdata/projects/external"
-	buildDir := "_ftl"
-
-	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, log.Config{}))
-	module, err := LoadModule(moduleDir)
-	assert.NoError(t, err)
-
-	sch := &schema.Schema{}
-	err = Build(ctx, sch, module)
-	assert.Contains(t, err.Error(), "field Month: unsupported external type time.Month")
-
-	err = os.RemoveAll(buildDir)
-	assert.NoError(t, err, "Error removing build directory")
+	bctx := buildContext{
+		moduleDir: "testdata/projects/external",
+		buildDir:  "_ftl",
+		sch:       &schema.Schema{},
+	}
+	testBuild(t, bctx, true, []assertion{
+		assertBuildProtoErrors("field Month: unsupported external type time.Month"),
+	})
 }

--- a/buildengine/build_kotlin.go
+++ b/buildengine/build_kotlin.go
@@ -2,7 +2,6 @@ package buildengine
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,10 +13,8 @@ import (
 	"github.com/beevik/etree"
 	sets "github.com/deckarep/golang-set/v2"
 	"golang.org/x/exp/maps"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/TBD54566975/ftl"
-	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/exec"
@@ -62,16 +59,7 @@ func buildKotlinModule(ctx context.Context, sch *schema.Schema, module Module) e
 	logger.Debugf("Using build command '%s'", module.Build)
 	err := exec.Command(ctx, log.Debug, module.Dir, "bash", "-c", module.Build).RunBuffered(ctx)
 	if err != nil {
-		// read runtime-specific build errors from the build directory
-		errorList, err := loadProtoErrors(module.AbsDeployDir())
-		if err != nil {
-			return fmt.Errorf("failed to read build errors for module: %w", err)
-		}
-		errs := make([]error, 0, len(errorList.Errors))
-		for _, e := range errorList.Errors {
-			errs = append(errs, *e)
-		}
-		return errors.Join(errs...)
+		return fmt.Errorf("failed to build module %q: %w", module.Module, err)
 	}
 
 	return nil
@@ -260,22 +248,4 @@ func genType(module *schema.Module, t schema.Type) string {
 		return t.String()
 	}
 	panic(fmt.Sprintf("unsupported type %T", t))
-}
-
-func loadProtoErrors(buildDir string) (*schema.ErrorList, error) {
-	f := filepath.Join(buildDir, "errors.pb")
-	if _, err := os.Stat(f); errors.Is(err, os.ErrNotExist) {
-		return &schema.ErrorList{Errors: make([]*schema.Error, 0)}, nil
-	}
-
-	content, err := os.ReadFile(f)
-	if err != nil {
-		return nil, err
-	}
-	errorspb := &schemapb.ErrorList{}
-	err = proto.Unmarshal(content, errorspb)
-	if err != nil {
-		return nil, err
-	}
-	return schema.ErrorListFromProto(errorspb), nil
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,6 +1,10 @@
 package errors
 
-import "errors"
+import (
+	"errors"
+	"golang.org/x/exp/maps"
+	"strings"
+)
 
 // UnwrapAll recursively unwraps all errors in err, including all intermediate errors.
 //
@@ -42,3 +46,14 @@ func As(err error, target interface{}) bool { return errors.As(err, target) }
 func Is(err, target error) bool { return errors.Is(err, target) }
 
 func Unwrap(err error) error { return errors.Unwrap(err) }
+
+// DeduplicateErrors de-duplicates equivalent errors.
+func DeduplicateErrors(merr []error) []error {
+	set := map[string]error{}
+	for _, err := range merr {
+		for _, subErr := range UnwrapAll(err) {
+			set[strings.TrimSpace(subErr.Error())] = subErr
+		}
+	}
+	return maps.Values(set)
+}

--- a/lsp/lsp.go
+++ b/lsp/lsp.go
@@ -77,18 +77,16 @@ func (s *Server) post(err error) {
 	errByFilename := make(map[string]errSet)
 
 	// Deduplicate and associate by filename.
-	errs := ftlErrors.UnwrapAll(err)
-	for _, err := range errs {
-		if ftlErrors.Innermost(err) {
-			var ce schema.Error
-			if errors.As(err, &ce) {
-				filename := ce.Pos.Filename
-				if _, exists := errByFilename[filename]; !exists {
-					errByFilename[filename] = make(errSet)
-				}
-				errByFilename[filename][strings.TrimSpace(ce.Error())] = ce
+	for _, err := range ftlErrors.DeduplicateErrors(ftlErrors.UnwrapAll(err)) {
+		var ce schema.Error
+		if errors.As(err, &ce) {
+			filename := ce.Pos.Filename
+			if _, exists := errByFilename[filename]; !exists {
+				errByFilename[filename] = make(errSet)
 			}
+			errByFilename[filename][strings.TrimSpace(ce.Error())] = ce
 		}
+
 	}
 
 	go publishErrors(errByFilename, s)


### PR DESCRIPTION
This approach enables arbitrary runtimes to surface schema errors via proto. Go will use this approach for consistency across runtimes.

fixes #1207