### PR TITLE
fix: fix several go-runtime JSON encoding issues

### DIFF
--- a/go-runtime/encoding/encoding_test.go
+++ b/go-runtime/encoding/encoding_test.go
@@ -3,6 +3,7 @@ package encoding_test
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
 
@@ -31,6 +32,8 @@ func TestMarshal(t *testing.T) {
 		{name: "SliceOfStrings", input: struct{ Slice []string }{[]string{"hello", "world"}}, expected: `{"slice":["hello","world"]}`},
 		{name: "Map", input: struct{ Map map[string]int }{map[string]int{"foo": 42}}, expected: `{"map":{"foo":42}}`},
 		{name: "Option", input: struct{ Option ftl.Option[int] }{ftl.Some(42)}, expected: `{"option":42}`},
+		{name: "OptionNull", input: struct{ Option ftl.Option[int] }{ftl.None[int]()}, expected: `{"option":null}`},
+		{name: "OptionZero", input: struct{ Option ftl.Option[int] }{ftl.Some(0)}, expected: `{"option":0}`},
 		{name: "OptionPtr", input: struct{ Option *ftl.Option[int] }{&somePtr}, expected: `{"option":42}`},
 		{name: "OptionStruct", input: struct{ Option ftl.Option[inner] }{ftl.Some(inner{"foo"})}, expected: `{"option":{"fooBar":"foo"}}`},
 		{name: "Unit", input: ftl.Unit{}, expected: `{}`},
@@ -69,6 +72,9 @@ func TestUnmarshal(t *testing.T) {
 		{name: "Slice", input: `{"slice":[1,2,3]}`, expected: struct{ Slice []int }{[]int{1, 2, 3}}},
 		{name: "SliceOfStrings", input: `{"slice":["hello","world"]}`, expected: struct{ Slice []string }{[]string{"hello", "world"}}},
 		{name: "Map", input: `{"map":{"foo":42}}`, expected: struct{ Map map[string]int }{map[string]int{"foo": 42}}},
+		{name: "OptionNull", input: `{"option":null}`, expected: struct{ Option ftl.Option[int] }{ftl.None[int]()}},
+		{name: "OptionNullWhitespace", input: `{"option": null}`, expected: struct{ Option ftl.Option[int] }{ftl.None[int]()}},
+		{name: "OptionZero", input: `{"option":0}`, expected: struct{ Option ftl.Option[int] }{ftl.Some(0)}},
 		{name: "Option", input: `{"option":42}`, expected: struct{ Option ftl.Option[int] }{ftl.Some(42)}},
 		{name: "OptionPtr", input: `{"option":42}`, expected: struct{ Option *ftl.Option[int] }{&somePtr}},
 		{name: "OptionStruct", input: `{"option":{"fooBar":"foo"}}`, expected: struct{ Option ftl.Option[inner] }{ftl.Some(inner{"foo"})}},
@@ -77,6 +83,12 @@ func TestUnmarshal(t *testing.T) {
 			String string
 			Unit   ftl.Unit
 		}{String: "something", Unit: ftl.Unit{}}},
+		// Whitespaces after each `:` and multiple fields to test handling of the
+		// two potential terminal delimiters: `}` and `,`
+		{name: "ComplexFormatting", input: `{"option": null, "bool": true}`, expected: struct {
+			Option ftl.Option[int]
+			Bool   bool
+		}{ftl.None[int](), true}},
 	}
 
 	for _, tt := range tests {
@@ -111,7 +123,9 @@ func TestRoundTrip(t *testing.T) {
 		{name: "Slice", input: struct{ Slice []int }{[]int{1, 2, 3}}},
 		{name: "SliceOfStrings", input: struct{ Slice []string }{[]string{"hello", "world"}}},
 		{name: "Map", input: struct{ Map map[string]int }{map[string]int{"foo": 42}}},
+		{name: "Time", input: struct{ Time time.Time }{time.Unix(123456780, 0)}},
 		{name: "Option", input: struct{ Option ftl.Option[int] }{ftl.Some(42)}},
+		{name: "OptionNull", input: struct{ Option ftl.Option[int] }{ftl.None[int]()}},
 		{name: "OptionPtr", input: struct{ Option *ftl.Option[int] }{&somePtr}},
 		{name: "OptionStruct", input: struct{ Option ftl.Option[inner] }{ftl.Some(inner{"foo"})}},
 		{name: "Unit", input: ftl.Unit{}},

--- a/go-runtime/encoding/encoding_test.go
+++ b/go-runtime/encoding/encoding_test.go
@@ -123,7 +123,7 @@ func TestRoundTrip(t *testing.T) {
 		{name: "Slice", input: struct{ Slice []int }{[]int{1, 2, 3}}},
 		{name: "SliceOfStrings", input: struct{ Slice []string }{[]string{"hello", "world"}}},
 		{name: "Map", input: struct{ Map map[string]int }{map[string]int{"foo": 42}}},
-		{name: "Time", input: struct{ Time time.Time }{time.Unix(123456780, 0)}},
+		{name: "Time", input: struct{ Time time.Time }{time.Date(2009, time.November, 29, 21, 33, 0, 0, time.UTC)}},
 		{name: "Option", input: struct{ Option ftl.Option[int] }{ftl.Some(42)}},
 		{name: "OptionNull", input: struct{ Option ftl.Option[int] }{ftl.None[int]()}},
 		{name: "OptionPtr", input: struct{ Option *ftl.Option[int] }{&somePtr}},

--- a/go-runtime/ftl/option_test.go
+++ b/go-runtime/ftl/option_test.go
@@ -2,7 +2,6 @@ package ftl
 
 import (
 	"database/sql"
-	"encoding/json"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -18,27 +17,6 @@ func TestOptionGet(t *testing.T) {
 	o = None[int]()
 	_, ok = o.Get()
 	assert.False(t, ok)
-}
-
-func TestOptionMarshalJSON(t *testing.T) {
-	o := Some(1)
-	b, err := o.MarshalJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, "1", string(b))
-
-	o = None[int]()
-	b, err = o.MarshalJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, "null", string(b))
-}
-
-func TestOptionUnmarshalJSON(t *testing.T) {
-	o := Option[int]{}
-	err := json.Unmarshal([]byte("1"), &o)
-	assert.NoError(t, err)
-	b, ok := o.Get()
-	assert.True(t, ok)
-	assert.Equal(t, 1, b)
 }
 
 func TestOptionString(t *testing.T) {


### PR DESCRIPTION
This PR:
* Rips out the existing textMarshaler and jsonMarshaler usage from encoding.go. We may want to add those back for https://github.com/TBD54566975/ftl/issues/1296 down the road, but we will need to be thoughtful about how we do that. Removing it for now keeps the logic much more predictable.
* Moves the (un)marshaling logic for `ftl.Option` out of `option.go` and into `encoding.go`.
* Special-cases both `time.Time` (the only stdlib type we currently support) and `ftl.Option`. Also `json.RawMessage` for _just_ encoding to preserve the existing `omitempty` behavior.
* Fixes some existing issues where the Pointer unmarshaling wasn't actually working correctly
* [eww] Adds a rather grotesque alternative to `Peek()` in `isNextTokenNull()` because json Decoder does not support Peek. 
* [eww] Makes the ftl.Option struct fields public so that they are settable by `encoding.go`.

Suggestions welcome for both counts of [eww] above :)

Fixes https://github.com/TBD54566975/ftl/issues/1247.
Addresses most of https://github.com/TBD54566975/ftl/issues/1262, except `omitempty` is only working for json.RawMessage for now. 