### PR TITLE
feat: extract database into schema for go

### DIFF
--- a/backend/controller/cronjobs/cronjobs_integration_test.go
+++ b/backend/controller/cronjobs/cronjobs_integration_test.go
@@ -4,19 +4,13 @@ package cronjobs
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
-	"connectrpc.com/connect"
 	db "github.com/TBD54566975/ftl/backend/controller/dal"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
-	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
-	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/internal/log"
-	"github.com/TBD54566975/ftl/internal/model"
 	"github.com/alecthomas/assert/v2"
-	"github.com/alecthomas/types/optional"
 	"github.com/benbjohnson/clock"
 )
 

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -230,6 +230,7 @@ func parseConfigDecl(pctx *parseContext, node *ast.CallExpr, fn *types.Func) {
 	}
 	if name == "" {
 		pctx.errors.add(errorf(node, "config and secret declarations must have a single string literal argument"))
+		return
 	}
 	index := node.Fun.(*ast.IndexExpr) //nolint:forcetypeassert
 
@@ -273,6 +274,7 @@ func parseDatabaseDecl(pctx *parseContext, node *ast.CallExpr) {
 	}
 	if name == "" {
 		pctx.errors.add(errorf(node, "config and secret declarations must have a single string literal argument"))
+		return
 	}
 	decl := &schema.Database{
 		Pos:  goPosToSchemaPos(node.Pos()),

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -50,6 +50,8 @@ func TestExtractModuleSchema(t *testing.T) {
   config configValue one.Config
   secret secretValue String
 
+  database testDb
+
   enum Color(String) {
     Red("Red")
     Blue("Blue")

--- a/go-runtime/compile/testdata/one/one.go
+++ b/go-runtime/compile/testdata/one/one.go
@@ -75,6 +75,7 @@ type Config struct {
 
 var configValue = ftl.Config[Config]("configValue")
 var secretValue = ftl.Secret[string]("secretValue")
+var testDb = ftl.PostgresDatabase("testDb")
 
 //ftl:export
 func Verb(ctx context.Context, req Req) (Resp, error) {

--- a/integration/testdata/go/database/echo.go
+++ b/integration/testdata/go/database/echo.go
@@ -16,7 +16,7 @@ type InsertResponse struct{}
 
 //ftl:export
 func Insert(ctx context.Context, req InsertRequest) (InsertResponse, error) {
-	err := persistRequest(req)
+	err := persistRequest(ctx, req)
 	if err != nil {
 		return InsertResponse{}, err
 	}
@@ -24,8 +24,8 @@ func Insert(ctx context.Context, req InsertRequest) (InsertResponse, error) {
 	return InsertResponse{}, nil
 }
 
-func persistRequest(req InsertRequest) error {
-	_, err := db.Exec(`CREATE TABLE IF NOT EXISTS requests
+func persistRequest(ctx context.Context, req InsertRequest) error {
+	_, err := db.Get(ctx).Exec(`CREATE TABLE IF NOT EXISTS requests
 	       (
 	         data TEXT,
 	         created_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
@@ -34,7 +34,7 @@ func persistRequest(req InsertRequest) error {
 	if err != nil {
 		return err
 	}
-	_, err = db.Exec("INSERT INTO requests (data) VALUES ($1);", req.Data)
+	_, err = db.Get(ctx).Exec("INSERT INTO requests (data) VALUES ($1);", req.Data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes integration tests on main.
`modulecontext` was not passing along DSNs to modules because the schema never included the database declaration in the schema.