### PR TITLE
fix: Resolve Header Duplication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/TBD54566975/ftl
 go 1.22.2
 
 require (
-	connectrpc.com/connect v1.16.0
+	connectrpc.com/connect v1.14.0
 	connectrpc.com/grpcreflect v1.2.0
 	connectrpc.com/otelconnect v0.7.0
 	github.com/BurntSushi/toml v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+connectrpc.com/connect v1.14.0 h1:PDS+J7uoz5Oui2VEOMcfz6Qft7opQM9hPiKvtGC01pA=
+connectrpc.com/connect v1.14.0/go.mod h1:uoAq5bmhhn43TwhaKdGKN/bZcGtzPW1v+ngDTn5u+8s=
 connectrpc.com/connect v1.16.0 h1:rdtfQjZ0OyFkWPTegBNcH7cwquGAN1WzyJy80oFNibg=
 connectrpc.com/connect v1.16.0/go.mod h1:XpZAduBQUySsb4/KO5JffORVkDI4B6/EYPi7N8xpNZw=
 connectrpc.com/grpcreflect v1.2.0 h1:Q6og1S7HinmtbEuBvARLNwYmTbhEGRpHDhqrPNlmK+U=

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,10 @@
       "matchPackageNames": ["eslint"],
       "enabled": false,
       "paths": ["frontend/**", "extensions/**"]
+    },
+    {
+      "matchPackageNames": ["connectrpc.com/connect"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
It has been found that when version 1.16.0 of connectrpc is used, that there can be duplicate headers present which results in malformed headers when using FTL in an environment where it communicates through an Envoy sidecar.

This change downgrades to 1.14.0 as that is a known good version, and it also prevents the renovate bot from updating this dependency.