### PR TITLE
fix: possible solution for ftl.Map with changing values

### DIFF
--- a/examples/go/echo/echo.go
+++ b/examples/go/echo/echo.go
@@ -3,7 +3,9 @@ package echo
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"unsafe"
 
 	"ftl/time"
 
@@ -11,6 +13,13 @@ import (
 )
 
 var defaultName = ftl.Config[string]("default")
+var defaultMap = ftl.Map(defaultName, func(ctx context.Context, configStr string) (string, error) {
+	return configStr + " mapped", nil
+})
+var db = ftl.PostgresDatabase("echo")
+var dbMap = ftl.Map(db, func(ctx context.Context, db *sql.DB) (uintptr, error) {
+	return uintptr(unsafe.Pointer(db)), nil
+})
 
 // An echo request.
 type EchoRequest struct {

--- a/examples/go/echo/echo_test.go
+++ b/examples/go/echo/echo_test.go
@@ -1,0 +1,37 @@
+package echo
+
+import (
+	"testing"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEcho(t *testing.T) {
+	ctx := ftltest.Context(
+		ftltest.WithConfig(defaultName, "hello"),
+	)
+	firstMapValue := defaultMap.Get(ctx)
+
+	ctx = ftltest.Context(
+		ftltest.WithConfig(defaultName, "world"),
+	)
+	secondMapValue := defaultMap.Get(ctx)
+
+	// The mapped value needs to be different when the config value is different
+	assert.Equal(t, "hello mapped", firstMapValue)
+	assert.Equal(t, "world mapped", secondMapValue)
+}
+
+func TestDatabase(t *testing.T) {
+	t.Setenv("FTL_POSTGRES_DSN_ECHO_ECHO", "fake")
+	ctx := ftltest.Context()
+	firstMapValue := dbMap.Get(ctx)
+
+	ctx = ftltest.Context()
+	secondMapValue := dbMap.Get(ctx)
+
+	// Each context's ModuleContext initiated a different sql.DB instance with its own connection pool
+	// Therefore the map should call it's mapping function twice
+	assert.NotEqual(t, firstMapValue, secondMapValue)
+}

--- a/go-runtime/ftl/config.go
+++ b/go-runtime/ftl/config.go
@@ -2,6 +2,7 @@ package ftl
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"runtime"
 	"strings"
@@ -37,6 +38,18 @@ func (c ConfigValue[T]) Get(ctx context.Context) (out T) {
 		panic(fmt.Errorf("failed to get %s: %w", c, err))
 	}
 	return
+}
+
+func (c ConfigValue[T]) Hash(ctx context.Context) []byte {
+	data, err := modulecontext.FromContext(ctx).GetConfigData(c.Name)
+	if err != nil {
+		panic(fmt.Errorf("failed to get %s: %w", c, err))
+	}
+
+	h := sha256.New()
+	h.Write([]byte(data))
+
+	return h.Sum(nil)
 }
 
 func callerModule() string {

--- a/go-runtime/ftl/map.go
+++ b/go-runtime/ftl/map.go
@@ -1,6 +1,7 @@
 package ftl
 
 import (
+	"bytes"
 	"context"
 	"sync"
 )
@@ -8,22 +9,35 @@ import (
 type MapHandle[T, U any] struct {
 	fn     func(context.Context, T) (U, error)
 	getter Handle[T]
+	inHash []byte
 	out    U
 	once   *sync.Once
 }
 
-func (sh *MapHandle[T, U]) Get(ctx context.Context) U {
-	sh.once.Do(func() {
-		t, err := sh.fn(ctx, sh.getter.Get(ctx))
+func (mh *MapHandle[T, U]) Get(ctx context.Context) U {
+	//TODO: this is no longer threadsafe
+	var latestHash []byte
+	if h, ok := mh.getter.(HashableHandle[T]); ok {
+		latestHash = h.Hash(ctx)
+	} else {
+		latestHash = []byte{}
+	}
+
+	if !bytes.Equal(mh.inHash, latestHash) {
+		mh.once = &sync.Once{}
+		mh.inHash = latestHash
+	}
+	mh.once.Do(func() {
+		t, err := mh.fn(ctx, mh.getter.Get(ctx))
 		if err != nil {
 			panic(err)
 		}
-		sh.out = t
+		mh.out = t
 	})
-	return sh.out
+	return mh.out
 }
 
 // Map an FTL resource type to a new type.
 func Map[T, U any](getter Handle[T], fn func(context.Context, T) (U, error)) MapHandle[T, U] {
-	return MapHandle[T, U]{fn: fn, getter: getter, once: &sync.Once{}}
+	return MapHandle[T, U]{fn: fn, getter: getter, once: &sync.Once{}, inHash: []byte{}}
 }

--- a/go-runtime/ftl/types.go
+++ b/go-runtime/ftl/types.go
@@ -13,6 +13,12 @@ type Handle[T any] interface {
 	Get(ctx context.Context) T
 }
 
+// HashableHandle is a Handle that can be hashed to determine when it's value has changed.
+type HashableHandle[T any] interface {
+	Handle[T]
+	Hash(ctx context.Context) []byte
+}
+
 // Unit is a type that has no value.
 //
 // It can be used as a parameter or return value to indicate that a function

--- a/internal/modulecontext/module_context.go
+++ b/internal/modulecontext/module_context.go
@@ -152,6 +152,15 @@ func (m ModuleContext) GetConfig(name string, value any) error {
 	return json.Unmarshal(data, value)
 }
 
+// GetConfigData reads a configuration value for the module and returns the raw bytes.
+func (m ModuleContext) GetConfigData(name string) ([]byte, error) {
+	data, ok := m.configs[name]
+	if !ok {
+		return nil, fmt.Errorf("no config value for %q", name)
+	}
+	return data, nil
+}
+
 // GetSecret reads a secret value for the module.
 //
 // "value" must be a pointer to a Go type that can be unmarshalled from JSON.


### PR DESCRIPTION
fixes https://github.com/TBD54566975/ftl/issues/1390

Currently this PR is half implemented to just get a sense of this is the right direction.

Changes:
- `ftl.HashableHandle` extends `ftl.Handle` with `Hash(ctx context.Context) []byte`
- When Get(ctx) is called on a map handle, it checks if the old hash matches the current hash. If they differ, it gets a new value.
    - If the handle does not support hashing, then it falls back to the original behaviour of only ever mapping once.
- See echo_test.go for examples with config and databases. I haven't implemented for other types just yet

Questions:
- is it only ftl types that we expect to work with `ftl.Map`? If not, it is more work for them to make it work well in tests or if they don't implement `HashableHandle` then they may see off behaviour in tests
- Is `HashableHandle` needed or should we make this part of Handle to make it more obvious that you have to implement `Hash(ctx)` to make it work...

**Other proposed solutions:**
> aat: I think ftl.Map would need to change such that it hashes ModuleContext somehow

I think that would break the once aim of map in this case:
```
ctx := ftl.Context(...)
x = mapHandle.Get(ctx) // map func called correctly

// modify the context somehow in an unrelated way
ctx = context.WithValue(ctx, aKey, aValue)

y = mapHandle.Get(ctx) // map func called but the underlying value hasn't changed
```