### PR TITLE
GetStatus() should always return just the active controllers/runners/ingress paths

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -291,7 +291,7 @@ func (s *Service) ProcessList(ctx context.Context, req *connect.Request[ftlv1.Pr
 }
 
 func (s *Service) Status(ctx context.Context, req *connect.Request[ftlv1.StatusRequest]) (*connect.Response[ftlv1.StatusResponse], error) {
-	status, err := s.dal.GetStatus(ctx, req.Msg.AllControllers, req.Msg.AllRunners, req.Msg.AllIngressRoutes)
+	status, err := s.dal.GetStatus(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get status: %w", err)
 	}
@@ -1061,7 +1061,7 @@ func (s *Service) heartbeatController(ctx context.Context) (time.Duration, error
 }
 
 func (s *Service) updateControllersList(ctx context.Context) (time.Duration, error) {
-	controllers, err := s.dal.GetControllers(ctx, false)
+	controllers, err := s.dal.GetActiveControllers(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/backend/controller/dal/dal.go
+++ b/backend/controller/dal/dal.go
@@ -1091,7 +1091,7 @@ func (d *DAL) InsertCallEvent(ctx context.Context, call *CallEvent) error {
 }
 
 func (d *DAL) GetActiveRunners(ctx context.Context) ([]Runner, error) {
-	rows, err := d.db.GetActiveRunners(ctx, false)
+	rows, err := d.db.GetActiveRunners(ctx)
 	if err != nil {
 		return nil, translatePGError(err)
 	}

--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -23,14 +23,14 @@ type Querier interface {
 	DeregisterRunner(ctx context.Context, key model.RunnerKey) (int64, error)
 	EndCronJob(ctx context.Context, nextExecution time.Time, key model.CronJobKey, startTime time.Time) (EndCronJobRow, error)
 	ExpireRunnerReservations(ctx context.Context) (int64, error)
+	GetActiveControllers(ctx context.Context) ([]Controller, error)
 	GetActiveDeploymentSchemas(ctx context.Context) ([]GetActiveDeploymentSchemasRow, error)
 	GetActiveDeployments(ctx context.Context) ([]GetActiveDeploymentsRow, error)
-	GetActiveRunners(ctx context.Context, all bool) ([]GetActiveRunnersRow, error)
-	GetAllIngressRoutes(ctx context.Context, all bool) ([]GetAllIngressRoutesRow, error)
+	GetActiveIngressRoutes(ctx context.Context) ([]GetActiveIngressRoutesRow, error)
+	GetActiveRunners(ctx context.Context) ([]GetActiveRunnersRow, error)
 	GetArtefactContentRange(ctx context.Context, start int32, count int32, iD int64) ([]byte, error)
 	// Return the digests that exist in the database.
 	GetArtefactDigests(ctx context.Context, digests [][]byte) ([]GetArtefactDigestsRow, error)
-	GetControllers(ctx context.Context, all bool) ([]Controller, error)
 	GetCronJobs(ctx context.Context) ([]GetCronJobsRow, error)
 	GetDeployment(ctx context.Context, key model.DeploymentKey) (GetDeploymentRow, error)
 	// Get all artefacts matching the given digests.

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -139,8 +139,7 @@ SELECT DISTINCT ON (r.key) r.key                                   AS runner_key
                                             THEN d.key END, NULL) AS deployment_key
 FROM runners r
          LEFT JOIN deployments d on d.id = r.deployment_id
-WHERE sqlc.arg('all')::bool = true
-   OR r.state <> 'dead'
+WHERE r.state <> 'dead'
 ORDER BY r.key;
 
 -- name: GetActiveDeployments :many
@@ -427,11 +426,10 @@ WITH matches AS (
 SELECT COUNT(*)
 FROM matches;
 
--- name: GetControllers :many
+-- name: GetActiveControllers :many
 SELECT *
 FROM controller c
-WHERE sqlc.arg('all')::bool = true
-   OR c.state <> 'dead'
+WHERE c.state <> 'dead'
 ORDER BY c.key;
 
 -- name: CreateIngressRoute :exec
@@ -447,12 +445,11 @@ FROM ingress_routes ir
 WHERE r.state = 'assigned'
   AND ir.method = $1;
 
--- name: GetAllIngressRoutes :many
+-- name: GetActiveIngressRoutes :many
 SELECT d.key AS deployment_key, ir.module, ir.verb, ir.method, ir.path
 FROM ingress_routes ir
          INNER JOIN deployments d ON ir.deployment_id = d.id
-WHERE sqlc.arg('all')::bool = true
-   OR d.min_replicas > 0;
+WHERE d.min_replicas > 0;
 
 
 -- name: InsertEvent :exec

--- a/backend/protos/xyz/block/ftl/v1/ftl.proto
+++ b/backend/protos/xyz/block/ftl/v1/ftl.proto
@@ -131,11 +131,6 @@ message GetDeploymentResponse {
   repeated DeploymentArtefact artefacts = 2;
 }
 
-enum ControllerState {
-  CONTROLLER_LIVE = 0;
-  CONTROLLER_DEAD = 1;
-}
-
 enum RunnerState {
   // The Runner is waiting for a deployment.
   RUNNER_IDLE = 0;
@@ -184,15 +179,11 @@ message StreamDeploymentLogsRequest {
 message StreamDeploymentLogsResponse {}
 
 message StatusRequest {
-  bool all_runners = 1;
-  bool all_controllers = 2;
-  bool all_ingress_routes = 3;
 }
 message StatusResponse {
   message Controller {
     string key = 1;
     string endpoint = 2;
-    ControllerState state = 4;
   }
   repeated Controller controllers = 1;
 


### PR DESCRIPTION
Fixes issue https://github.com/TBD54566975/ftl/issues/1171

Generated file changes produced by running `./bin/sqlc generate`

Manually tested by running `ftl status` and `ftl serve`, the two commands that use `GetStatus()` via `StatusRequest`:

1. In tab 1, ran `ftl dev ./examples/go`. Confirmed everything started as expected.
2. Opened a new tab 2, ran `ftl status`. Confirmed everything got returned.
3. Went back to tab 1, Ctrl+C.
4. Went back to tab 2 and ran `ftl status` again. Confirmed got `ftl: error: unavailable: dial tcp 127.0.0.1:8892: connect: connection refused`.
5. Went back to tab 1 and ran `ftl serve`. Confirmed serving executed as expected.
6. Went back to tab 2 and ran `ftl status` again. Confirmed everything got returned again.