### PR TITLE
fix: custom verb behaviors implement behaviors

### DIFF
--- a/go-runtime/ftl/call.go
+++ b/go-runtime/ftl/call.go
@@ -16,13 +16,12 @@ import (
 )
 
 func call[Req, Resp any](ctx context.Context, callee Ref, req Req, inline Verb[Req, Resp]) (resp Resp, err error) {
-	behavior, err := modulecontext.FromContext(ctx).BehaviorForVerb(schema.Ref{Module: callee.Module, Name: callee.Name})
+	override, err := modulecontext.FromContext(ctx).BehaviorForVerb(schema.Ref{Module: callee.Module, Name: callee.Name})
 	if err != nil {
 		return resp, fmt.Errorf("%s: %w", callee, err)
 	}
-	switch behavior := behavior.(type) {
-	case modulecontext.MockBehavior:
-		uncheckedResp, err := behavior.Mock(ctx, req)
+	if behavior, ok := override.Get(); ok {
+		uncheckedResp, err := behavior.Call(ctx, modulecontext.Verb(widenVerb(inline)), req)
 		if err != nil {
 			return resp, fmt.Errorf("%s: %w", callee, err)
 		}
@@ -30,39 +29,31 @@ func call[Req, Resp any](ctx context.Context, callee Ref, req Req, inline Verb[R
 			return r, nil
 		}
 		return resp, fmt.Errorf("%s: overridden verb had invalid response type %T, expected %v", callee, uncheckedResp, reflect.TypeFor[Resp]())
-	case modulecontext.DirectBehavior:
-		resp, err = inline(ctx, req)
+	}
+
+	reqData, err := encoding.Marshal(req)
+	if err != nil {
+		return resp, fmt.Errorf("%s: failed to marshal request: %w", callee, err)
+	}
+
+	client := rpc.ClientFromContext[ftlv1connect.VerbServiceClient](ctx)
+	cresp, err := client.Call(ctx, connect.NewRequest(&ftlv1.CallRequest{Verb: callee.ToProto(), Body: reqData}))
+	if err != nil {
+		return resp, fmt.Errorf("%s: failed to call Verb: %w", callee, err)
+	}
+	switch cresp := cresp.Msg.Response.(type) {
+	case *ftlv1.CallResponse_Error_:
+		return resp, fmt.Errorf("%s: %s", callee, cresp.Error.Message)
+
+	case *ftlv1.CallResponse_Body:
+		err = encoding.Unmarshal(cresp.Body, &resp)
 		if err != nil {
-			return resp, fmt.Errorf("%s: %w", callee, err)
+			return resp, fmt.Errorf("%s: failed to decode response: %w", callee, err)
 		}
 		return resp, nil
-	case modulecontext.StandardBehavior:
-		reqData, err := encoding.Marshal(req)
-		if err != nil {
-			return resp, fmt.Errorf("%s: failed to marshal request: %w", callee, err)
-		}
 
-		client := rpc.ClientFromContext[ftlv1connect.VerbServiceClient](ctx)
-		cresp, err := client.Call(ctx, connect.NewRequest(&ftlv1.CallRequest{Verb: callee.ToProto(), Body: reqData}))
-		if err != nil {
-			return resp, fmt.Errorf("%s: failed to call Verb: %w", callee, err)
-		}
-		switch cresp := cresp.Msg.Response.(type) {
-		case *ftlv1.CallResponse_Error_:
-			return resp, fmt.Errorf("%s: %s", callee, cresp.Error.Message)
-
-		case *ftlv1.CallResponse_Body:
-			err = encoding.Unmarshal(cresp.Body, &resp)
-			if err != nil {
-				return resp, fmt.Errorf("%s: failed to decode response: %w", callee, err)
-			}
-			return resp, nil
-
-		default:
-			panic(fmt.Sprintf("%s: invalid response type %T", callee, cresp))
-		}
 	default:
-		panic(fmt.Sprintf("unknown behavior: %s", behavior))
+		panic(fmt.Sprintf("%s: invalid response type %T", callee, cresp))
 	}
 }
 
@@ -92,4 +83,14 @@ func CallEmpty(ctx context.Context, empty Empty) error {
 		return Unit{}, empty(ctx)
 	})
 	return err
+}
+
+func widenVerb[Req, Resp any](verb Verb[Req, Resp]) Verb[any, any] {
+	return func(ctx context.Context, uncheckedReq any) (any, error) {
+		req, ok := uncheckedReq.(Req)
+		if !ok {
+			return nil, fmt.Errorf("invalid request type %T for %v, expected %v", uncheckedReq, FuncRef(verb), reflect.TypeFor[Req]())
+		}
+		return verb(ctx, req)
+	}
 }

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -19,7 +19,7 @@ type OptionsState struct {
 	configs                 map[string][]byte
 	secrets                 map[string][]byte
 	databases               map[string]modulecontext.Database
-	mockVerbs               map[schema.RefKey]modulecontext.MockVerb
+	mockVerbs               map[schema.RefKey]modulecontext.Verb
 	allowDirectVerbBehavior bool
 }
 
@@ -39,7 +39,7 @@ func Context(options ...Option) context.Context {
 		configs:   make(map[string][]byte),
 		secrets:   make(map[string][]byte),
 		databases: databases,
-		mockVerbs: make(map[schema.RefKey]modulecontext.MockVerb),
+		mockVerbs: make(map[schema.RefKey]modulecontext.Verb),
 	}
 	for _, option := range options {
 		err := option(ctx, state)


### PR DESCRIPTION
fixes https://github.com/TBD54566975/ftl/issues/1401

Now the logic is:
- `call.go` asks `modulecontext` for any custom behaviour for a verb
- `modulecontext` responds with a `VerbBehavior` if it wants anything custom to happen (mocks, direct calls, specialised unit test errors)
- `call.go` calls `Call(...)` on the `VerbBehavior` if one is returned. Otherwise it calls the controller itself.
    - I think it's best that modulecontext isnt responsible for implementing that behavior, though it does make sense for modulecontext to implement the custom behaviors