### PR TITLE
fix: unbreak ci - omitempty integration test

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -113,7 +113,11 @@ func TestHttpEncodeOmitempty(t *testing.T) {
 		copyModule("omitempty"),
 		deploy("omitempty"),
 		httpCall(http.MethodGet, "/get", jsonData(t, obj{}), func(resp *httpResponse) error {
-			assert.Equal(t, "{\"mustset\":\"\"}", repr.String(resp.jsonBody))
+			assert.Equal(t, 200, resp.status)
+			_, ok := resp.jsonBody["mustset"]
+			assert.True(t, ok)
+			_, ok = resp.jsonBody["error"]
+			assert.False(t, ok)
 			return nil
 		}),
 	)

--- a/integration/testdata/go/omitempty/omitempty.go
+++ b/integration/testdata/go/omitempty/omitempty.go
@@ -2,19 +2,23 @@ package omitempty
 
 import (
 	"context"
-	"fmt"
+
+	"ftl/builtin"
 
 	"github.com/TBD54566975/ftl/go-runtime/ftl" // Import the FTL SDK.
 )
 
-type EchoRequest struct{}
+type Request struct{}
 
-type EchoResponse struct {
+type Response struct {
 	Error   string `json:"error,omitempty"` // Should be omitted from marshaled JSON
 	MustSet string `json:"mustset"`         // Should marshal to `"mustset":""`
 }
 
 //ftl:ingress http GET /get
-func Get(ctx context.Context, req builtin.HttpRequest[EchoRequest]) (builtin.HttpResponse[EchoResponse, string], error) {
-	return EchoResponse{}, nil
+func Get(ctx context.Context, req builtin.HttpRequest[Request]) (builtin.HttpResponse[Response, string], error) {
+	return builtin.HttpResponse[Response, string]{
+		Headers: map[string][]string{"Get": {"Header from FTL"}},
+		Body: ftl.Some[Response](Response{}),
+	}, nil
 }


### PR DESCRIPTION
```
$ just integration-tests TestHttpEncodeOmitempty
=== RUN   TestHttpEncodeOmitempty
INFO: Building ftl
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: go build -o build/release/ftl -tags release -ldflags '-X github.com/TBD54566975/ftl.Version=0.207.1-5-ge8fdce90-dirty -X github.com/TBD54566975/ftl.Timestamp=1715296195' ./cmd/ftl
INFO: Starting ftl cluster
INFO: Waiting for controller to be ready
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: Unary RPC failed: unavailable: dial tcp [::1]:8892: connect: connection refused: /xyz.block.ftl.v1.ControllerService/Status
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: Unary RPC failed: unavailable: dial tcp [::1]:8892: connect: connection refused: /xyz.block.ftl.v1.ControllerService/Status
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: Unary RPC failed: unavailable: dial tcp [::1]:8892: connect: connection refused: /xyz.block.ftl.v1.ControllerService/Status
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: info: Starting FTL with 1 controller(s)
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: Unary RPC failed: unavailable: dial tcp [::1]:8892: connect: connection refused: /xyz.block.ftl.v1.ControllerService/Status
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: info:controller0: Web console available at: http://localhost:8892
INFO: Starting test
INFO: Copying omitempty -> omitempty
INFO: Executing: ftl deploy omitempty
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: info:omitempty: Building module
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: info:omitempty: Deploying module
    /Users/dli/Development/ftl/integration/harness_test.go:143: debug: info:controller0: Deployed dpl-omitempty-2g0du8hmloj38qv3
INFO: Waiting for omitempty to become ready
INFO: HTTP GET /get
--- PASS: TestHttpEncodeOmitempty (10.98s)
PASS
ok  	github.com/TBD54566975/ftl/integration	11.216s
testing: warning: no tests to run
PASS
ok  	github.com/TBD54566975/ftl/backend/controller/cronjobs	0.337s [no tests to run]
```