### PR TITLE
revert: "fix: replace json.RawMessage with underlying []byte type in ingress response"

### DIFF
--- a/backend/controller/ingress/handler_test.go
+++ b/backend/controller/ingress/handler_test.go
@@ -85,13 +85,17 @@ func TestIngress(t *testing.T) {
 			method:     "GET",
 			path:       "/getAlias",
 			query:      url.Values{"alias": {"value"}},
-			response:   optional.Some(ingress.HTTPResponse{Body: []byte(`{"key":"value"}`)}),
+			response:   optional.Some(ingress.HTTPResponse{Body: []byte(`{}`)}),
 			statusCode: http.StatusOK},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			rec := httptest.NewRecorder()
 			rec.Body = &bytes.Buffer{}
-			response, _ := test.response.Get()
+			var response ingress.HTTPResponse
+			var ok bool
+			if response, ok = test.response.Get(); ok {
+				response = ingress.HTTPResponse{Body: []byte(`{}`)}
+			}
 			req := httptest.NewRequest(test.method, test.path, bytes.NewBuffer(test.payload)).WithContext(ctx)
 			req.URL.RawQuery = test.query.Encode()
 			reqKey := model.NewRequestKey(model.OriginIngress, "test")

--- a/backend/controller/ingress/response.go
+++ b/backend/controller/ingress/response.go
@@ -16,8 +16,8 @@ import (
 type HTTPResponse struct {
 	Status  int                 `json:"status,omitempty"`
 	Headers map[string][]string `json:"headers,omitempty"`
-	Body    []byte              `json:"body,omitempty"`
-	Error   []byte              `json:"error,omitempty"`
+	Body    json.RawMessage     `json:"body,omitempty"`
+	Error   json.RawMessage     `json:"error,omitempty"`
 }
 
 // ResponseForVerb returns the HTTP response for a given verb.

--- a/go-runtime/encoding/encoding.go
+++ b/go-runtime/encoding/encoding.go
@@ -59,6 +59,16 @@ func encodeValue(ctx context.Context, v reflect.Value, w *bytes.Buffer) error {
 	case t.Implements(optionMarshaler):
 		enc := v.Interface().(OptionMarshaler) //nolint:forcetypeassert
 		return enc.Marshal(ctx, w, encodeValue)
+
+	// TODO(Issue #1439): remove this special case by removing all usage of
+	// json.RawMessage, which is not a type we support.
+	case t == reflect.TypeFor[json.RawMessage]():
+		data, err := json.Marshal(v.Interface())
+		if err != nil {
+			return err
+		}
+		w.Write(data)
+		return nil
 	}
 
 	switch v.Kind() {


### PR DESCRIPTION
Reverts TBD54566975/ftl#1454

Tragedy strikes! This is breaking the http ingress integration tests (TestHttpIngress and TestHttpEncodeOmitempty) - all the status codes are getting set to 500. Reverting for now