### PR TITLE
fix: go-runtime extraneous secret/config duplication error

### DIFF
--- a/backend/schema/validate_test.go
+++ b/backend/schema/validate_test.go
@@ -222,6 +222,14 @@ func TestValidate(t *testing.T) {
 				"5:41-41: duplicate secret declaration at 3:41",
 			},
 		},
+		{name: "ConfigAndSecretsWithSameName",
+			schema: `
+				module one {
+                                        config FTL_ENDPOINT String
+                                        secret FTL_ENDPOINT String
+				}
+			`,
+		},
 		{name: "DuplicateDatabases",
 			schema: `
 				module one {

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -261,15 +261,20 @@ func parseConfigDecl(pctx *parseContext, node *ast.CallExpr, fn *types.Func) {
 	// Check for duplicates
 	_, endCol := goNodePosToSchemaPos(node)
 	for _, d := range pctx.module.Decls {
-		c, ok := d.(*schema.Config)
-		if ok && c.Name == name && c.Type.String() == st.String() {
-			pctx.errors.add(errorf(node, "duplicate config declaration at %d:%d-%d", c.Pos.Line, c.Pos.Column, endCol))
-			return
-		}
-		s, ok := d.(*schema.Secret)
-		if ok && s.Name == name && s.Type.String() == st.String() {
-			pctx.errors.add(errorf(node, "duplicate secret declaration at %d:%d-%d", s.Pos.Line, s.Pos.Column, endCol))
-			return
+		switch fn.FullName() {
+		case ftlConfigFuncPath:
+			c, ok := d.(*schema.Config)
+			if ok && c.Name == name && c.Type.String() == st.String() {
+				pctx.errors.add(errorf(node, "duplicate config declaration at %d:%d-%d", c.Pos.Line, c.Pos.Column, endCol))
+				return
+			}
+		case ftlSecretFuncPath:
+			s, ok := d.(*schema.Secret)
+			if ok && s.Name == name && s.Type.String() == st.String() {
+				pctx.errors.add(errorf(node, "duplicate secret declaration at %d:%d-%d", s.Pos.Line, s.Pos.Column, endCol))
+				return
+			}
+		default:
 		}
 	}
 

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -248,7 +248,7 @@ func TestErrorReporting(t *testing.T) {
 	assert.EqualError(t, errors.Join(genericizeErrors(schemaErrs)...),
 		filename+":10:13-35: config and secret declarations must have a single string literal argument\n"+
 			filename+":13:18-52: duplicate config declaration at 12:18-52\n"+
-			filename+":16:18-49: duplicate secret declaration at 15:18-49\n"+
+			filename+":16:18-52: duplicate secret declaration at 15:18-52\n"+
 			filename+":19:14-44: duplicate database declaration at 18:14-44\n"+
 			filename+":22:2-10: unsupported type \"error\" for field \"BadParam\"\n"+
 			filename+":25:2-17: unsupported type \"uint64\" for field \"AnotherBadParam\"\n"+

--- a/go-runtime/compile/testdata/failing/failing.go
+++ b/go-runtime/compile/testdata/failing/failing.go
@@ -12,8 +12,8 @@ var empty = ftl.Config[string]("")
 var goodConfig = ftl.Config[string]("FTL_ENDPOINT")
 var duplConfig = ftl.Config[string]("FTL_ENDPOINT")
 
-var goodSecret = ftl.Secret[string]("MY_SECRET")
-var duplSecret = ftl.Secret[string]("MY_SECRET")
+var goodSecret = ftl.Secret[string]("FTL_ENDPOINT")
+var duplSecret = ftl.Secret[string]("FTL_ENDPOINT")
 
 var goodDB = ftl.PostgresDatabase("testDb")
 var duplDB = ftl.PostgresDatabase("testDb")


### PR DESCRIPTION
Fix a bug I introduced in prior PRs for https://github.com/TBD54566975/ftl/issues/1121

In the go-runtime validation, we would previously error if a secret and config had the same name. This fixes that error and adds tests to ensure we don't rebreak this either in the go-runtime nor on the backend.