### PR TITLE
chore: expose getter/setter for DSN envars

### DIFF
--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -182,10 +182,9 @@ func WithSecret[T ftl.SecretType](secret ftl.SecretValue[T], value T) Option {
 // )
 func WithDatabase(dbHandle ftl.Database) Option {
 	return func(ctx context.Context, state *OptionsState) error {
-		envarName := fmt.Sprintf("FTL_POSTGRES_DSN_%s_%s", strings.ToUpper(ftl.Module()), strings.ToUpper(dbHandle.Name))
-		originalDSN, ok := os.LookupEnv(envarName)
-		if !ok {
-			return fmt.Errorf("missing DSN for database %s: expected to find it at the environment variable %s", dbHandle.Name, envarName)
+		originalDSN, err := modulecontext.GetDSNFromEnvar(ftl.Module(), dbHandle.Name)
+		if err != nil {
+			return err
 		}
 
 		// convert DSN by appending "_test" to table name

--- a/integration/actions_test.go
+++ b/integration/actions_test.go
@@ -26,6 +26,7 @@ import (
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	ftlexec "github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/modulecontext"
 	"github.com/TBD54566975/scaffolder"
 )
 
@@ -271,7 +272,7 @@ func createDBAction(module, dbName string, isTest bool) action {
 
 func createDB(t testing.TB, module, dbName string, isTestDb bool) {
 	// envars do not include test suffix
-	t.Setenv(fmt.Sprintf("FTL_POSTGRES_DSN_%s_%s", strings.ToUpper(module), strings.ToUpper(dbName)),
+	t.Setenv(modulecontext.DSNEnvarName(module, dbName),
 		fmt.Sprintf("postgres://postgres:secret@localhost:54320/%s?sslmode=disable", dbName))
 
 	// insert test suffix if needed when actually setting up db

--- a/internal/modulecontext/from_environment.go
+++ b/internal/modulecontext/from_environment.go
@@ -41,3 +41,20 @@ func DatabasesFromEnvironment(ctx context.Context, module string) (map[string]Da
 	}
 	return databases, nil
 }
+
+// DSNEnvarName returns the name of the environment variable that is expected to hold the DSN for a database.
+//
+// The format is FTL_POSTGRES_DSN_<MODULE>_<DBNAME>
+func DSNEnvarName(module, name string) string {
+	return fmt.Sprintf("FTL_POSTGRES_DSN_%s_%s", strings.ToUpper(module), strings.ToUpper(name))
+}
+
+// GetDSNFromEnvar returns the DSN for a database from an environment variable.
+func GetDSNFromEnvar(module, name string) (string, error) {
+	envarName := DSNEnvarName(module, name)
+	dsn, ok := os.LookupEnv(envarName)
+	if !ok {
+		return "", fmt.Errorf("missing DSN for database %s: expected to find it at the environment variable %s", name, envarName)
+	}
+	return dsn, nil
+}

--- a/internal/modulecontext/from_environment_test.go
+++ b/internal/modulecontext/from_environment_test.go
@@ -12,8 +12,7 @@ import (
 func TestFromEnvironment(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 
-	t.Setenv("FTL_POSTGRES_DSN_ECHO_ECHO", "postgres://echo:echo@localhost:5432/echo")
-
+	t.Setenv(DSNEnvarName("echo", "echo"), "postgres://echo:echo@localhost:5432/echo")
 	databases, err := DatabasesFromEnvironment(ctx, "echo")
 	assert.NoError(t, err)
 


### PR DESCRIPTION
This centralises the DSN envar name format, and hopefully makes it easier to move away from envars soon.