### PR TITLE
chore: pin codemirror npm module

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["eslint"],
+      "matchPackageNames": ["eslint", "codemirror"],
       "enabled": false,
       "paths": ["frontend/**", "extensions/**"]
     },


### PR DESCRIPTION
Follow up to https://github.com/TBD54566975/ftl/pull/1539

We use `react-codemirror2`, which requires `codemirror` major version `5.*`, even on their [master branch](https://github.com/scniro/react-codemirror2/blob/master/package.json). Since we have no reason to stop using `react-codemirror2`, we just need to stop codemirror from continuing to get updated automatically by renovate.

After this PR merges (assuming reviewers think this looks right!), I'll close https://github.com/TBD54566975/ftl/pull/1539.