### PR TITLE
fix: simplify config/secret duplication validation logic

### DIFF
--- a/backend/schema/validate_test.go
+++ b/backend/schema/validate_test.go
@@ -196,73 +196,33 @@ func TestValidate(t *testing.T) {
 				}
 			`,
 		},
-		{name: "DuplicateConfigsSimple",
+		{name: "DuplicateConfigs",
 			schema: `
 				module one {
                                         config FTL_ENDPOINT String
+                                        config FTL_ENDPOINT Any
                                         config FTL_ENDPOINT String
 				}
 			`,
 			errs: []string{
 				"4:41-41: duplicate config declaration at 3:41",
-			},
-		},
-		{name: "DuplicateConfigsDiffTypes",
-			schema: `
-				module one {
-                                        config FTL_ENDPOINT String
-                                        config FTL_ENDPOINT Any
-				}
-			`,
-		},
-		{name: "DuplicateConfigsMultiple",
-			schema: `
-				module one {
-                                        config FTL_ENDPOINT String
-                                        config FTL_ENDPOINT Any
-                                        config FTL_ENDPOINT String
-                                        config FTL_ENDPOINT String
-				}
-			`,
-			errs: []string{
 				"5:41-41: duplicate config declaration at 3:41",
-				"6:41-41: duplicate config declaration at 3:41",
 			},
 		},
-		{name: "DuplicateSecretsSimple",
+		{name: "DuplicateSecrets",
 			schema: `
 				module one {
                                         secret MY_SECRET String
+                                        secret MY_SECRET Any
                                         secret MY_SECRET String
 				}
 			`,
 			errs: []string{
 				"4:41-41: duplicate secret declaration at 3:41",
-			},
-		},
-		{name: "DuplicateSecretsDiffTypes",
-			schema: `
-				module one {
-                                        secret MY_SECRET String
-                                        secret MY_SECRET Any
-				}
-			`,
-		},
-		{name: "DuplicateSecretsMultiple",
-			schema: `
-				module one {
-                                        secret MY_SECRET String
-                                        secret MY_SECRET Any
-                                        secret MY_SECRET String
-                                        secret MY_SECRET String
-				}
-			`,
-			errs: []string{
 				"5:41-41: duplicate secret declaration at 3:41",
-				"6:41-41: duplicate secret declaration at 3:41",
 			},
 		},
-		{name: "DuplicateDatabasesSimple",
+		{name: "DuplicateDatabases",
 			schema: `
 				module one {
                                         database MY_DB


### PR DESCRIPTION
Fixes https://github.com/TBD54566975/ftl/issues/1121

* Addresses comments in PR https://github.com/TBD54566975/ftl/pull/1336
* Adds additional duplication error case for configs/secrets with the same name but different types, which also simplifies the overall validation logic