### PR TITLE
fix: use base64 URL encoding for config/secrets

### DIFF
--- a/common/configuration/1password_provider.go
+++ b/common/configuration/1password_provider.go
@@ -31,7 +31,7 @@ func (o OnePasswordProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([
 		return nil, fmt.Errorf("1Password CLI tool \"op\" not found: %w", err)
 	}
 
-	decoded, err := base64.RawStdEncoding.DecodeString(key.Host)
+	decoded, err := base64.RawURLEncoding.DecodeString(key.Host)
 	if err != nil {
 		return nil, fmt.Errorf("1Password secret reference must be a base64 encoded string: %w", err)
 	}
@@ -56,7 +56,7 @@ func (o OnePasswordProvider) Store(ctx context.Context, ref Ref, value []byte) (
 	if !strings.HasPrefix(opref, "op://") {
 		return nil, fmt.Errorf("1Password secret reference must start with \"op://\"")
 	}
-	encoded := base64.RawStdEncoding.EncodeToString([]byte(opref))
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(opref))
 	return &url.URL{Scheme: "op", Host: encoded}, nil
 }
 

--- a/common/configuration/envar_provider.go
+++ b/common/configuration/envar_provider.go
@@ -25,7 +25,7 @@ func (e EnvarProvider[R]) Load(ctx context.Context, ref Ref, key *url.URL) ([]by
 
 	value, ok := os.LookupEnv(envar)
 	if ok {
-		return base64.RawStdEncoding.DecodeString(value)
+		return base64.RawURLEncoding.DecodeString(value)
 	}
 	return nil, fmt.Errorf("environment variable %q is not set: %w", envar, ErrNotFound)
 }
@@ -36,7 +36,7 @@ func (e EnvarProvider[R]) Delete(ctx context.Context, ref Ref) error {
 
 func (e EnvarProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
 	envar := e.key(ref)
-	fmt.Printf("%s=%s\n", envar, base64.RawStdEncoding.EncodeToString(value))
+	fmt.Printf("%s=%s\n", envar, base64.RawURLEncoding.EncodeToString(value))
 	return &url.URL{Scheme: "envar", Host: ref.Name}, nil
 }
 
@@ -45,9 +45,9 @@ func (e EnvarProvider[R]) Writer() bool { return e.Envar }
 func (e EnvarProvider[R]) key(ref Ref) string {
 	key := e.prefix()
 	if m, ok := ref.Module.Get(); ok {
-		key += base64.RawStdEncoding.EncodeToString([]byte(m)) + "_"
+		key += base64.RawURLEncoding.EncodeToString([]byte(m)) + "_"
 	}
-	key += base64.RawStdEncoding.EncodeToString([]byte(ref.Name))
+	key += base64.RawURLEncoding.EncodeToString([]byte(ref.Name))
 	return key
 }
 
@@ -84,13 +84,13 @@ func (EnvarProvider[R]) prefix() string {
 // 	}
 // 	var module optional.Option[string]
 // 	if nameParts[2] != "" {
-// 		decoded, err := base64.RawStdEncoding.DecodeString(nameParts[2])
+// 		decoded, err := base64.RawURLEncoding.DecodeString(nameParts[2])
 // 		if err != nil {
 // 			return Entry{}, fmt.Errorf("invalid encoded module %q: %w", nameParts[2], err)
 // 		}
 // 		module = optional.Some(string(decoded))
 // 	}
-// 	decoded, err := base64.RawStdEncoding.DecodeString(nameParts[3])
+// 	decoded, err := base64.RawURLEncoding.DecodeString(nameParts[3])
 // 	if err != nil {
 // 		return Entry{}, fmt.Errorf("invalid encoded name %q: %w", nameParts[3], err)
 // 	}

--- a/common/configuration/inline_provider.go
+++ b/common/configuration/inline_provider.go
@@ -20,7 +20,7 @@ func (InlineProvider[R]) Key() string { return "inline" }
 func (i InlineProvider[R]) Writer() bool { return i.Inline }
 
 func (InlineProvider[R]) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
-	data, err := base64.RawStdEncoding.DecodeString(key.Host)
+	data, err := base64.RawURLEncoding.DecodeString(key.Host)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base64 data in inline configuration: %w", err)
 	}
@@ -28,7 +28,7 @@ func (InlineProvider[R]) Load(ctx context.Context, ref Ref, key *url.URL) ([]byt
 }
 
 func (InlineProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
-	b64 := base64.RawStdEncoding.EncodeToString(value)
+	b64 := base64.RawURLEncoding.EncodeToString(value)
 	return &url.URL{Scheme: "inline", Host: b64}, nil
 }
 


### PR DESCRIPTION
This solves an issue with outputting invalid URLs that were unable to be round-tripped back into the Go URL structure.