### PR TITLE
fix: logging of console web url

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -102,6 +102,7 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 		if err != nil {
 			return err
 		}
+		logger.Infof("Web console available at: %s", config.Bind)
 	}
 
 	// Bring up the DB connection and DAL.

--- a/frontend/local.go
+++ b/frontend/local.go
@@ -31,7 +31,6 @@ func Server(ctx context.Context, timestamp time.Time, publicURL *url.URL, allowO
 	if err != nil {
 		return nil, err
 	}
-	logger.Infof("Web console available at: %s", publicURL.String())
 
 	if allowOrigin == nil {
 		return proxy, nil


### PR DESCRIPTION
Fixes #1453 

```sh
build/release/ftl dev examples/go --recreate
info: Starting FTL with 1 controller(s)
info:controller0: Web console available at: http://localhost:8892/
info: FTL startup command ⚡️
```