### PR TITLE
chore: revert error on missing config as it breaks the integration tests

### DIFF
--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"os"
 	"os/signal"
@@ -80,7 +81,7 @@ func main() {
 	ctx = log.ContextWithLogger(ctx, logger)
 
 	config, err := projectconfig.LoadConfig(ctx, cli.ConfigFlag)
-	if err != nil {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		kctx.Fatalf(err.Error())
 	}
 	kctx.Bind(config)

--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -2,6 +2,7 @@ package projectconfig
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -84,6 +85,9 @@ func loadFile(path string) (Config, error) {
 	config := Config{}
 	md, err := toml.DecodeFile(path, &config)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Config{}, nil
+		}
 		return Config{}, err
 	}
 	if len(md.Undecoded()) > 0 {

--- a/common/projectconfig/projectconfig_test.go
+++ b/common/projectconfig/projectconfig_test.go
@@ -38,29 +38,6 @@ func TestProjectConfig(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestProjectLoadConfig(t *testing.T) {
-	tests := []struct {
-		name  string
-		paths []string
-		err   string
-	}{
-		{name: "AllValid", paths: []string{"testdata/ftl-project.toml"}},
-		{name: "IsNonExistent", paths: []string{"testdata/ftl-project-nonexistent.toml"}, err: "no such file or directory"},
-		{name: "ContainsNonExistent", paths: []string{"testdata/ftl-project.toml", "testdata/ftl-project-nonexistent.toml"}, err: "no such file or directory"},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			_, err := LoadConfig(log.ContextWithNewDefaultLogger(context.Background()), test.paths)
-			if test.err != "" {
-				assert.Contains(t, err.Error(), test.err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestProjectConfigChecksMinVersion(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
See https://github.com/TBD54566975/ftl/actions/runs/9102976431/job/25023813425

I'm going to pull the integration tests into PR CI, unfortunately it's really opaque when it only runs on main.

Revert "fix: error out if specified config doesn't exist, fixes #1347 (#1485)"

This reverts commit 57659f3e160a30439809fd15597a73052a70380f.