### PR TITLE
chore: fix linter warnings in terminal

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,6 @@
 run:
   tests: true
   timeout: 5m
-  skip-dirs:
-    - resources
-    - old
-  skip-files:
-    - cmd/protopkg/main.go
 
 output:
   print-issued-lines: false
@@ -78,8 +73,8 @@ linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
   govet:
-    check-shadowing: true
-    use-installed-packages: true
+    enable:
+      - 'shadow'
   dupl:
     threshold: 100
   goconst:
@@ -113,6 +108,11 @@ linters-settings:
 issues:
   max-same-issues: 0
   max-issues-per-linter: 0
+  exclude-dirs:
+    - resources
+    - old
+  exclude-files:
+    - cmd/protopkg/main.go
   exclude-use-default: false
   exclude:
     # Captured by errcheck.


### PR DESCRIPTION
I was getting these warnings when running go linting.

```sh
./bin/golangci-lint run
WARN [config_reader] The configuration option `run.skip-files` is deprecated, please use `issues.exclude-files`.
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`.
WARN [config_reader] The configuration option `govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.
```