### PR TITLE
fix: refactor and fix deployment redirect

### DIFF
--- a/frontend/src/features/deployments/DeploymentPage.tsx
+++ b/frontend/src/features/deployments/DeploymentPage.tsx
@@ -11,6 +11,7 @@ import { isCron, isExported, isHttpIngress } from '../verbs/verb.utils'
 import { NotificationType, NotificationsContext } from '../../providers/notifications-provider'
 import { SidePanelProvider } from '../../providers/side-panel-provider'
 import { Badge } from '../../components/Badge'
+import { deploymentKeyModuleName } from '../modules/module.utils'
 
 const timeSettings = { isTailing: true, isPaused: false }
 
@@ -32,9 +33,9 @@ export const DeploymentPage = () => {
     if (modules.modules.length > 0 && deploymentKey) {
       let module = modules.modules.find((module) => module.deploymentKey === deploymentKey)
       if (!module) {
-        const lastIndex = deploymentKey.lastIndexOf('-')
-        if (lastIndex !== -1) {
-          module = modules.modules.find((module) => module.name === deploymentKey.substring(0, lastIndex))
+        const moduleName = deploymentKeyModuleName(deploymentKey)
+        if (moduleName) {
+          module = modules.modules.find((module) => module.name === moduleName)
           navgation(`/deployments/${module?.deploymentKey}`)
           notification.showNotification({
             title: 'Showing latest deployment',

--- a/frontend/src/features/modules/module.utils.ts
+++ b/frontend/src/features/modules/module.utils.ts
@@ -47,3 +47,11 @@ export const callsIn = (modules: Module[], module: Module) => {
 }
 
 export const callsOut = (module: Module) => module.verbs?.flatMap((v) => verbCalls(v))
+
+export const deploymentKeyModuleName = (deploymentKey: string) => {
+  const lastIndex = deploymentKey.lastIndexOf('-')
+  if (lastIndex !== -1) {
+    return deploymentKey.substring(0, lastIndex).replaceAll('dpl-', '')
+  }
+  return null
+}

--- a/frontend/src/features/verbs/VerbPage.tsx
+++ b/frontend/src/features/verbs/VerbPage.tsx
@@ -11,6 +11,7 @@ import { ResizablePanels } from '../../components/ResizablePanels'
 import { CallList } from '../calls/CallList'
 import { VerbRequestForm } from './VerbRequestForm'
 import { verbPanels } from './VerbRightPanel'
+import { deploymentKeyModuleName } from '../modules/module.utils'
 
 export const VerbPage = () => {
   const { deploymentKey, verbName } = useParams()
@@ -26,9 +27,8 @@ export const VerbPage = () => {
 
     let module = modules.modules.find((module) => module.deploymentKey === deploymentKey)
     if (!module) {
-      const lastIndex = deploymentKey.lastIndexOf('-')
-      if (lastIndex !== -1) {
-        const moduleName = deploymentKey.substring(0, lastIndex).replaceAll('dpl-', '')
+      const moduleName = deploymentKeyModuleName(deploymentKey)
+      if (moduleName) {
         module = modules.modules.find((module) => module.name === moduleName)
         navgation(`/deployments/${module?.deploymentKey}/verbs/${verbName}`)
         notification.showNotification({


### PR DESCRIPTION
Previously, only the verb page was redirecting correctly. This fixes the deployment page as well and centralizes the parsing logic.
![Screenshot 2024-05-14 at 7 42 20 AM](https://github.com/TBD54566975/ftl/assets/51647/b403c9f9-1407-4171-bc1d-8542c3941f16)
