### PR TITLE
fix: skip out of date file changes

### DIFF
--- a/buildengine/deps.go
+++ b/buildengine/deps.go
@@ -123,7 +123,7 @@ func extractKotlinFTLImports(self, dir string) ([]string, error) {
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
 			matches := kotlinImportRegex.FindStringSubmatch(scanner.Text())
-			if matches != nil && len(matches) > 1 {
+			if len(matches) > 1 {
 				module := strings.Split(matches[1], ".")[0]
 				if module == self {
 					continue

--- a/buildengine/watch.go
+++ b/buildengine/watch.go
@@ -26,6 +26,7 @@ type WatchEventProjectChanged struct {
 	Project Project
 	Change  FileChangeType
 	Path    string
+	Time    time.Time
 }
 
 func (WatchEventProjectChanged) watchEvent() {}
@@ -86,7 +87,7 @@ func Watch(ctx context.Context, period time.Duration, moduleDirs []string, exter
 						continue
 					}
 					logger.Debugf("changed %s %q: %c%s", project.TypeString(), project.Config().Key, changeType, path)
-					topic.Publish(WatchEventProjectChanged{Project: existingProject.Project, Change: changeType, Path: path})
+					topic.Publish(WatchEventProjectChanged{Project: existingProject.Project, Change: changeType, Path: path, Time: time.Now()})
 					existingProjects[config.Dir] = projectHashes{Hashes: hashes, Project: existingProject.Project}
 					continue
 				}


### PR DESCRIPTION
Fixes #1210 

This required a bit of a refactor to use pointers for `Module` and `ExternalLibrary` here. Hopefully, that's ok.

Example of rapid changes getting skipped. Note that I logged skips in `Warnf` just to highlight for this screenshot. Real skip messages are logged at `Debugf`

![Screenshot 2024-04-16 at 2 03 09 PM](https://github.com/TBD54566975/ftl/assets/51647/079878c6-3fa6-4f4c-9705-7a422e639db6)
