### PR TITLE
fix: error out if cli config doesn't exist, fixes #1347

### DIFF
--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"os"
 	"os/signal"
@@ -81,7 +80,7 @@ func main() {
 	ctx = log.ContextWithLogger(ctx, logger)
 
 	config, err := projectconfig.LoadConfig(ctx, cli.ConfigFlag)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err != nil {
 		kctx.Fatalf(err.Error())
 	}
 	kctx.Bind(config)

--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -2,7 +2,6 @@ package projectconfig
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -85,9 +84,6 @@ func loadFile(path string) (Config, error) {
 	config := Config{}
 	md, err := toml.DecodeFile(path, &config)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return Config{}, nil
-		}
 		return Config{}, err
 	}
 	if len(md.Undecoded()) > 0 {

--- a/common/projectconfig/projectconfig_test.go
+++ b/common/projectconfig/projectconfig_test.go
@@ -38,6 +38,29 @@ func TestProjectConfig(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestProjectLoadConfig(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		err   string
+	}{
+		{name: "AllValid", paths: []string{"testdata/ftl-project.toml"}},
+		{name: "IsNonExistent", paths: []string{"testdata/ftl-project-nonexistent.toml"}, err: "no such file or directory"},
+		{name: "ContainsNonExistent", paths: []string{"testdata/ftl-project.toml", "testdata/ftl-project-nonexistent.toml"}, err: "no such file or directory"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := LoadConfig(log.ContextWithNewDefaultLogger(context.Background()), test.paths)
+			if test.err != "" {
+				assert.Contains(t, err.Error(), test.err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestProjectConfigChecksMinVersion(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
This reverts commit 4a2902d
Integration tests now run successfully after #1514 