### PR TITLE
chore: disable kotlin tests/releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
         uses: cashapp/activate-hermit@v1
       - name: Build Cache
         uses: ./.github/actions/build-cache
-      - name: Build Kotlin
-        run: just build-kt-runtime
       - name: Docker Compose
         run: docker compose up -d --wait
       - name: Test

--- a/.github/workflows/writecache.yml
+++ b/.github/workflows/writecache.yml
@@ -21,8 +21,6 @@ jobs:
         run: just init-db
       - name: Rebuild All
         run: just build-all
-      - name: Download Maven Dependencies
-        run: mvn -f kotlin-runtime/ftl-runtime dependency:resolve --batch-mode
       - name: Download Go Dependencies
         run: go mod download -x
       - id: find-go-build-cache

--- a/Justfile
+++ b/Justfile
@@ -37,7 +37,7 @@ dev *args:
   watchexec -r -e go -e sql -f sqlc.yaml -- "just build-sqlc && ftl dev {{args}}"
 
 # Build everything
-build-all: build-frontend build-generate build-kt-runtime build-protos build-sqlc build-zips
+build-all: build-frontend build-generate build-protos build-sqlc build-zips
   @just build ftl ftl-controller ftl-runner ftl-initdb
 
 # Run "go generate" on all packages
@@ -86,11 +86,11 @@ package-extension: build-extension
 publish-extension: package-extension
   @cd extensions/vscode && vsce publish
 
-# Build the Kotlin runtime (if necessary)
+# Kotlin runtime is temporarily disabled; these instructions create a dummy zip in place of the kotlin runtime jar for
+# the runner.
 build-kt-runtime:
-  @mk {{KT_RUNTIME_OUT}} : kotlin-runtime/ftl-runtime -- mvn -f kotlin-runtime/ftl-runtime -Dmaven.test.skip=true -B install
-  @mk {{KT_RUNTIME_RUNNER_TEMPLATE_OUT}} : {{KT_RUNTIME_OUT}} -- "mkdir -p $(dirname {{KT_RUNTIME_RUNNER_TEMPLATE_OUT}}) && install -m 0600 {{KT_RUNTIME_OUT}} {{KT_RUNTIME_RUNNER_TEMPLATE_OUT}}"
-  @mk {{RUNNER_TEMPLATE_ZIP}} : {{KT_RUNTIME_RUNNER_TEMPLATE_OUT}} -- "cd build/template && zip -q --symlinks -r ../../{{RUNNER_TEMPLATE_ZIP}} ."
+  @mkdir -p build/template/ftl && touch build/template/ftl/temp.txt
+  @cd build/template && zip -q --symlinks -r ../../{{RUNNER_TEMPLATE_ZIP}} .
 
 # Install Node dependencies
 npm-install:


### PR DESCRIPTION
don't build kotlin when running just build-all

follow up from #1364 with stuff that was missed