### PR TITLE
fix: test context strictly enforces names and types

### DIFF
--- a/go-runtime/ftl/config.go
+++ b/go-runtime/ftl/config.go
@@ -15,26 +15,25 @@ type ConfigType interface{ any }
 // Config declares a typed configuration key for the current module.
 func Config[T ConfigType](name string) ConfigValue[T] {
 	module := callerModule()
-	return ConfigValue[T]{module, name}
+	return ConfigValue[T]{Ref{module, name}}
 }
 
 // ConfigValue is a typed configuration key for the current module.
 type ConfigValue[T ConfigType] struct {
-	module string
-	name   string
+	Ref
 }
 
-func (c ConfigValue[T]) String() string { return fmt.Sprintf("config \"%s.%s\"", c.module, c.name) }
+func (c ConfigValue[T]) String() string { return fmt.Sprintf("config \"%s.%s\"", c.Module, c.Name) }
 
 func (c ConfigValue[T]) GoString() string {
 	var t T
-	return fmt.Sprintf("ftl.ConfigValue[%T](\"%s.%s\")", t, c.module, c.name)
+	return fmt.Sprintf("ftl.ConfigValue[%T](\"%s.%s\")", t, c.Module, c.Name)
 }
 
 // Get returns the value of the configuration key from FTL.
 func (c ConfigValue[T]) Get(ctx context.Context) (out T) {
 	cm := configuration.ConfigFromContext(ctx)
-	ref := configuration.NewRef(c.module, c.name)
+	ref := configuration.NewRef(c.Module, c.Name)
 	err := cm.Get(ctx, ref, &out)
 	if err != nil {
 		panic(fmt.Errorf("failed to get %s: %w", c, err))

--- a/go-runtime/ftl/config.go
+++ b/go-runtime/ftl/config.go
@@ -23,11 +23,11 @@ type ConfigValue[T ConfigType] struct {
 	Ref
 }
 
-func (c ConfigValue[T]) String() string { return fmt.Sprintf("config \"%s.%s\"", c.Module, c.Name) }
+func (c ConfigValue[T]) String() string { return fmt.Sprintf("config \"%s\"", c.Ref) }
 
 func (c ConfigValue[T]) GoString() string {
 	var t T
-	return fmt.Sprintf("ftl.ConfigValue[%T](\"%s.%s\")", t, c.Module, c.Name)
+	return fmt.Sprintf("ftl.ConfigValue[%T](\"%s\")", t, c.Ref)
 }
 
 // Get returns the value of the configuration key from FTL.

--- a/go-runtime/ftl/database.go
+++ b/go-runtime/ftl/database.go
@@ -11,13 +11,15 @@ import (
 )
 
 type Database struct {
-	Name string
+	Name   string
+	DBType modulecontext.DBType
 }
 
 // PostgresDatabase returns a handler for the named database.
 func PostgresDatabase(name string) Database {
 	return Database{
-		Name: name,
+		Name:   name,
+		DBType: modulecontext.DBTypePostgres,
 	}
 }
 

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -4,9 +4,7 @@ package ftltest
 import (
 	"context"
 	"fmt"
-	"os"
 	"reflect"
-	"strings"
 
 	"github.com/alecthomas/types/optional"
 
@@ -72,30 +70,6 @@ func WithSecret[T ftl.SecretType](secret ftl.SecretValue[T], value T) func(conte
 		}
 		sm := cf.SecretsFromContext(ctx)
 		return sm.Set(ctx, cf.Ref{Module: optional.Some(secret.Module), Name: secret.Name}, value)
-	}
-}
-
-// WithDatabase sets up a database based on the name
-//
-// A DSN will be read at the environment variable `FTL_POSTGRES_DSN_<MODULE>_<DBNAME>`
-// If no DSN is found an error will be returned
-//
-// To be used when setting up a context for a test:
-// ctx := ftltest.Context(
-//
-//	ftltest.WithDatabase(dbHandle, "..."),
-//	... other options
-//
-// )
-func WithDatabase(database ftl.Database, name string) func(context.Context) error {
-	return func(ctx context.Context) error {
-		envarKey := "FTL_POSTGRES_DSN_" + strings.ToUpper(ftl.Module()) + "_" + strings.ToUpper(name)
-		dsn, ok := os.LookupEnv(envarKey)
-		if !ok {
-			return fmt.Errorf("could not find DSN for database %s at environment variable %s", name, envarKey)
-		}
-		dbProvider := modulecontext.DBProviderFromContext(ctx)
-		return dbProvider.Add(database.Name, database.DBType, dsn)
 	}
 }
 

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -46,6 +46,9 @@ func Context(options ...func(context.Context) error) context.Context {
 // )
 func WithConfig[T ftl.ConfigType](config ftl.ConfigValue[T], value T) func(context.Context) error {
 	return func(ctx context.Context) error {
+		if config.Module != ftl.Module() {
+			return fmt.Errorf("config %v does not match current module %s", config.Module, ftl.Module())
+		}
 		cm := cf.ConfigFromContext(ctx)
 		return cm.Set(ctx, cf.Ref{Module: optional.Some(config.Module), Name: config.Name}, value)
 	}
@@ -62,6 +65,9 @@ func WithConfig[T ftl.ConfigType](config ftl.ConfigValue[T], value T) func(conte
 // )
 func WithSecret[T ftl.SecretType](secret ftl.SecretValue[T], value T) func(context.Context) error {
 	return func(ctx context.Context) error {
+		if secret.Module != ftl.Module() {
+			return fmt.Errorf("secret %v does not match current module %s", secret.Module, ftl.Module())
+		}
 		sm := cf.SecretsFromContext(ctx)
 		return sm.Set(ctx, cf.Ref{Module: optional.Some(secret.Module), Name: secret.Name}, value)
 	}

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -14,12 +14,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/log"
 )
 
-type DBType int32
-
-const (
-	DBTypePostgres = DBType(modulecontext.DBTypePostgres)
-)
-
 // Context suitable for use in testing FTL verbs with provided options
 func Context(options ...func(context.Context) error) context.Context {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
@@ -43,31 +37,49 @@ func Context(options ...func(context.Context) error) context.Context {
 
 // WithConfig sets a configuration for the current module
 //
-// To be used with Context(...)
-func WithConfig(name string, value any) func(context.Context) error {
+// To be used when setting up a context for a test:
+// ctx := ftltest.Context(
+//
+//	ftltest.WithConfig(exampleEndpoint, "https://example.com"),
+//	... other options
+//
+// )
+func WithConfig[T ftl.ConfigType](config ftl.ConfigValue[T], value T) func(context.Context) error {
 	return func(ctx context.Context) error {
 		cm := cf.ConfigFromContext(ctx)
-		return cm.Set(ctx, cf.Ref{Module: optional.Some(ftl.Module()), Name: name}, value)
+		return cm.Set(ctx, cf.Ref{Module: optional.Some(config.Module), Name: config.Name}, value)
 	}
 }
 
 // WithSecret sets a secret for the current module
 //
-// To be used with Context(...)
-func WithSecret(name string, value any) func(context.Context) error {
+// To be used when setting up a context for a test:
+// ctx := ftltest.Context(
+//
+//	ftltest.WithSecret(privateKey, "abc123"),
+//	... other options
+//
+// )
+func WithSecret[T ftl.SecretType](secret ftl.SecretValue[T], value T) func(context.Context) error {
 	return func(ctx context.Context) error {
-		cm := cf.SecretsFromContext(ctx)
-		return cm.Set(ctx, cf.Ref{Module: optional.Some(ftl.Module()), Name: name}, value)
+		sm := cf.SecretsFromContext(ctx)
+		return sm.Set(ctx, cf.Ref{Module: optional.Some(secret.Module), Name: secret.Name}, value)
 	}
 }
 
 // WithDSN sets a DSN for the current module
 //
-// To be used with Context(...)
-func WithDSN(name string, dbType DBType, dsn string) func(context.Context) error {
+// To be used when setting up a context for a test:
+// ctx := ftltest.Context(
+//
+//	ftltest.WithDSN(dbHandle, "..."),
+//	... other options
+//
+// )
+func WithDSN(database ftl.Database, dsn string) func(context.Context) error {
 	return func(ctx context.Context) error {
 		dbProvider := modulecontext.DBProviderFromContext(ctx)
-		return dbProvider.Add(name, modulecontext.DBType(dbType), dsn)
+		return dbProvider.Add(database.Name, database.DBType, dsn)
 	}
 }
 

--- a/go-runtime/ftl/secrets.go
+++ b/go-runtime/ftl/secrets.go
@@ -13,26 +13,25 @@ type SecretType interface{ any }
 // Secret declares a typed secret for the current module.
 func Secret[T SecretType](name string) SecretValue[T] {
 	module := callerModule()
-	return SecretValue[T]{module, name}
+	return SecretValue[T]{Ref{module, name}}
 }
 
 // SecretValue is a typed secret for the current module.
 type SecretValue[T SecretType] struct {
-	module string
-	name   string
+	Ref
 }
 
-func (s SecretValue[T]) String() string { return fmt.Sprintf("secret \"%s.%s\"", s.module, s.name) }
+func (s SecretValue[T]) String() string { return fmt.Sprintf("secret \"%s.%s\"", s.Module, s.Name) }
 
 func (s SecretValue[T]) GoString() string {
 	var t T
-	return fmt.Sprintf("ftl.SecretValue[%T](\"%s.%s\")", t, s.module, s.name)
+	return fmt.Sprintf("ftl.SecretValue[%T](\"%s.%s\")", t, s.Module, s.Name)
 }
 
 // Get returns the value of the secret from FTL.
 func (s SecretValue[T]) Get(ctx context.Context) (out T) {
 	sm := configuration.SecretsFromContext(ctx)
-	if err := sm.Get(ctx, configuration.NewRef(s.module, s.name), &out); err != nil {
+	if err := sm.Get(ctx, configuration.NewRef(s.Module, s.Name), &out); err != nil {
 		panic(fmt.Errorf("failed to get %s: %w", s, err))
 	}
 	return

--- a/go-runtime/ftl/secrets.go
+++ b/go-runtime/ftl/secrets.go
@@ -21,11 +21,11 @@ type SecretValue[T SecretType] struct {
 	Ref
 }
 
-func (s SecretValue[T]) String() string { return fmt.Sprintf("secret \"%s.%s\"", s.Module, s.Name) }
+func (s SecretValue[T]) String() string { return fmt.Sprintf("secret \"%s\"", s.Ref) }
 
 func (s SecretValue[T]) GoString() string {
 	var t T
-	return fmt.Sprintf("ftl.SecretValue[%T](\"%s.%s\")", t, s.Module, s.Name)
+	return fmt.Sprintf("ftl.SecretValue[%T](\"%s\")", t, s.Ref)
 }
 
 // Get returns the value of the secret from FTL.


### PR DESCRIPTION
Get rid of any chance of:
- Mistyping a secret/config when writing a unit test
- Passing in the wrong value type when passing in a secret/config in a unit test
```
func TestEcho(t *testing.T) {
	ctx := ftltest.Context(
		ftltest.WithConfig(defaultName, "helloworld"),
		ftltest.WithSecret(secretKey, "shhhhh"),
		ftltest.WhenVerb(time.Time, func(ctx context.Context, req time.TimeRequest) (time.TimeResponse, error) {
			return time.TimeResponse{Time: stdtime.Now()}, nil
		}),
	)
        ...
}
```

Other changes:
- `ftl.Database` holds its db type
- `ftl.ConfigValue` and ftl.SecretValue embeds Ref rather than holding private module+name fields