### PR TITLE
feat: simplify config/secret API

### DIFF
--- a/common/configuration/api.go
+++ b/common/configuration/api.go
@@ -34,6 +34,7 @@ type Entry struct {
 
 // A Ref is a reference to a configuration value.
 type Ref struct {
+	// If not present, the Ref is considered to be global.
 	Module optional.Option[string]
 	Name   string
 }

--- a/examples/go/echo/echo.go
+++ b/examples/go/echo/echo.go
@@ -30,5 +30,5 @@ func Echo(ctx context.Context, req EchoRequest) (EchoResponse, error) {
 		return EchoResponse{}, err
 	}
 
-	return EchoResponse{Message: fmt.Sprintf("Hello, %s!!! It is %s!", req.Name.Default(defaultName.Get(ctx)), tresp.Time)}, nil
+	return EchoResponse{Message: fmt.Sprintf("Hello, %s!!! It is %s!", req.Name.Default(defaultName.Get()), tresp.Time)}, nil
 }

--- a/go-runtime/ftl/config_test.go
+++ b/go-runtime/ftl/config_test.go
@@ -1,27 +1,17 @@
 package ftl
 
 import (
-	"context"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-
-	"github.com/TBD54566975/ftl/common/configuration"
-	"github.com/TBD54566975/ftl/common/projectconfig"
-	"github.com/TBD54566975/ftl/internal/log"
 )
 
 func TestConfig(t *testing.T) {
-	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	cr := configuration.ProjectConfigResolver[configuration.Configuration]{Config: []string{"testdata/ftl-project.toml"}}
-	assert.Equal(t, []string{"testdata/ftl-project.toml"}, projectconfig.ConfigPaths(cr.Config))
-	cm, err := configuration.NewConfigurationManager(ctx, cr)
-	assert.NoError(t, err)
-	ctx = configuration.ContextWithConfig(ctx, cm)
+	t.Setenv("FTL_CONFIG", "testdata/ftl-project.toml")
 	type C struct {
 		One string
 		Two string
 	}
 	config := Config[C]("test")
-	assert.Equal(t, C{"one", "two"}, config.Get(ctx))
+	assert.Equal(t, C{"one", "two"}, config.Get())
 }

--- a/go-runtime/ftl/secrets.go
+++ b/go-runtime/ftl/secrets.go
@@ -3,21 +3,42 @@ package ftl
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"sync"
 
-	"github.com/TBD54566975/ftl/common/configuration"
+	cf "github.com/TBD54566975/ftl/common/configuration"
+	"github.com/TBD54566975/ftl/internal/log"
 )
 
-// SecretType is a type that can be used as a secret value.
-type SecretType interface{ any }
+var globalSecretsManagerOnce sync.Once
+
+// globalSecretsManager returns a global secrets manager instance.
+func globalSecretsManager() (manager *cf.Manager[cf.Secrets]) {
+	globalSecretsManagerOnce.Do(func() {
+		var configs []string
+		if envar, ok := os.LookupEnv("FTL_CONFIG"); ok {
+			configs = strings.Split(envar, ",")
+		}
+		config := cf.DefaultSecretsMixin{}
+		var err error
+		ctx := log.ContextWithNewDefaultLogger(context.Background())
+		manager, err = config.NewSecretsManager(ctx, cf.ProjectConfigResolver[cf.Secrets]{Config: configs})
+		if err != nil {
+			panic("failed to create global secrets manager: " + err.Error())
+		}
+	})
+	return manager
+}
 
 // Secret declares a typed secret for the current module.
-func Secret[T SecretType](name string) SecretValue[T] {
+func Secret[T any](name string) SecretValue[T] {
 	module := callerModule()
 	return SecretValue[T]{module, name}
 }
 
 // SecretValue is a typed secret for the current module.
-type SecretValue[T SecretType] struct {
+type SecretValue[T any] struct {
 	module string
 	name   string
 }
@@ -30,10 +51,11 @@ func (s SecretValue[T]) GoString() string {
 }
 
 // Get returns the value of the secret from FTL.
-func (s SecretValue[T]) Get(ctx context.Context) (out T) {
-	sm := configuration.SecretsFromContext(ctx)
-	if err := sm.Get(ctx, configuration.NewRef(s.module, s.name), &out); err != nil {
-		panic(fmt.Errorf("failed to get %s: %w", s, err))
+func (s SecretValue[T]) Get() (out T) {
+	sm := globalSecretsManager()
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	if err := sm.Get(ctx, cf.NewRef(s.module, s.name), &out); err != nil {
+		panic(fmt.Errorf("failed to get secrets %s.%s: %w", s.module, s.name, err))
 	}
 	return
 }

--- a/go-runtime/ftl/secrets_test.go
+++ b/go-runtime/ftl/secrets_test.go
@@ -1,25 +1,17 @@
 package ftl
 
 import (
-	"context"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
-
-	"github.com/TBD54566975/ftl/common/configuration"
-	"github.com/TBD54566975/ftl/internal/log"
 )
 
 func TestSecret(t *testing.T) {
-	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	sr := configuration.ProjectConfigResolver[configuration.Secrets]{Config: []string{"testdata/ftl-project.toml"}}
-	sm, err := configuration.NewSecretsManager(ctx, sr)
-	assert.NoError(t, err)
-	ctx = configuration.ContextWithSecrets(ctx, sm)
+	t.Setenv("FTL_CONFIG", "testdata/ftl-project.toml")
 	type C struct {
 		One string
 		Two string
 	}
 	config := Secret[C]("secret")
-	assert.Equal(t, C{"one", "two"}, config.Get(ctx))
+	assert.Equal(t, C{"one", "two"}, config.Get())
 }


### PR DESCRIPTION
Rather than `ftl.Config[string]("foo").Get(ctx)` it is now `ftl.Config[string]("foo").Get()`.