### PR TITLE
fix: watcher should not remove all modules on error

### DIFF
--- a/buildengine/discover.go
+++ b/buildengine/discover.go
@@ -13,31 +13,25 @@ import (
 // DiscoverProjects recursively loads all modules under the given directories
 // (or if none provided, the current working directory is used) and external
 // libraries in externalLibDirs.
-func DiscoverProjects(ctx context.Context, moduleDirs []string, externalLibDirs []string, stopOnError bool) ([]Project, error) {
+func DiscoverProjects(ctx context.Context, moduleDirs []string, externalLibDirs []string) ([]Project, error) {
 	out := []Project{}
 	logger := log.FromContext(ctx)
 
 	modules, err := discoverModules(moduleDirs...)
 	if err != nil {
 		logger.Tracef("error discovering modules: %v", err)
-		if stopOnError {
-			return nil, err
-		}
-	} else {
-		for _, module := range modules {
-			out = append(out, Project(module))
-		}
+		return nil, err
+	}
+	for _, module := range modules {
+		out = append(out, Project(module))
 	}
 	for _, dir := range externalLibDirs {
 		lib, err := LoadExternalLibrary(dir)
 		if err != nil {
 			logger.Tracef("error discovering external library: %v", err)
-			if stopOnError {
-				return nil, err
-			}
-		} else {
-			out = append(out, Project(lib))
+			return nil, err
 		}
+		out = append(out, Project(lib))
 	}
 	return out, nil
 }

--- a/buildengine/discover_test.go
+++ b/buildengine/discover_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDiscoverModules(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	projects, err := DiscoverProjects(ctx, []string{"testdata/projects"}, []string{"testdata/projects/lib", "testdata/projects/libkotlin"}, true)
+	projects, err := DiscoverProjects(ctx, []string{"testdata/projects"}, []string{"testdata/projects/lib", "testdata/projects/libkotlin"})
 	assert.NoError(t, err)
 	expected := []Project{
 		Module{

--- a/buildengine/engine.go
+++ b/buildengine/engine.go
@@ -102,7 +102,7 @@ func New(ctx context.Context, client ftlv1connect.ControllerServiceClient, modul
 	ctx, cancel := context.WithCancel(ctx)
 	e.cancel = cancel
 
-	projects, err := DiscoverProjects(ctx, moduleDirs, externalDirs, true)
+	projects, err := DiscoverProjects(ctx, moduleDirs, externalDirs)
 	if err != nil {
 		return nil, fmt.Errorf("could not find projects: %w", err)
 	}

--- a/buildengine/watch.go
+++ b/buildengine/watch.go
@@ -89,7 +89,11 @@ func (w *Watcher) Watch(ctx context.Context, period time.Duration, moduleDirs []
 				return
 			}
 
-			projects, _ := DiscoverProjects(ctx, moduleDirs, externalLibDirs, false)
+			projects, err := DiscoverProjects(ctx, moduleDirs, externalLibDirs)
+			if err != nil {
+				logger.Tracef("error discovering projects: %v", err)
+				continue
+			}
 
 			projectsByDir := maps.FromSlice(projects, func(project Project) (string, Project) {
 				return project.Config().Dir, project

--- a/buildengine/watch_test.go
+++ b/buildengine/watch_test.go
@@ -31,7 +31,7 @@ func TestWatch(t *testing.T) {
 
 	waitForEvents(t, events, []WatchEvent{})
 
-	// Initiate a bunch of changes.
+	// Initiate two modules
 	err := ftl("init", "go", dir, "one")
 	assert.NoError(t, err)
 	err = ftl("init", "go", dir, "two")


### PR DESCRIPTION
Steps were sometimes being hit by `TestWatch`:
- `ftl init ...` scaffolds a go.mod file with the ftl version set to `latest`
- `discoverModules` finds the module, looks in the go.mod file for replacements to follow (newish behavior) but errors when it can't parse the file with `latest` (expects `v_._._`)
- watcher ignores this error and believes the new module list (empty)
- watcher sends events saying all known modules have been removed

I added this behavior to ignore the error when discovering modules & external libraries in watcher... But I don't remember why. Looks like a mistake now.

Related to https://github.com/TBD54566975/ftl/issues/1419