### PR TITLE
fix: verb page redirection when new modules are deployed

### DIFF
--- a/frontend/src/features/verbs/VerbPage.tsx
+++ b/frontend/src/features/verbs/VerbPage.tsx
@@ -28,7 +28,8 @@ export const VerbPage = () => {
     if (!module) {
       const lastIndex = deploymentKey.lastIndexOf('-')
       if (lastIndex !== -1) {
-        module = modules.modules.find((module) => module.name === deploymentKey.substring(0, lastIndex))
+        const moduleName = deploymentKey.substring(0, lastIndex).replaceAll('dpl-', '')
+        module = modules.modules.find((module) => module.name === moduleName)
         navgation(`/deployments/${module?.deploymentKey}/verbs/${verbName}`)
         notification.showNotification({
           title: 'Showing latest deployment',

--- a/frontend/src/features/verbs/VerbRightPanel.tsx
+++ b/frontend/src/features/verbs/VerbRightPanel.tsx
@@ -7,7 +7,6 @@ import { ingress, isHttpIngress, httpRequestPath, verbCalls } from './verb.utils
 export const verbPanels = (verb?: Verb) => {
   const panels = [] as ExpandablePanelProps[]
 
-  console.log(verb?.schema)
   if (isHttpIngress(verb)) {
     const http = ingress(verb)
     const path = httpRequestPath(verb)


### PR DESCRIPTION
Because the deployment key format changed a bit to have the prefix `dpl-` the verb page redirection wasn't working. This PR should correct that issue.