### PR TITLE
fix: skip validation on external req/resp types

### DIFF
--- a/backend/protos/xyz/block/ftl/v1/ftl.proto
+++ b/backend/protos/xyz/block/ftl/v1/ftl.proto
@@ -178,8 +178,7 @@ message StreamDeploymentLogsRequest {
 }
 message StreamDeploymentLogsResponse {}
 
-message StatusRequest {
-}
+message StatusRequest {}
 message StatusResponse {
   message Controller {
     string key = 1;

--- a/backend/schema/validate_test.go
+++ b/backend/schema/validate_test.go
@@ -171,7 +171,6 @@ func TestValidate(t *testing.T) {
 				"6:10-10: verb can not have multiple instances of ingress",
 			},
 		},
-
 		{name: "CronOnNonEmptyVerb",
 			schema: `
 				module one {
@@ -186,6 +185,16 @@ func TestValidate(t *testing.T) {
 				"6:7-7: verb verbWithWrongOutput: cron job can not have a response type",
 			},
 		},
+		{name: "IngressBodyExternalType",
+			schema: `
+				module two {
+					data Data {}
+				}
+				module one {
+					verb a(HttpRequest<two.Data>) HttpResponse<two.Data, Empty>
+						+ingress http GET /a
+				}
+			`},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We don't have access to the full schema at this point, so we can't validate that external types exist

Fixes #1298
