### PR TITLE
feat: Remove runners and ingress from dal GetStatus

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -257,7 +257,7 @@ func (s *Service) ProcessList(ctx context.Context, req *connect.Request[ftlv1.Pr
 }
 
 func (s *Service) Status(ctx context.Context, req *connect.Request[ftlv1.StatusRequest]) (*connect.Response[ftlv1.StatusResponse], error) {
-	status, err := s.dal.GetStatus(ctx, req.Msg.AllControllers, req.Msg.AllRunners, req.Msg.AllIngressRoutes)
+	status, err := s.dal.GetStatus(ctx, req.Msg.AllControllers)
 	if err != nil {
 		return nil, fmt.Errorf("could not get status: %w", err)
 	}
@@ -276,28 +276,6 @@ func (s *Service) Status(ctx context.Context, req *connect.Request[ftlv1.StatusR
 	})
 	s.routesMu.RUnlock()
 	replicas := map[string]int32{}
-	protoRunners, err := slices.MapErr(status.Runners, func(r dal.Runner) (*ftlv1.StatusResponse_Runner, error) {
-		var deployment *string
-		if d, ok := r.Deployment.Get(); ok {
-			asString := d.String()
-			deployment = &asString
-			replicas[asString]++
-		}
-		labels, err := structpb.NewStruct(r.Labels)
-		if err != nil {
-			return nil, fmt.Errorf("could not marshal attributes for runner %s: %w", r.Key, err)
-		}
-		return &ftlv1.StatusResponse_Runner{
-			Key:        r.Key.String(),
-			Endpoint:   r.Endpoint,
-			State:      r.State.ToProto(),
-			Deployment: deployment,
-			Labels:     labels,
-		}, nil
-	})
-	if err != nil {
-		return nil, err
-	}
 	deployments, err := slices.MapErr(status.Deployments, func(d dal.Deployment) (*ftlv1.StatusResponse_Deployment, error) {
 		labels, err := structpb.NewStruct(d.Labels)
 		if err != nil {
@@ -324,17 +302,8 @@ func (s *Service) Status(ctx context.Context, req *connect.Request[ftlv1.StatusR
 				State:    c.State.ToProto(),
 			}
 		}),
-		Runners:     protoRunners,
 		Deployments: deployments,
-		IngressRoutes: slices.Map(status.IngressRoutes, func(r dal.IngressRouteEntry) *ftlv1.StatusResponse_IngressRoute {
-			return &ftlv1.StatusResponse_IngressRoute{
-				DeploymentKey: r.Deployment.String(),
-				Verb:          &schemapb.Ref{Module: r.Module, Name: r.Verb},
-				Method:        r.Method,
-				Path:          r.Path,
-			}
-		}),
-		Routes: routes,
+		Routes:      routes,
 	}
 	return connect.NewResponse(resp), nil
 }

--- a/backend/protos/xyz/block/ftl/v1/ftl.proto
+++ b/backend/protos/xyz/block/ftl/v1/ftl.proto
@@ -184,9 +184,9 @@ message StreamDeploymentLogsRequest {
 message StreamDeploymentLogsResponse {}
 
 message StatusRequest {
-  bool all_runners = 1;
   bool all_controllers = 2;
-  bool all_ingress_routes = 3;
+
+  reserved 1, 3;
 }
 message StatusResponse {
   message Controller {
@@ -195,16 +195,6 @@ message StatusResponse {
     ControllerState state = 4;
   }
   repeated Controller controllers = 1;
-
-  message Runner {
-    string key = 1;
-    repeated string languages = 2;
-    string endpoint = 3;
-    RunnerState state = 4;
-    optional string deployment = 5;
-    google.protobuf.Struct labels = 6;
-  }
-  repeated Runner runners = 2;
 
   message Deployment {
     string key = 1;
@@ -217,16 +207,6 @@ message StatusResponse {
   }
   repeated Deployment deployments = 3;
 
-  message IngressRoute {
-    string deployment_key = 1;
-    schema.Ref verb = 5;
-    string method = 3;
-    string path = 4;
-
-    reserved 2;
-  }
-  repeated IngressRoute ingress_routes = 4;
-
   message Route {
     string module = 1;
     string runner = 2;
@@ -234,6 +214,8 @@ message StatusResponse {
     string endpoint = 4;
   }
   repeated Route routes = 5;
+
+  reserved 2, 4;
 }
 
 message ProcessListRequest {}


### PR DESCRIPTION
Fixes issue https://github.com/TBD54566975/ftl/issues/1171

This PR includes some proto field deletions following the guidance here: https://protobuf.dev/programming-guides/proto3/#deleting

Manually tested `ftl serve` and `ftl status` (the two commands that reference `StatusRequest`) and got the desired output:
```
$ ftl status
{
  "controllers": [
    {
      "key": "ctr-0-3lky7r59cey54xq",
      "endpoint": "http://localhost:8892"
    }
  ]
}% 
$ ftl serve --recreate
info: Starting FTL with 1 controller(s)
info:controller0: Web console available at: http://localhost:8892
^C% 
$
```