### PR TITLE
feat: add ftltest.WithDatabase(…) to get a clean test db

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -84,11 +84,17 @@ func TestNonExportedDecls(t *testing.T) {
 }
 
 func TestDatabase(t *testing.T) {
-	createDB(t, "database", "testdb")
+	createDB(t, "database", "testdb", false)
 	run(t,
+		// deploy real module against "testdb"
 		copyModule("database"),
 		deploy("database"),
 		call("database", "insert", obj{"data": "hello"}, func(response obj) error { return nil }),
+		queryRow("testdb", "SELECT data FROM requests", "hello"),
+
+		// run tests which should only affect "testdb_test"
+		createDBAction("database", "testdb", true),
+		testModule("database"),
 		queryRow("testdb", "SELECT data FROM requests", "hello"),
 	)
 }

--- a/integration/testdata/go/database/database_test.go
+++ b/integration/testdata/go/database/database_test.go
@@ -1,0 +1,50 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestDatabase(t *testing.T) {
+	ctx := ftltest.Context(
+		ftltest.WithDatabase(db),
+	)
+
+	Insert(ctx, InsertRequest{Data: "unit test 1"})
+	list, err := getAll(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, "unit test 1", list[0])
+
+	ctx = ftltest.Context(
+		ftltest.WithDatabase(db),
+	)
+
+	Insert(ctx, InsertRequest{Data: "unit test 2"})
+	list, err = getAll(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(list))
+	assert.Equal(t, "unit test 2", list[0])
+}
+
+func getAll(ctx context.Context) ([]string, error) {
+	rows, err := db.Get(ctx).Query("SELECT data FROM requests ORDER BY created_at;")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	list := []string{}
+	for rows.Next() {
+		var data string
+		err := rows.Scan(&data)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, data)
+	}
+	return list, nil
+}

--- a/integration/testdata/go/database/go.mod
+++ b/integration/testdata/go/database/go.mod
@@ -2,20 +2,28 @@ module ftl/database
 
 go 1.22.2
 
-require github.com/TBD54566975/ftl v0.189.0
+require (
+	github.com/TBD54566975/ftl v0.189.0
+	github.com/alecthomas/assert/v2 v2.9.0
+)
 
 require (
 	connectrpc.com/connect v1.16.1 // indirect
 	connectrpc.com/grpcreflect v1.2.0 // indirect
 	connectrpc.com/otelconnect v0.7.0 // indirect
+	github.com/BurntSushi/toml v1.3.2 // indirect
+	github.com/TBD54566975/scaffolder v0.8.0 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
+	github.com/alecthomas/kong v0.9.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
+	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/alecthomas/types v0.14.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.5.5 // indirect

--- a/integration/testdata/go/database/go.sum
+++ b/integration/testdata/go/database/go.sum
@@ -4,10 +4,16 @@ connectrpc.com/grpcreflect v1.2.0 h1:Q6og1S7HinmtbEuBvARLNwYmTbhEGRpHDhqrPNlmK+U
 connectrpc.com/grpcreflect v1.2.0/go.mod h1:nwSOKmE8nU5u/CidgHtPYk1PFI3U9ignz7iDMxOYkSY=
 connectrpc.com/otelconnect v0.7.0 h1:ZH55ZZtcJOTKWWLy3qmL4Pam4RzRWBJFOqTPyAqCXkY=
 connectrpc.com/otelconnect v0.7.0/go.mod h1:Bt2ivBymHZHqxvo4HkJ0EwHuUzQN6k2l0oH+mp/8nwc=
+github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
+github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/TBD54566975/scaffolder v0.8.0 h1:DWl1K3dWcLsOPAYGQGPQXtffrml6XCB0tF05JdpMqZU=
+github.com/TBD54566975/scaffolder v0.8.0/go.mod h1:Ab/jbQ4q8EloYL0nbkdh2DVvkGc4nxr1OcIbdMpTxxg=
 github.com/alecthomas/assert/v2 v2.9.0 h1:ZcLG8ccMEtlMLkLW4gwGpBWBb0N8MUCmsy1lYBVd1xQ=
 github.com/alecthomas/assert/v2 v2.9.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
+github.com/alecthomas/kong v0.9.0 h1:G5diXxc85KvoV2f0ZRVuMsi45IrBgx9zDNGNj165aPA=
+github.com/alecthomas/kong v0.9.0/go.mod h1:Y47y5gKfHp1hDc7CH7OeXgLIpp+Q2m1Ni0L5s3bI8Os=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=


### PR DESCRIPTION
```
ftltest.Context(
  ftltest.WithDatabase(dbHandle),
)
```
This new option does the following:
- reads the existing DSN but appends `_test` to the table name
- clears out all tables in the db's public schema

Integration test `TestDatabase()` has been updated to have real and test db set up, with a deployment writing to the real db and unit tests running on a test db.