### PR TITLE
chore: ci uses integration tag to find tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
         id: extract-tests
         run: |
           # shellcheck disable=SC2046
-          echo "matrix={\"test\":$(jq -c -n '$ARGS.positional' --args $(grep '^func Test' $(find integration -name '*_test.go') | awk '{print $2}' | cut -d'(' -f1))}" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"test\":$(jq -c -n '$ARGS.positional' --args $(grep -r -l '^//go:build integration' integration backend/controller/cronjobs | xargs grep '^func Test' | awk '{print $2}' | cut -d'(' -f1))}" >> "$GITHUB_OUTPUT"
   integration:
     needs: prepare
     runs-on: ubuntu-latest
@@ -42,4 +42,4 @@ jobs:
       - name: Download Go Modules
         run: go mod download
       - name: Run ${{ matrix.test }}
-        run: go test -v -race -tags integration -run ${{ matrix.test }} ./integration/...
+        run: go test -v -race -tags integration -run ${{ matrix.test }} ./integration/... ./backend/controller/cronjobs


### PR DESCRIPTION
Two changes:
- CI looks in `intergration` and `backend/controller/cronjobs` directories for integration tests
- Filters files by ones that include `//go:build integration`
```
$ echo "matrix={\"test\":$(jq -c -n '$ARGS.positional' --args $(grep -r -l '^//go:build integration' integration backend/controller/cronjobs | xargs grep '^func Test' | awk '{print $2}' | cut -d'(' -f1))}"

matrix={"test":["TestCron","TestLifecycle","TestInterModuleCall","TestDatabase","TestSchemaGenerate","TestHttpIngress","TestServiceWithRealDal"]}
```