### PR TITLE
fix: display db type after 'database'

### DIFF
--- a/backend/schema/database.go
+++ b/backend/schema/database.go
@@ -15,8 +15,8 @@ type Database struct {
 	Pos Position `parser:"" protobuf:"1,optional"`
 
 	Comments []string `parser:"@Comment*" protobuf:"3"`
-	Type     string   `parser:"@'postgres'" protobuf:"4"`
-	Name     string   `parser:"'database' @Ident" protobuf:"2"`
+	Type     string   `parser:"'database' @'postgres'" protobuf:"4"`
+	Name     string   `parser:"@Ident" protobuf:"2"`
 }
 
 var _ Decl = (*Database)(nil)
@@ -29,7 +29,7 @@ func (d *Database) schemaChildren() []Node { return nil }
 func (d *Database) String() string {
 	w := &strings.Builder{}
 	fmt.Fprint(w, encodeComments(d.Comments))
-	fmt.Fprintf(w, "%s database %s", d.Type, d.Name)
+	fmt.Fprintf(w, "database %s %s", d.Type, d.Name)
 	return w.String()
 }
 

--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -22,7 +22,7 @@ module todo {
   config configValue String
   secret secretValue String
 
-  postgres database testdb
+  database postgres testdb
 
   export data CreateRequest {
     name {String: String}? +alias json "rqn"
@@ -392,7 +392,7 @@ func TestParseModule(t *testing.T) {
 module todo {
   config configValue String
   secret secretValue String
-  postgres database testdb
+  database postgres testdb
 
   export data CreateRequest {
     name {String: String}? +alias json "rqn"

--- a/backend/schema/validate_test.go
+++ b/backend/schema/validate_test.go
@@ -235,8 +235,8 @@ func TestValidate(t *testing.T) {
 		{name: "DuplicateDatabases",
 			schema: `
 				module one {
-                                        postgres database MY_DB
-                                        postgres database MY_DB
+                                        database postgres MY_DB
+                                        database postgres MY_DB
 				}
 			`,
 			errs: []string{

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -50,7 +50,7 @@ func TestExtractModuleSchema(t *testing.T) {
   config configValue one.Config
   secret secretValue String
 
-  postgres database testDb
+  database postgres testDb
 
   export enum Color: String {
     Red = "Red"


### PR DESCRIPTION
displaying attributes after the resource identifier for consistency with other resources