### PR TITLE
fix: expireStaleLeases can't be singleton

### DIFF
--- a/backend/controller/dal/lease_test.go
+++ b/backend/controller/dal/lease_test.go
@@ -29,6 +29,9 @@ func leaseExists(t *testing.T, conn sql.DBI, idempotencyKey uuid.UUID, key lease
 }
 
 func TestLease(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	conn := sqltest.OpenForTesting(ctx, t)
 	dal, err := New(ctx, conn)
@@ -57,6 +60,9 @@ func TestLease(t *testing.T) {
 }
 
 func TestExpireLeases(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	conn := sqltest.OpenForTesting(ctx, t)
 	dal, err := New(ctx, conn)


### PR DESCRIPTION
Because a lease is required to run it, and if the lease is stale it will never be expired. This is a quick workaround by making the task parallel, but we should fix this probably by making the task use the hash ring.