### PR TITLE
fix: Fix Header Duplication

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -793,7 +793,8 @@ func (s *Service) callWithRequest(
 	ctx = rpc.WithVerbs(ctx, append(callers, verbRef))
 	headers.AddCaller(req.Header(), schema.RefFromProto(req.Msg.Verb))
 
-	resp, err := client.verb.Call(ctx, req)
+	response, err := client.verb.Call(ctx, req)
+	resp := connect.NewResponse(response.Msg)
 	var maybeResponse optional.Option[*ftlv1.CallResponse]
 	if resp != nil {
 		maybeResponse = optional.Some(resp.Msg)

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -196,7 +196,8 @@ func (s *Service) Call(ctx context.Context, req *connect.Request[ftlv1.CallReque
 	if !ok {
 		return nil, connect.NewError(connect.CodeUnavailable, errors.New("no deployment"))
 	}
-	return deployment.plugin.Client.Call(ctx, req)
+	response, err := deployment.plugin.Client.Call(ctx, req)
+	return connect.NewResponse(response.Msg), err
 }
 
 func (s *Service) Reserve(ctx context.Context, c *connect.Request[ftlv1.ReserveRequest]) (*connect.Response[ftlv1.ReserveResponse], error) {


### PR DESCRIPTION
When using connectrpc to perform calls, duplicate headers are introduced if the response object is returned directly by the runner or the controller. This causes bugs when FTL is deployed to an environment that does not work when there are duplicate headers, such as an environment where envoy is used to facilitate traffic.

The fix for this is to instantiate a new response object to return from the Call functions.

For more information on the envoy bug, see the issue linked below. 
https://github.com/envoyproxy/envoy/issues/9019

The fix for this took place after reaching out to the Buf team on slack https://bufbuild.slack.com/archives/CRZ680FUH/p1716344335783839