### PR TITLE
fix: ftltest config: use ConfigPaths with envar fallback

### DIFF
--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -60,7 +60,8 @@ func Context(options ...Option) context.Context {
 // WithProjectFiles loads config and secrets from a project file
 //
 // Takes a list of paths to project files. If multiple paths are provided, they are loaded in order, with later files taking precedence.
-// If no paths are provided, the list is inferred from the FTL_CONFIG environment variable. If that is not found, an error is returned.
+// If no paths are provided, the list is inferred from the FTL_CONFIG environment variable. If that is not found, the ftl-project.toml
+// file in the git root is used. If ftl-project.toml is not found, no project files are loaded.
 //
 // To be used when setting up a context for a test:
 // ctx := ftltest.Context(

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/TBD54566975/ftl/backend/schema"
 	cf "github.com/TBD54566975/ftl/common/configuration"
+	pc "github.com/TBD54566975/ftl/common/projectconfig"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -73,10 +74,11 @@ func WithProjectFiles(paths ...string) Option {
 	var preprocessingErr error
 	if len(paths) == 0 {
 		envValue, ok := os.LookupEnv("FTL_CONFIG")
-		if !ok {
-			preprocessingErr = fmt.Errorf("loading project files: no path provided and FTL_CONFIG environment variable not set")
+		if ok {
+			paths = strings.Split(envValue, ",")
+		} else {
+			paths = pc.ConfigPaths(paths)
 		}
-		paths = strings.Split(envValue, ",")
 	}
 	paths = slices.Map(paths, func(p string) string {
 		path, err := filepath.Abs(p)

--- a/integration/testdata/go/wrapped/ftl-project.toml
+++ b/integration/testdata/go/wrapped/ftl-project.toml
@@ -1,0 +1,12 @@
+ftl-min-version = ""
+
+[global]
+  [global.configuration]
+    config = "inline://ImJhemJheiI"
+  [global.secrets]
+    secret = "inline://ImJhemJheiI"
+
+[executables]
+  ftl = ""
+
+[commands]

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["eslint"],
+      "matchPackageNames": ["eslint", "codemirror"],
       "enabled": false,
       "paths": ["frontend/**", "extensions/**"]
     },


### PR DESCRIPTION
Fixes #1502.

Adds tests to ensure we're correctly falling back to the config in `FTL_CONFIG` and to `ftl-project.toml` in the gitroot.