### PR TITLE
feat: add support for FSMs to ftltest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ examples/**/go.work.sum
 testdata/**/go.work
 testdata/**/go.work.sum
 **/_ftl
+!go-runtime/compile/external-module-template/_ftl
 buildengine/.gitignore
 go.work*
 junit*.xml

--- a/buildengine/build_go_test.go
+++ b/buildengine/build_go_test.go
@@ -166,7 +166,7 @@ func Nothing(context.Context) error {
 
 func init() {
   reflection.Register(
-    reflection.WithSumType[TypeEnum](
+    reflection.SumType[TypeEnum](
       *new(A),
       *new(B),
     ),

--- a/buildengine/testdata/type_registry_main.go
+++ b/buildengine/testdata/type_registry_main.go
@@ -15,19 +15,19 @@ import (
 
 func init() {
 	reflection.Register(
-		reflection.WithSumType[another.SecondTypeEnum](
+		reflection.SumType[another.SecondTypeEnum](
 			*new(another.One),
 			*new(another.Two),
 		),
-		reflection.WithSumType[another.TypeEnum](
+		reflection.SumType[another.TypeEnum](
 			*new(another.A),
 			*new(another.B),
 		),
-		reflection.WithSumType[other.SecondTypeEnum](
+		reflection.SumType[other.SecondTypeEnum](
 			*new(other.A),
 			*new(other.B),
 		),
-		reflection.WithSumType[other.TypeEnum](
+		reflection.SumType[other.TypeEnum](
 			*new(other.MyBool),
 			*new(other.MyBytes),
 			*new(other.MyFloat),

--- a/go-runtime/compile/build-template/_ftl.tmpl/go/main/main.go
+++ b/go-runtime/compile/build-template/_ftl.tmpl/go/main/main.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	reflection.Register(
 {{- range .SumTypes}}
-		reflection.WithSumType[{{.Discriminator}}](
+		reflection.SumType[{{.Discriminator}}](
 			{{- range .Variants}}
 			*new({{.Type}}),
 			{{- end}}

--- a/go-runtime/compile/external-module-template/_ftl/go/modules/{{ range .NonMainModules }}{{ push .Name . }}{{ end }}/external_module.go
+++ b/go-runtime/compile/external-module-template/_ftl/go/modules/{{ range .NonMainModules }}{{ push .Name . }}{{ end }}/external_module.go
@@ -82,7 +82,7 @@ func {{.Name|title}}(context.Context, {{type $ .Request}}) ({{type $ .Response}}
 func init() {
   reflection.Register(
 {{- range $sumTypes}}
-    reflection.WithSumType[{{.Name|title}}](
+    reflection.SumType[{{.Name|title}}](
 {{- range .Variants}}
       *new({{.Name|title}}),
 {{- end}}

--- a/go-runtime/encoding/encoding_test.go
+++ b/go-runtime/encoding/encoding_test.go
@@ -83,7 +83,7 @@ func TestMarshal(t *testing.T) {
 	reflection.AllowAnyPackageForTesting = true
 	defer func() { reflection.AllowAnyPackageForTesting = false }()
 	reflection.ResetTypeRegistry()
-	reflection.Register(reflection.WithSumType[discriminator](variant{}))
+	reflection.Register(reflection.SumType[discriminator](variant{}))
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -139,7 +139,7 @@ func TestUnmarshal(t *testing.T) {
 	reflection.AllowAnyPackageForTesting = true
 	defer func() { reflection.AllowAnyPackageForTesting = false }()
 	reflection.ResetTypeRegistry()
-	reflection.Register(reflection.WithSumType[discriminator](variant{}))
+	reflection.Register(reflection.SumType[discriminator](variant{}))
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestRoundTrip(t *testing.T) {
 	reflection.AllowAnyPackageForTesting = true
 	defer func() { reflection.AllowAnyPackageForTesting = false }()
 	reflection.ResetTypeRegistry()
-	reflection.Register(reflection.WithSumType[discriminator](variant{}))
+	reflection.Register(reflection.SumType[discriminator](variant{}))
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go-runtime/ftl/fsm.go
+++ b/go-runtime/ftl/fsm.go
@@ -2,45 +2,51 @@ package ftl
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
-	"connectrpc.com/connect"
-
-	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
-	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
-	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
-	"github.com/TBD54566975/ftl/backend/schema"
-	"github.com/TBD54566975/ftl/go-runtime/encoding"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
-	"github.com/TBD54566975/ftl/internal/rpc"
+	"github.com/TBD54566975/ftl/go-runtime/internal"
 )
 
 type FSMHandle struct {
-	name        string
-	transitions []FSMTransition
+	name string
 }
 
 type FSMTransition struct {
-	from reflection.Ref
-	to   reflection.Ref
+	fromFunc reflect.Value
+	from     reflection.Ref
+	toFunc   reflect.Value
+	to       reflection.Ref
 }
 
 // Start specifies a start state in an FSM.
 func Start[In any](state Sink[In]) FSMTransition {
-	return FSMTransition{to: reflection.FuncRef(state)}
+	return FSMTransition{
+		toFunc: reflect.ValueOf(state),
+		to:     reflection.FuncRef(state),
+	}
 }
 
 // Transition specifies a transition in an FSM.
 //
 // The "event" triggering the transition is the input to the "from" state.
 func Transition[FromIn, ToIn any](from Sink[FromIn], to Sink[ToIn]) FSMTransition {
-	return FSMTransition{from: reflection.FuncRef(from), to: reflection.FuncRef(to)}
+	return FSMTransition{
+		fromFunc: reflect.ValueOf(from),
+		from:     reflection.FuncRef(from),
+		toFunc:   reflect.ValueOf(to),
+		to:       reflection.FuncRef(to),
+	}
 }
 
 // FSM creates a new finite-state machine.
 func FSM(name string, transitions ...FSMTransition) *FSMHandle {
-	return &FSMHandle{name: name, transitions: transitions}
+	rtransitions := make([]reflection.Transition, len(transitions))
+	for i, transition := range transitions {
+		rtransitions[i] = reflection.Transition{From: transition.fromFunc, To: transition.toFunc}
+	}
+	reflection.Register(reflection.FSM(name, rtransitions...))
+	return &FSMHandle{name: name}
 }
 
 // Send an event to an instance of the FSM.
@@ -51,19 +57,5 @@ func FSM(name string, transitions ...FSMTransition) *FSMHandle {
 // If the FSM instance is not executing, a new one will be started. If the event
 // is not valid for the current state, an error will be returned.
 func (f *FSMHandle) Send(ctx context.Context, instance string, event any) error {
-	client := rpc.ClientFromContext[ftlv1connect.VerbServiceClient](ctx)
-	body, err := encoding.Marshal(event)
-	if err != nil {
-		return fmt.Errorf("failed to marshal event: %w", err)
-	}
-	_, err = client.SendFSMEvent(ctx, connect.NewRequest(&ftlv1.SendFSMEventRequest{
-		Fsm:      &schemapb.Ref{Module: reflection.Module(), Name: f.name},
-		Instance: instance,
-		Event:    schema.TypeToProto(reflection.ReflectTypeToSchemaType(reflect.TypeOf(event))),
-		Body:     body,
-	}))
-	if err != nil {
-		return fmt.Errorf("failed to send event: %w", err)
-	}
-	return nil
+	return internal.FromContext(ctx).FSMSend(ctx, f.name, instance, event)
 }

--- a/go-runtime/ftl/ftltest/fake.go
+++ b/go-runtime/ftl/ftltest/fake.go
@@ -1,0 +1,23 @@
+package ftltest
+
+import (
+	"context"
+
+	"github.com/TBD54566975/ftl/go-runtime/internal"
+)
+
+type fakeFTL struct {
+	fsm *fakeFSMManager
+}
+
+func newFakeFTL() *fakeFTL {
+	return &fakeFTL{
+		fsm: newFakeFSMManager(),
+	}
+}
+
+var _ internal.FTL = &fakeFTL{}
+
+func (f *fakeFTL) FSMSend(ctx context.Context, fsm string, instance string, event any) error {
+	return f.fsm.SendEvent(ctx, fsm, instance, event)
+}

--- a/go-runtime/ftl/ftltest/fsm.go
+++ b/go-runtime/ftl/ftltest/fsm.go
@@ -1,0 +1,87 @@
+package ftltest
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+)
+
+type fakeFSMInstance struct {
+	name       string
+	terminated bool
+	state      reflect.Value
+}
+
+func newFakeFSMManager() *fakeFSMManager {
+	return &fakeFSMManager{
+		instances: make(map[fsmInstanceKey]*fakeFSMInstance),
+	}
+}
+
+type fsmInstanceKey struct {
+	fsm      string
+	instance string
+}
+
+type fakeFSMManager struct {
+	instances map[fsmInstanceKey]*fakeFSMInstance
+}
+
+func (f *fakeFSMManager) SendEvent(ctx context.Context, fsm string, instance string, event any) error {
+	// Retrieve the FSM transitions.
+	rfsm, ok := reflection.GetFSM(fsm).Get()
+	if !ok {
+		return fmt.Errorf("fsm %q not found", fsm)
+	}
+	schema := rfsm.Schema
+
+	/// Upsert the FSM instance.
+	key := fsmInstanceKey{fsm, instance}
+	fsmInstance, ok := f.instances[key]
+	if !ok {
+		fsmInstance = &fakeFSMInstance{name: fsm}
+		f.instances[key] = fsmInstance
+	}
+
+	if fsmInstance.terminated {
+		return fmt.Errorf("fsm %q instance %q is terminated", fsm, instance)
+	}
+
+	// The function to execute.
+	var transition reflection.Transition
+
+	// Find the transition that matches the current state and the event type.
+	for _, t := range rfsm.Transitions {
+		if fsmInstance.state == t.From && reflect.TypeOf(event).AssignableTo(t.To.Type().In(1)) {
+			transition = t
+			break
+		}
+	}
+
+	// Didn't find a transition.
+	if !transition.To.IsValid() {
+		return fmt.Errorf("no transition found for event %T", event)
+	}
+
+	out := transition.To.Call([]reflect.Value{reflect.ValueOf(ctx), reflect.ValueOf(event)})
+	var err error
+	erri := out[0]
+	if erri.IsNil() {
+		fsmInstance.state = transition.To
+	} else {
+		err = erri.Interface().(error) //nolint:forcetypeassert
+		fsmInstance.state = reflect.Value{}
+	}
+	currentStateRef := reflection.FuncRef(fsmInstance.state.Interface()).ToSchema()
+
+	// Flag the FSM instance as terminated if the current state is a terminal state.
+	for _, end := range schema.TerminalStates() {
+		if currentStateRef.Equal(end) {
+			fsmInstance.terminated = true
+			break
+		}
+	}
+	return err
+}

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -19,6 +19,7 @@ import (
 	pc "github.com/TBD54566975/ftl/common/projectconfig"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+	"github.com/TBD54566975/ftl/go-runtime/internal"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/modulecontext"
 	"github.com/TBD54566975/ftl/internal/slices"
@@ -37,6 +38,7 @@ type Option func(context.Context, *OptionsState) error
 // Context suitable for use in testing FTL verbs with provided options
 func Context(options ...Option) context.Context {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	ctx = internal.WithContext(ctx, newFakeFTL())
 	name := reflection.Module()
 
 	state := &OptionsState{

--- a/go-runtime/ftl/reflection/reflection.go
+++ b/go-runtime/ftl/reflection/reflection.go
@@ -145,6 +145,9 @@ func moduleForType(t reflect.Type) string {
 	return parts[len(parts)-1]
 }
 
+// refForType returns the schema.Ref for a Go type.
+//
+// This is not type checked in any way, so only valid types should be passed.
 func refForType(t reflect.Type) *schema.Ref {
 	module := moduleForType(t)
 	return &schema.Ref{Module: module, Name: strcase.ToUpperCamel(t.Name())}

--- a/go-runtime/ftl/reflection/reflection_test.go
+++ b/go-runtime/ftl/reflection/reflection_test.go
@@ -41,7 +41,7 @@ func TestReflectTypeFromValue(t *testing.T) {
 	AllowAnyPackageForTesting = true
 	t.Cleanup(func() { AllowAnyPackageForTesting = false })
 
-	Register(WithSumType[MySumType](Variant1{}, Variant2{}))
+	Register(SumType[MySumType](Variant1{}, Variant2{}))
 
 	v := AllTypesToReflect{SumType: Variant1{}}
 

--- a/go-runtime/ftl/reflection/singleton.go
+++ b/go-runtime/ftl/reflection/singleton.go
@@ -1,0 +1,50 @@
+package reflection
+
+import (
+	"reflect"
+
+	"github.com/alecthomas/types/optional"
+)
+
+// singletonTypeRegistry is the global type registry that all public functions in this
+// package interface with. It is not truly threadsafe. However, everything is initialized
+// in init() calls, which are safe, and the type registry is never mutated afterwards.
+var singletonTypeRegistry = newTypeRegistry()
+
+// ResetTypeRegistry clears the contents of the singleton type registry for tests to
+// guarantee determinism.
+func ResetTypeRegistry() {
+	singletonTypeRegistry = newTypeRegistry()
+}
+
+// Register applies all the provided options to the singleton TypeRegistry
+func Register(options ...Registree) {
+	for _, o := range options {
+		o(singletonTypeRegistry)
+	}
+}
+
+// GetFSM returns the FSM with the given name, if any.
+func GetFSM(name string) optional.Option[ReflectedFSM] {
+	return singletonTypeRegistry.getFSM(name)
+}
+
+// GetVariantByType returns the variant name for the given discriminator and variant type.
+func GetVariantByType(discriminator reflect.Type, variantType reflect.Type) optional.Option[string] {
+	return singletonTypeRegistry.getVariantByType(discriminator, variantType)
+}
+
+// GetVariantByName returns the variant type for the given discriminator and variant name.
+func GetVariantByName(discriminator reflect.Type, name string) optional.Option[reflect.Type] {
+	return singletonTypeRegistry.getVariantByName(discriminator, name)
+}
+
+// GetDiscriminatorByVariant returns the discriminator type for the given variant type.
+func GetDiscriminatorByVariant(variant reflect.Type) optional.Option[reflect.Type] {
+	return singletonTypeRegistry.getDiscriminatorByVariant(variant)
+}
+
+// IsSumTypeDiscriminator returns true if the given type is a sum type discriminator.
+func IsSumTypeDiscriminator(discriminator reflect.Type) bool {
+	return singletonTypeRegistry.isSumTypeDiscriminator(discriminator)
+}

--- a/go-runtime/ftl/reflection/type_registry_test.go
+++ b/go-runtime/ftl/reflection/type_registry_test.go
@@ -11,7 +11,7 @@ func TestTypeRegistry(t *testing.T) {
 	AllowAnyPackageForTesting = true
 	defer func() { AllowAnyPackageForTesting = false }()
 	ResetTypeRegistry()
-	Register(WithSumType[MySumType](Variant1{}, Variant2{}))
+	Register(SumType[MySumType](Variant1{}, Variant2{}))
 
 	svariant, ok := GetVariantByType(reflect.TypeFor[MySumType](), reflect.TypeFor[Variant1]()).Get()
 	assert.True(t, ok)

--- a/go-runtime/ftl/reflection/types.go
+++ b/go-runtime/ftl/reflection/types.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
+	"github.com/TBD54566975/ftl/backend/schema"
 )
 
 // Ref is an untyped reference to a symbol.
@@ -31,9 +32,8 @@ func (v *Ref) UnmarshalText(text []byte) error {
 	return nil
 }
 
-func (v Ref) String() string { return v.Module + "." + v.Name }
-func (v Ref) ToProto() *schemapb.Ref {
-	return &schemapb.Ref{Module: v.Module, Name: v.Name}
-}
+func (v Ref) String() string         { return v.Module + "." + v.Name }
+func (v Ref) ToProto() *schemapb.Ref { return &schemapb.Ref{Module: v.Module, Name: v.Name} }
+func (v Ref) ToSchema() *schema.Ref  { return &schema.Ref{Module: v.Module, Name: v.Name} }
 
 func RefFromProto(p *schemapb.Ref) Ref { return Ref{Module: p.Module, Name: p.Name} }

--- a/go-runtime/internal/api.go
+++ b/go-runtime/internal/api.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"context"
+)
+
+// FTL is the interface that the FTL runtime provides to user code.
+//
+// In production, the FTL runtime will provide an implementation of this
+// interface that communicates with the Controller over gRPC.
+//
+// In testing code, the implementation will inject fakes and other test
+// implementations.
+type FTL interface {
+	// FSMSend sends an event to an instance of an FSM.
+	FSMSend(ctx context.Context, fsm, instance string, data any) error
+}
+
+type ftlContextKey struct{}
+
+// WithContext returns a new context with the FTL instance.
+func WithContext(ctx context.Context, ftl FTL) context.Context {
+	return context.WithValue(ctx, ftlContextKey{}, ftl)
+}
+
+// FromContext returns the FTL instance from the context.
+func FromContext(ctx context.Context) FTL {
+	ftl, ok := ctx.Value(ftlContextKey{}).(FTL)
+	if !ok {
+		panic("FTL not found in context")
+	}
+	return ftl
+}

--- a/go-runtime/internal/impl.go
+++ b/go-runtime/internal/impl.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"connectrpc.com/connect"
+
+	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
+	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/TBD54566975/ftl/go-runtime/encoding"
+	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+	"github.com/TBD54566975/ftl/internal/rpc"
+)
+
+// RealFTL is the real implementation of the [internal.FTL] interface using the Controller.
+type RealFTL struct{}
+
+// New creates a new [RealFTL]
+func New() *RealFTL { return &RealFTL{} }
+
+var _ FTL = &RealFTL{}
+
+func (r *RealFTL) FSMSend(ctx context.Context, fsm, instance string, event any) error {
+	client := rpc.ClientFromContext[ftlv1connect.VerbServiceClient](ctx)
+	body, err := encoding.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal event: %w", err)
+	}
+	_, err = client.SendFSMEvent(ctx, connect.NewRequest(&ftlv1.SendFSMEventRequest{
+		Fsm:      &schemapb.Ref{Module: reflection.Module(), Name: fsm},
+		Instance: instance,
+		Event:    schema.TypeToProto(reflection.ReflectTypeToSchemaType(reflect.TypeOf(event))),
+		Body:     body,
+	}))
+	if err != nil {
+		return fmt.Errorf("failed to send event: %w", err)
+	}
+	return nil
+}

--- a/go-runtime/server/server.go
+++ b/go-runtime/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TBD54566975/ftl/go-runtime/encoding"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+	"github.com/TBD54566975/ftl/go-runtime/internal"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/maps"
 	"github.com/TBD54566975/ftl/internal/modulecontext"
@@ -32,6 +33,7 @@ type UserVerbConfig struct {
 // This function is intended to be used by the code generator.
 func NewUserVerbServer(moduleName string, handlers ...Handler) plugin.Constructor[ftlv1connect.VerbServiceHandler, UserVerbConfig] {
 	return func(ctx context.Context, uc UserVerbConfig) (context.Context, ftlv1connect.VerbServiceHandler, error) {
+		ctx = internal.WithContext(ctx, internal.New())
 		verbServiceClient := rpc.Dial(ftlv1connect.NewVerbServiceClient, uc.FTLEndpoint.String(), log.Error)
 		ctx = rpc.ContextWithClient(ctx, verbServiceClient)
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -289,6 +289,16 @@ func TestLease(t *testing.T) {
 	)
 }
 
+func TestFSMGoTests(t *testing.T) {
+	logFilePath := filepath.Join(t.TempDir(), "fsm.log")
+	t.Setenv("FSM_LOG_FILE", logFilePath)
+	run(t, "",
+		copyModule("fsm"),
+		build("fsm"),
+		testModule("fsm"),
+	)
+}
+
 func TestFSM(t *testing.T) {
 	logFilePath := filepath.Join(t.TempDir(), "fsm.log")
 	t.Setenv("FSM_LOG_FILE", logFilePath)

--- a/integration/testdata/go/fsm/fsm_test.go
+++ b/integration/testdata/go/fsm/fsm_test.go
@@ -1,0 +1,26 @@
+package fsm
+
+import (
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
+)
+
+func TestFSM(t *testing.T) {
+	ctx := ftltest.Context()
+
+	err := fsm.Send(ctx, "one", Two{Instance: "one"}) // No start transition on Two
+	assert.Error(t, err)
+
+	err = fsm.Send(ctx, "one", One{Instance: "one"}) // -> Start
+	assert.NoError(t, err)
+	err = fsm.Send(ctx, "one", One{Instance: "one"}) // -> Middle
+	assert.NoError(t, err)
+	err = fsm.Send(ctx, "one", One{Instance: "one"}) // -> End
+	assert.NoError(t, err)
+
+	err = fsm.Send(ctx, "one", One{Instance: "one"}) // Invalid, terminated
+	assert.Error(t, err)
+}

--- a/integration/testdata/go/fsm/go.mod
+++ b/integration/testdata/go/fsm/go.mod
@@ -4,20 +4,28 @@ go 1.22.2
 
 toolchain go1.22.3
 
-require github.com/TBD54566975/ftl v0.224.0
+require (
+	github.com/TBD54566975/ftl v0.224.0
+	github.com/alecthomas/assert/v2 v2.10.0
+)
 
 require (
 	connectrpc.com/connect v1.16.1 // indirect
 	connectrpc.com/grpcreflect v1.2.0 // indirect
 	connectrpc.com/otelconnect v0.7.0 // indirect
+	github.com/BurntSushi/toml v1.4.0 // indirect
+	github.com/TBD54566975/scaffolder v1.0.0 // indirect
 	github.com/alecthomas/concurrency v0.0.2 // indirect
+	github.com/alecthomas/kong v0.9.0 // indirect
 	github.com/alecthomas/participle/v2 v2.1.1 // indirect
+	github.com/alecthomas/repr v0.4.0 // indirect
 	github.com/alecthomas/types v0.16.0 // indirect
 	github.com/alessio/shellescape v1.4.2 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect

--- a/integration/testdata/go/fsm/go.sum
+++ b/integration/testdata/go/fsm/go.sum
@@ -4,10 +4,16 @@ connectrpc.com/grpcreflect v1.2.0 h1:Q6og1S7HinmtbEuBvARLNwYmTbhEGRpHDhqrPNlmK+U
 connectrpc.com/grpcreflect v1.2.0/go.mod h1:nwSOKmE8nU5u/CidgHtPYk1PFI3U9ignz7iDMxOYkSY=
 connectrpc.com/otelconnect v0.7.0 h1:ZH55ZZtcJOTKWWLy3qmL4Pam4RzRWBJFOqTPyAqCXkY=
 connectrpc.com/otelconnect v0.7.0/go.mod h1:Bt2ivBymHZHqxvo4HkJ0EwHuUzQN6k2l0oH+mp/8nwc=
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/TBD54566975/scaffolder v1.0.0 h1:QUFSy2wVzumLDg7IHcKC6AP+IYyqWe9Wxiu72nZn5qU=
+github.com/TBD54566975/scaffolder v1.0.0/go.mod h1:auVpczIbOAdIhYDVSruIw41DanxOKB9bSvjf6MEl7Fs=
 github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
 github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
 github.com/alecthomas/concurrency v0.0.2/go.mod h1:GmuQb/iHX7mbNtPlC/WDzEFxDMB0HYFer2Qda9QTs7w=
+github.com/alecthomas/kong v0.9.0 h1:G5diXxc85KvoV2f0ZRVuMsi45IrBgx9zDNGNj165aPA=
+github.com/alecthomas/kong v0.9.0/go.mod h1:Y47y5gKfHp1hDc7CH7OeXgLIpp+Q2m1Ni0L5s3bI8Os=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
 github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=


### PR DESCRIPTION
This also introduces an interface `go-runtime/internal.FSM` that provides a consistent interface for production and test code. Only `FSMSend` is supported currently as a proof of concept, but we should refactor all of our existing code to use this so it's something like this:

```go
type FTL interface {
  GetConfig(ctx context.Context, name string, dest any) error
  GetSecret(ctx context.Context, name string, dest any) error
  // Call a verb.
  Call(ctx context.Context, fn any, arg any) (any, error)
  // FSMSend sends an event to an instance of an FSM.
  FSMSend(ctx context.Context, fsm, instance string, event any) error
  // AcquireLease attempts to acquire a new lease.
  AcquireLease(ctx context.Context, module string, key []string, ttl time.Duration) (Lease, error)
}
```

cc @mistermoe 