### PR TITLE
fix: convert to absolute path immediately incase test changes dirs

### DIFF
--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 
 	"github.com/TBD54566975/ftl/backend/schema"
@@ -63,7 +64,12 @@ func Context(options ...Option) context.Context {
 //
 // )
 func WithProjectFile(path string) Option {
+	// Convert to absolute path immediately in case working directory changes
+	path, err := filepath.Abs(path)
 	return func(ctx context.Context, state *OptionsState) error {
+		if err != nil {
+			return err
+		}
 		if _, err := os.Stat(path); err != nil {
 			return fmt.Errorf("error accessing project file: %w", err)
 		}


### PR DESCRIPTION
Catches an edge case where the working directory changes between when the relative path is passed in and when the inner function is executed