### PR TITLE
feat: internal encoder updates

### DIFF
--- a/go-runtime/encoding/encoding_test.go
+++ b/go-runtime/encoding/encoding_test.go
@@ -3,6 +3,7 @@ package encoding_test
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
 
@@ -14,7 +15,6 @@ func TestMarshal(t *testing.T) {
 	type inner struct {
 		FooBar string
 	}
-	somePtr := ftl.Some(42)
 	tests := []struct {
 		name     string
 		input    any
@@ -26,18 +26,19 @@ func TestMarshal(t *testing.T) {
 		{name: "Int", input: struct{ Int int }{42}, expected: `{"int":42}`},
 		{name: "Float", input: struct{ Float float64 }{42.42}, expected: `{"float":42.42}`},
 		{name: "Bool", input: struct{ Bool bool }{true}, expected: `{"bool":true}`},
-		{name: "Nil", input: struct{ Nil *int }{nil}, expected: `{"nil":null}`},
 		{name: "Slice", input: struct{ Slice []int }{[]int{1, 2, 3}}, expected: `{"slice":[1,2,3]}`},
 		{name: "SliceOfStrings", input: struct{ Slice []string }{[]string{"hello", "world"}}, expected: `{"slice":["hello","world"]}`},
 		{name: "Map", input: struct{ Map map[string]int }{map[string]int{"foo": 42}}, expected: `{"map":{"foo":42}}`},
 		{name: "Option", input: struct{ Option ftl.Option[int] }{ftl.Some(42)}, expected: `{"option":42}`},
-		{name: "OptionPtr", input: struct{ Option *ftl.Option[int] }{&somePtr}, expected: `{"option":42}`},
+		{name: "OptionNull", input: struct{ Option ftl.Option[int] }{ftl.None[int]()}, expected: `{"option":null}`},
+		{name: "OptionZero", input: struct{ Option ftl.Option[int] }{ftl.Some(0)}, expected: `{"option":0}`},
 		{name: "OptionStruct", input: struct{ Option ftl.Option[inner] }{ftl.Some(inner{"foo"})}, expected: `{"option":{"fooBar":"foo"}}`},
 		{name: "Unit", input: ftl.Unit{}, expected: `{}`},
 		{name: "UnitField", input: struct {
 			String string
 			Unit   ftl.Unit
 		}{String: "something", Unit: ftl.Unit{}}, expected: `{"string":"something","unit":{}}`},
+		{name: "Pointer", input: &struct{ String string }{"foo"}, err: `pointer types are not supported: *struct { String string }`},
 	}
 
 	for _, tt := range tests {
@@ -53,7 +54,6 @@ func TestUnmarshal(t *testing.T) {
 	type inner struct {
 		FooBar string
 	}
-	somePtr := ftl.Some(42)
 	tests := []struct {
 		name     string
 		input    string
@@ -65,30 +65,37 @@ func TestUnmarshal(t *testing.T) {
 		{name: "Int", input: `{"int":42}`, expected: struct{ Int int }{42}},
 		{name: "Float", input: `{"float":42.42}`, expected: struct{ Float float64 }{42.42}},
 		{name: "Bool", input: `{"bool":true}`, expected: struct{ Bool bool }{true}},
-		{name: "Nil", input: `{"nil":null}`, expected: struct{ Nil *int }{nil}},
 		{name: "Slice", input: `{"slice":[1,2,3]}`, expected: struct{ Slice []int }{[]int{1, 2, 3}}},
 		{name: "SliceOfStrings", input: `{"slice":["hello","world"]}`, expected: struct{ Slice []string }{[]string{"hello", "world"}}},
 		{name: "Map", input: `{"map":{"foo":42}}`, expected: struct{ Map map[string]int }{map[string]int{"foo": 42}}},
+		{name: "OptionNull", input: `{"option":null}`, expected: struct{ Option ftl.Option[int] }{ftl.None[int]()}},
+		{name: "OptionNullWhitespace", input: `{"option": null}`, expected: struct{ Option ftl.Option[int] }{ftl.None[int]()}},
+		{name: "OptionZero", input: `{"option":0}`, expected: struct{ Option ftl.Option[int] }{ftl.Some(0)}},
 		{name: "Option", input: `{"option":42}`, expected: struct{ Option ftl.Option[int] }{ftl.Some(42)}},
-		{name: "OptionPtr", input: `{"option":42}`, expected: struct{ Option *ftl.Option[int] }{&somePtr}},
 		{name: "OptionStruct", input: `{"option":{"fooBar":"foo"}}`, expected: struct{ Option ftl.Option[inner] }{ftl.Some(inner{"foo"})}},
 		{name: "Unit", input: `{}`, expected: ftl.Unit{}},
 		{name: "UnitField", input: `{"string":"something"}`, expected: struct {
 			String string
 			Unit   ftl.Unit
 		}{String: "something", Unit: ftl.Unit{}}},
+		// Whitespaces after each `:` and multiple fields to test handling of the
+		// two potential terminal delimiters: `}` and `,`
+		{name: "ComplexFormatting", input: `{"option": null, "bool": true}`, expected: struct {
+			Option ftl.Option[int]
+			Bool   bool
+		}{ftl.None[int](), true}},
+		{name: "Pointer", input: `{"string":"foo"}`, expected: &struct{ String string }{}, err: `pointer types are not supported: *struct { String string }`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			eType := reflect.TypeOf(tt.expected)
-			if eType.Kind() == reflect.Ptr {
-				eType = eType.Elem()
-			}
 			o := reflect.New(eType)
 			err := Unmarshal([]byte(tt.input), o.Interface())
 			assert.EqualError(t, err, tt.err)
-			assert.Equal(t, tt.expected, o.Elem().Interface())
+			if err == nil {
+				assert.Equal(t, tt.expected, o.Elem().Interface())
+			}
 		})
 	}
 }
@@ -97,7 +104,6 @@ func TestRoundTrip(t *testing.T) {
 	type inner struct {
 		FooBar string
 	}
-	somePtr := ftl.Some(42)
 	tests := []struct {
 		name  string
 		input any
@@ -107,12 +113,12 @@ func TestRoundTrip(t *testing.T) {
 		{name: "Int", input: struct{ Int int }{42}},
 		{name: "Float", input: struct{ Float float64 }{42.42}},
 		{name: "Bool", input: struct{ Bool bool }{true}},
-		{name: "Nil", input: struct{ Nil *int }{nil}},
 		{name: "Slice", input: struct{ Slice []int }{[]int{1, 2, 3}}},
 		{name: "SliceOfStrings", input: struct{ Slice []string }{[]string{"hello", "world"}}},
 		{name: "Map", input: struct{ Map map[string]int }{map[string]int{"foo": 42}}},
+		{name: "Time", input: struct{ Time time.Time }{time.Date(2009, time.November, 29, 21, 33, 0, 0, time.UTC)}},
 		{name: "Option", input: struct{ Option ftl.Option[int] }{ftl.Some(42)}},
-		{name: "OptionPtr", input: struct{ Option *ftl.Option[int] }{&somePtr}},
+		{name: "OptionNull", input: struct{ Option ftl.Option[int] }{ftl.None[int]()}},
 		{name: "OptionStruct", input: struct{ Option ftl.Option[inner] }{ftl.Some(inner{"foo"})}},
 		{name: "Unit", input: ftl.Unit{}},
 		{name: "UnitField", input: struct {
@@ -130,9 +136,6 @@ func TestRoundTrip(t *testing.T) {
 			assert.NoError(t, err)
 
 			eType := reflect.TypeOf(tt.input)
-			if eType.Kind() == reflect.Ptr {
-				eType = eType.Elem()
-			}
 			o := reflect.New(eType)
 			err = Unmarshal(marshaled, o.Interface())
 			assert.NoError(t, err)

--- a/go-runtime/ftl/option_test.go
+++ b/go-runtime/ftl/option_test.go
@@ -2,7 +2,6 @@ package ftl
 
 import (
 	"database/sql"
-	"encoding/json"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -18,27 +17,6 @@ func TestOptionGet(t *testing.T) {
 	o = None[int]()
 	_, ok = o.Get()
 	assert.False(t, ok)
-}
-
-func TestOptionMarshalJSON(t *testing.T) {
-	o := Some(1)
-	b, err := o.MarshalJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, "1", string(b))
-
-	o = None[int]()
-	b, err = o.MarshalJSON()
-	assert.NoError(t, err)
-	assert.Equal(t, "null", string(b))
-}
-
-func TestOptionUnmarshalJSON(t *testing.T) {
-	o := Option[int]{}
-	err := json.Unmarshal([]byte("1"), &o)
-	assert.NoError(t, err)
-	b, ok := o.Get()
-	assert.True(t, ok)
-	assert.Equal(t, 1, b)
 }
 
 func TestOptionString(t *testing.T) {


### PR DESCRIPTION
un-reverts @deniseli's prior [change](https://github.com/TBD54566975/ftl/pull/1417/files) with some adjustments
- optional fields remain private
- pointers not supported