### PR TITLE
fix: fix crash extracting struct with type parameter

### DIFF
--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -1109,7 +1109,11 @@ func visitStruct(pctx *parseContext, pos token.Pos, tnode types.Type, isExported
 			Pos:  goPosToSchemaPos(pos),
 			Name: param.Obj().Name(),
 		})
-		if typeArg, ok := visitType(pctx, pos, named.TypeArgs().At(i), isExported).Get(); ok {
+		typeArgs := named.TypeArgs()
+		if typeArgs == nil {
+			continue
+		}
+		if typeArg, ok := visitType(pctx, pos, typeArgs.At(i), isExported).Get(); ok {
 			dataRef.TypeParameters = append(dataRef.TypeParameters, typeArg)
 		}
 	}

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -96,6 +96,10 @@ func TestExtractModuleSchema(t *testing.T) {
     field String
   }
 
+  data DataWithType<T> {
+    value T
+  }
+  
   export data ExportedData {
     field String
   }

--- a/go-runtime/compile/testdata/one/one.go
+++ b/go-runtime/compile/testdata/one/one.go
@@ -145,3 +145,8 @@ func Nothing(ctx context.Context) error {
 func Http(ctx context.Context, req builtin.HttpRequest[Req]) (builtin.HttpResponse[Resp, ftl.Unit], error) {
 	return builtin.HttpResponse[Resp, ftl.Unit]{}, nil
 }
+
+//ftl:data
+type DataWithType[T any] struct {
+	Value T
+}


### PR DESCRIPTION
FTL panics when compiling code like this:
```
//ftl:data
type DataWithType[T any] struct {
	Value T
}
```

`VisitStruct` was iterating through type parameters and type parameter values, but there are no values in this case.
