### PR TITLE
fix: module context should be immutable

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -640,11 +640,11 @@ func (s *Service) GetModuleContext(ctx context.Context, req *connect.Request[ftl
 	if !ok {
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("module %q not found", req.Msg.Module))
 	}
-	moduleContext, err := modulecontext.FromEnvironment(ctx, module.Name, false)
+	moduleContext, err := modulecontext.New(module.Name).UpdateFromEnvironment(ctx)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("could not get module context: %w", err))
 	}
-	response, err := moduleContext.ToProto(module.Name)
+	response, err := moduleContext.ToProto()
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("could not marshal module context: %w", err))
 	}

--- a/go-runtime/ftl/call.go
+++ b/go-runtime/ftl/call.go
@@ -9,13 +9,14 @@ import (
 
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/go-runtime/encoding"
 	"github.com/TBD54566975/ftl/go-runtime/modulecontext"
 	"github.com/TBD54566975/ftl/internal/rpc"
 )
 
 func call[Req, Resp any](ctx context.Context, callee Ref, req Req, inline Verb[Req, Resp]) (resp Resp, err error) {
-	behavior, err := modulecontext.FromContext(ctx).BehaviorForVerb(modulecontext.Ref(callee))
+	behavior, err := modulecontext.FromContext(ctx).BehaviorForVerb(schema.Ref{Module: callee.Module, Name: callee.Name})
 	if err != nil {
 		return resp, fmt.Errorf("%s: %w", callee, err)
 	}

--- a/go-runtime/ftl/config_test.go
+++ b/go-runtime/ftl/config_test.go
@@ -2,6 +2,7 @@ package ftl
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -11,16 +12,25 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	ctx := log.ContextWithNewDefaultLogger(context.Background())
-
-	moduleCtx := modulecontext.New("test")
-	ctx = moduleCtx.ApplyToContext(ctx)
-
 	type C struct {
 		One string
 		Two string
 	}
+
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+
+	data, err := json.Marshal(C{"one", "two"})
+	assert.NoError(t, err)
+
+	moduleCtx := modulecontext.New("test").Update(
+		map[string][]byte{
+			"test": data,
+		},
+		map[string][]byte{},
+		map[string]modulecontext.Database{},
+	)
+	ctx = moduleCtx.ApplyToContext(ctx)
+
 	config := Config[C]("test")
-	assert.NoError(t, moduleCtx.SetConfig("test", C{"one", "two"}))
 	assert.Equal(t, C{"one", "two"}, config.Get(ctx))
 }

--- a/go-runtime/ftl/secrets_test.go
+++ b/go-runtime/ftl/secrets_test.go
@@ -2,6 +2,7 @@ package ftl
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -11,16 +12,25 @@ import (
 )
 
 func TestSecret(t *testing.T) {
-	ctx := log.ContextWithNewDefaultLogger(context.Background())
-
-	moduleCtx := modulecontext.New("test")
-	ctx = moduleCtx.ApplyToContext(ctx)
-
 	type C struct {
 		One string
 		Two string
 	}
+
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+
+	data, err := json.Marshal(C{"one", "two"})
+	assert.NoError(t, err)
+
+	moduleCtx := modulecontext.New("test").Update(
+		map[string][]byte{},
+		map[string][]byte{
+			"test": data,
+		},
+		map[string]modulecontext.Database{},
+	)
+	ctx = moduleCtx.ApplyToContext(ctx)
+
 	secret := Secret[C]("test")
-	assert.NoError(t, moduleCtx.SetSecret("test", C{"one", "two"}))
 	assert.Equal(t, C{"one", "two"}, secret.Get(ctx))
 }

--- a/go-runtime/modulecontext/from_environment_test.go
+++ b/go-runtime/modulecontext/from_environment_test.go
@@ -37,10 +37,10 @@ func TestFromEnvironment(t *testing.T) {
 
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 
-	moduleContext, err := FromEnvironment(ctx, "echo", false)
+	moduleContext, err := New("echo").UpdateFromEnvironment(ctx)
 	assert.NoError(t, err)
 
-	response, err := moduleContext.ToProto("echo")
+	response, err := moduleContext.ToProto()
 	assert.NoError(t, err)
 
 	assert.Equal(t, &ftlv1.ModuleContextResponse{

--- a/go-runtime/modulecontext/from_proto.go
+++ b/go-runtime/modulecontext/from_proto.go
@@ -1,21 +1,19 @@
 package modulecontext
 
 import (
+	"fmt"
+
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 )
 
-func FromProto(response *ftlv1.ModuleContextResponse) (*ModuleContext, error) {
-	moduleCtx := New(response.Module)
-	for name, data := range response.Configs {
-		moduleCtx.configs[name] = data
-	}
-	for name, data := range response.Secrets {
-		moduleCtx.secrets[name] = data
-	}
-	for _, entry := range response.Databases {
-		if err := moduleCtx.AddDatabase(entry.Name, DBType(entry.Type), entry.Dsn); err != nil {
-			return nil, err
+func FromProto(response *ftlv1.ModuleContextResponse) (ModuleContext, error) {
+	databases := map[string]Database{}
+	for name, entry := range response.Databases {
+		db, err := NewDatabase(DBType(entry.Type), entry.Dsn)
+		if err != nil {
+			return ModuleContext{}, fmt.Errorf("could not create database %q with DSN %q: %w", name, entry.Dsn, err)
 		}
+		databases[entry.Name] = db
 	}
-	return moduleCtx, nil
+	return New(response.Module).Update(response.Configs, response.Secrets, databases), nil
 }

--- a/go-runtime/modulecontext/module_context.go
+++ b/go-runtime/modulecontext/module_context.go
@@ -9,21 +9,31 @@ import (
 	"strings"
 
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/backend/schema"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // SQL driver
 )
 
-type Ref struct {
-	Module string
-	Name   string
-}
-
 type MockVerb func(ctx context.Context, req any) (resp any, err error)
 
-type dbEntry struct {
-	dsn    string
-	dbType DBType
-	db     *sql.DB
+type Database struct {
+	DSN    string
+	DBType DBType
+
+	db *sql.DB
+}
+
+// NewDatabase creates a Database that can be added to ModuleContext
+func NewDatabase(dbType DBType, dsn string) (Database, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return Database{}, err
+	}
+	return Database{
+		DSN:    dsn,
+		DBType: dbType,
+		db:     db,
+	}, nil
 }
 
 type DBType ftlv1.ModuleContextResponse_DBType
@@ -46,33 +56,53 @@ type ModuleContext struct {
 	module    string
 	configs   map[string][]byte
 	secrets   map[string][]byte
-	databases map[string]dbEntry
+	databases map[string]Database
 
 	isTesting               bool
-	mockVerbs               map[Ref]MockVerb
+	mockVerbs               map[schema.RefKey]MockVerb
 	allowDirectVerbBehavior bool
 }
 
 type contextKeyModuleContext struct{}
 
-func New(module string) *ModuleContext {
-	return &ModuleContext{
+// New creates a new blank ModuleContext for the given module.
+func New(module string) ModuleContext {
+	return ModuleContext{
 		module:    module,
 		configs:   map[string][]byte{},
 		secrets:   map[string][]byte{},
-		databases: map[string]dbEntry{},
-		mockVerbs: map[Ref]MockVerb{},
+		databases: map[string]Database{},
+		mockVerbs: map[schema.RefKey]MockVerb{},
 	}
 }
 
-func NewForTesting(module string) *ModuleContext {
-	moduleCtx := New(module)
-	moduleCtx.isTesting = true
-	return moduleCtx
+// Update copies a ModuleContext and adds configs, secrets and databases.
+func (m ModuleContext) Update(configs map[string][]byte, secrets map[string][]byte, databases map[string]Database) ModuleContext {
+	for name, data := range configs {
+		m.configs[name] = data
+	}
+	for name, data := range secrets {
+		m.secrets[name] = data
+	}
+	for name, db := range databases {
+		m.databases[name] = db
+	}
+	return m
 }
 
-func FromContext(ctx context.Context) *ModuleContext {
-	m, ok := ctx.Value(contextKeyModuleContext{}).(*ModuleContext)
+// UpdateForTesting copies a ModuleContext and marks it as part of a test environment and adds mock verbs and flags for other test features.
+func (m ModuleContext) UpdateForTesting(mockVerbs map[schema.RefKey]MockVerb, allowDirectVerbBehavior bool) ModuleContext {
+	m.isTesting = true
+	for name, verb := range mockVerbs {
+		m.mockVerbs[name] = verb
+	}
+	m.allowDirectVerbBehavior = allowDirectVerbBehavior
+	return m
+}
+
+// FromContext returns the ModuleContext attached to a context.
+func FromContext(ctx context.Context) ModuleContext {
+	m, ok := ctx.Value(contextKeyModuleContext{}).(ModuleContext)
 	if !ok {
 		panic("no ModuleContext in context")
 	}
@@ -80,14 +110,14 @@ func FromContext(ctx context.Context) *ModuleContext {
 }
 
 // ApplyToContext returns a Go context.Context with ModuleContext added.
-func (m *ModuleContext) ApplyToContext(ctx context.Context) context.Context {
+func (m ModuleContext) ApplyToContext(ctx context.Context) context.Context {
 	return context.WithValue(ctx, contextKeyModuleContext{}, m)
 }
 
 // GetConfig reads a configuration value for the module.
 //
 // "value" must be a pointer to a Go type that can be unmarshalled from JSON.
-func (m *ModuleContext) GetConfig(name string, value any) error {
+func (m ModuleContext) GetConfig(name string, value any) error {
 	data, ok := m.configs[name]
 	if !ok {
 		return fmt.Errorf("no config value for %q", name)
@@ -95,25 +125,10 @@ func (m *ModuleContext) GetConfig(name string, value any) error {
 	return json.Unmarshal(data, value)
 }
 
-// SetConfig sets a configuration value for the module.
-func (m *ModuleContext) SetConfig(name string, value any) error {
-	data, err := json.Marshal(value)
-	if err != nil {
-		return err
-	}
-	m.SetConfigData(name, data)
-	return nil
-}
-
-// SetConfigData sets a configuration value with raw bytes
-func (m *ModuleContext) SetConfigData(name string, data []byte) {
-	m.configs[name] = data
-}
-
 // GetSecret reads a secret value for the module.
 //
 // "value" must be a pointer to a Go type that can be unmarshalled from JSON.
-func (m *ModuleContext) GetSecret(name string, value any) error {
+func (m ModuleContext) GetSecret(name string, value any) error {
 	data, ok := m.secrets[name]
 	if !ok {
 		return fmt.Errorf("no secret value for %q", name)
@@ -121,54 +136,25 @@ func (m *ModuleContext) GetSecret(name string, value any) error {
 	return json.Unmarshal(data, value)
 }
 
-// SetSecret sets a secret value for the module.
-func (m *ModuleContext) SetSecret(name string, value any) error {
-	data, err := json.Marshal(value)
-	if err != nil {
-		return err
-	}
-	m.SetSecretData(name, data)
-	return nil
-}
-
-// SetSecretData sets a secret value with raw bytes
-func (m *ModuleContext) SetSecretData(name string, data []byte) {
-	m.secrets[name] = data
-}
-
-// AddDatabase adds a database connection
-func (m *ModuleContext) AddDatabase(name string, dbType DBType, dsn string) error {
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		return err
-	}
-	m.databases[name] = dbEntry{
-		dsn:    dsn,
-		db:     db,
-		dbType: dbType,
-	}
-	return nil
-}
-
 // GetDatabase gets a database connection
 //
 // Returns an error if no database with that name is found or it is not the expected type
-func (m *ModuleContext) GetDatabase(name string, dbType DBType) (*sql.DB, error) {
-	entry, ok := m.databases[name]
+func (m ModuleContext) GetDatabase(name string, dbType DBType) (*sql.DB, error) {
+	db, ok := m.databases[name]
 	if !ok {
 		return nil, fmt.Errorf("missing DSN for database %s", name)
 	}
-	if entry.dbType != dbType {
+	if db.DBType != dbType {
 		return nil, fmt.Errorf("database %s does not match expected type of %s", name, dbType)
 	}
-	return entry.db, nil
+	return db.db, nil
 }
 
 // BehaviorForVerb returns what to do to execute a verb
 //
 // This allows module context to dictate behavior based on testing options
-func (m *ModuleContext) BehaviorForVerb(ref Ref) (VerbBehavior, error) {
-	if mock, ok := m.mockVerbs[ref]; ok {
+func (m ModuleContext) BehaviorForVerb(ref schema.Ref) (VerbBehavior, error) {
+	if mock, ok := m.mockVerbs[ref.ToRefKey()]; ok {
 		return MockBehavior{Mock: mock}, nil
 	} else if m.allowDirectVerbBehavior && ref.Module == m.module {
 		return DirectBehavior{}, nil
@@ -179,14 +165,6 @@ func (m *ModuleContext) BehaviorForVerb(ref Ref) (VerbBehavior, error) {
 		return StandardBehavior{}, fmt.Errorf("no mock found: provide a mock with ftltest.WhenVerb(%s.%s, ...)", ref.Module, strings.ToUpper(ref.Name[:1])+ref.Name[1:])
 	}
 	return StandardBehavior{}, nil
-}
-
-func (m *ModuleContext) SetMockVerb(ref Ref, mock MockVerb) {
-	m.mockVerbs[ref] = mock
-}
-
-func (m *ModuleContext) AllowDirectVerbBehaviorWithinModule() {
-	m.allowDirectVerbBehavior = true
 }
 
 // VerbBehavior indicates how to execute a verb

--- a/go-runtime/modulecontext/to_proto.go
+++ b/go-runtime/modulecontext/to_proto.go
@@ -5,17 +5,17 @@ import (
 )
 
 // ToProto converts a ModuleContext to a proto response.
-func (m *ModuleContext) ToProto(moduleName string) (*ftlv1.ModuleContextResponse, error) {
+func (m ModuleContext) ToProto() (*ftlv1.ModuleContextResponse, error) {
 	databases := make([]*ftlv1.ModuleContextResponse_DSN, 0, len(m.databases))
 	for name, entry := range m.databases {
 		databases = append(databases, &ftlv1.ModuleContextResponse_DSN{
 			Name: name,
-			Type: ftlv1.ModuleContextResponse_DBType(entry.dbType),
-			Dsn:  entry.dsn,
+			Type: ftlv1.ModuleContextResponse_DBType(entry.DBType),
+			Dsn:  entry.DSN,
 		})
 	}
 	return &ftlv1.ModuleContextResponse{
-		Module:    moduleName,
+		Module:    m.module,
 		Configs:   m.configs,
 		Secrets:   m.secrets,
 		Databases: databases,

--- a/integration/testdata/go/wrapped/wrapped_test.go
+++ b/integration/testdata/go/wrapped/wrapped_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWrapped(t *testing.T) {
-	allOptions := []func(context.Context) error{
+	allOptions := []func(*ftltest.Options) error{
 		ftltest.WithConfig(myConfig, "helloworld"),
 		ftltest.WithSecret(mySecret, "shhhhh"),
 		ftltest.WithCallsAllowedWithinModule(),
@@ -23,7 +23,7 @@ func TestWrapped(t *testing.T) {
 
 	for _, tt := range []struct {
 		name          string
-		options       []func(context.Context) error
+		options       []func(*ftltest.Options) error
 		expectedError ftl.Option[string]
 	}{
 		{


### PR DESCRIPTION
fixes: https://github.com/TBD54566975/ftl/issues/1398
Now a ModuleContext is built using the following functions:
- `New(moduleName)`
- `func (m ModuleContext) Update(configs map[string][]byte, secrets map[string][]byte, databases map[string]Database) ModuleContext`
- `func (m ModuleContext) UpdateForTesting(mockVerbs map[schema.RefKey]MockVerb, allowDirectVerbBehavior bool) ModuleContext`
- `func (m ModuleContext) UpdateFromEnvironment(ctx context.Context) (ModuleContext, error)`
   - (this one will still be split up and changed in an upcoming PR)

`ftltest` now uses `ftltest.Options` as an opaque way of building up state to then create a ModuleContext with the above functions. Before we were passing around `context.Context` and mutating the ModuleContext directly each anything was changed.

And now everything uses the ModuleContext struct directly, rather than with a pointer.

This change won't have any effect on how users write their module unit tests.