### PR TITLE
fix: return early from ftl dev when incompatible flags (--stop --no-serve) are used

### DIFF
--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -39,6 +39,10 @@ func (d *devCmd) Run(ctx context.Context, projConfig projectconfig.Config) error
 
 	g, ctx := errgroup.WithContext(ctx)
 
+	if d.NoServe && d.ServeCmd.Stop {
+		logger := log.FromContext(ctx)
+		return KillBackgroundServe(logger)
+	}
 	if !d.NoServe {
 		if d.ServeCmd.Stop {
 			err := d.ServeCmd.Run(ctx)


### PR DESCRIPTION
Fixes https://github.com/TBD54566975/ftl/issues/1167

Manually tested:

```
$ ftl dev --stop --no-serve ./examples/go --log-level=trace
trace: Loading config from /Users/dli/Development/ftl/ftl-project.toml
debug: FTL serve is not running in the background
$ ftl serve --background
info: `ftl serve` running in background with pid: 42320
$ ftl dev --stop --no-serve ./examples/go --log-level=trace
trace: Loading config from /Users/dli/Development/ftl/ftl-project.toml
info: `ftl serve` stopped (pid: 42320)
```