### PR TITLE
refactor: add user-accessible transactions to the DAL

### DIFF
--- a/backend/controller/dal/lease.go
+++ b/backend/controller/dal/lease.go
@@ -21,7 +21,7 @@ var _ leases.Leaser = (*DAL)(nil)
 type Lease struct {
 	key            leases.Key
 	idempotencyKey uuid.UUID
-	db             *sql.DB
+	db             sql.DBI
 	ttl            time.Duration
 	errch          chan error
 	release        chan bool

--- a/backend/controller/dal/lease_test.go
+++ b/backend/controller/dal/lease_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/TBD54566975/ftl/internal/log"
 )
 
-func leaseExists(t *testing.T, conn sql.DBI, idempotencyKey uuid.UUID, key leases.Key) bool {
+func leaseExists(t *testing.T, conn sql.ConnI, idempotencyKey uuid.UUID, key leases.Key) bool {
 	t.Helper()
 	var count int
 	err := translatePGError(conn.

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+	"fmt"
 
 	"github.com/TBD54566975/ftl/backend/controller/leases"
 	"github.com/TBD54566975/ftl/backend/schema"
@@ -55,6 +56,7 @@ type AcquireAsyncCallRow struct {
 // Reserve a pending async call for execution, returning the associated lease
 // reservation key.
 func (q *Queries) AcquireAsyncCall(ctx context.Context, ttl time.Duration) (AcquireAsyncCallRow, error) {
+	fmt.Printf("%#v\n", q.db)
 	row := q.db.QueryRow(ctx, acquireAsyncCall, ttl)
 	var i AcquireAsyncCallRow
 	err := row.Scan(


### PR DESCRIPTION
Up until now all transactions were hidden behind DAL methods, but in order to cleanly separate the core of async calls from the type-specific post-execution callbacks, we'll need to pass an open DAL transaction to the callback.

eg. when an FSM transition async call completes there will be a callback that will update the executing FSM instance with the destination state.