### PR TITLE
chore: globally replace ftl in go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ brew tap TBD54566975/ftl && brew install ftl
 set -Eeuxo pipefail
 
 just build ftl
-export FTL_ROOT="$(git rev-parse --show-toplevel)"
-export PATH="$FTL_ROOT/build/release:$PATH"
-export FTL_INIT_GO_REPLACE="github.com/TBD54566975/ftl=$FTL_ROOT"
+export PATH="$(git rev-parse --show-toplevel)/build/release:$PATH"
 
 pwd
 

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -3,5 +3,7 @@ env = {
   "FTL_SOURCE": "${HERMIT_ENV}",
   "OTEL_METRIC_EXPORT_INTERVAL": "5000",
   "PATH": "${HERMIT_ENV}/scripts:${HERMIT_ENV}/frontend/node_modules/.bin:${PATH}",
+  "FTL_INIT_GO_REPLACE": "github.com/TBD54566975/ftl=${HERMIT_ENV}",
+
 }
 sources = ["env:///bin/packages", "https://github.com/cashapp/hermit-packages.git"]


### PR DESCRIPTION
Whenever we do `ftl init go ...` in a test, by default this will be configured to pull the FTL source from GitHub. This PR changes that to always use the local FTL, which is much more correct.

This has confused me many times.