### PR TITLE
fix: only build verb schema for non-nil refs

### DIFF
--- a/backend/controller/console.go
+++ b/backend/controller/console.go
@@ -44,15 +44,14 @@ func visitNode(sch *schema.Schema, n schema.Node, verbString *string) error {
 	return schema.Visit(n, func(n schema.Node, next func() error) error {
 		switch n := n.(type) {
 		case *schema.Ref:
-			decl, ok := sch.Resolve(n).Get()
-			if !ok {
-				return fmt.Errorf("failed to resolve %s", n)
+			if decl, ok := sch.Resolve(n).Get(); ok {
+				*verbString += decl.String() + "\n\n"
+				err := visitNode(sch, decl, verbString)
+				if err != nil {
+					return err
+				}
 			}
-			*verbString += decl.String() + "\n\n"
-			err := visitNode(sch, decl, verbString)
-			if err != nil {
-				return err
-			}
+
 		default:
 		}
 		return next()

--- a/backend/controller/console_test.go
+++ b/backend/controller/console_test.go
@@ -13,10 +13,20 @@ func TestVerbSchemaString(t *testing.T) {
 		Request:  &schema.Ref{Module: "foo", Name: "EchoRequest"},
 		Response: &schema.Ref{Module: "foo", Name: "EchoResponse"},
 	}
+	ingressVerb := &schema.Verb{
+		Name:     "Ingress",
+		Request:  &schema.Ref{Module: "builtin", Name: "HttpRequest", TypeParameters: []schema.Type{&schema.String{}}},
+		Response: &schema.Ref{Module: "builtin", Name: "HttpResponse", TypeParameters: []schema.Type{&schema.String{}, &schema.String{}}},
+		Metadata: []schema.Metadata{
+			&schema.MetadataIngress{Type: "http", Method: "GET", Path: []schema.IngressPathComponent{&schema.IngressPathLiteral{Text: "test"}}},
+		},
+	}
 	sch := &schema.Schema{
 		Modules: []*schema.Module{
+			schema.Builtins(),
 			{Name: "foo", Decls: []schema.Decl{
 				verb,
+				ingressVerb,
 				&schema.Data{
 					Name: "EchoRequest",
 					Fields: []*schema.Field{
@@ -51,6 +61,7 @@ func TestVerbSchemaString(t *testing.T) {
 			}},
 			{Name: "bar", Decls: []schema.Decl{
 				verb,
+				ingressVerb,
 				&schema.Data{
 					Name:   "BarData",
 					Export: true,
@@ -87,6 +98,71 @@ data EchoResponse {
 }
 
 verb Echo(foo.EchoRequest) foo.EchoResponse`
+
+	schemaString, err := verbSchemaString(sch, verb)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, schemaString)
+}
+
+func TestVerbSchemaStringIngress(t *testing.T) {
+	verb := &schema.Verb{
+		Name:     "Ingress",
+		Request:  &schema.Ref{Module: "builtin", Name: "HttpRequest", TypeParameters: []schema.Type{&schema.Ref{Module: "foo", Name: "FooRequest"}}},
+		Response: &schema.Ref{Module: "builtin", Name: "HttpResponse", TypeParameters: []schema.Type{&schema.Ref{Module: "foo", Name: "FooResponse"}, &schema.String{}}},
+		Metadata: []schema.Metadata{
+			&schema.MetadataIngress{Type: "http", Method: "GET", Path: []schema.IngressPathComponent{&schema.IngressPathLiteral{Text: "foo"}}},
+		},
+	}
+	sch := &schema.Schema{
+		Modules: []*schema.Module{
+			schema.Builtins(),
+			{Name: "foo", Decls: []schema.Decl{
+				verb,
+				&schema.Data{
+					Name: "FooRequest",
+					Fields: []*schema.Field{
+						{Name: "Name", Type: &schema.String{}},
+					},
+				},
+				&schema.Data{
+					Name: "FooResponse",
+					Fields: []*schema.Field{
+						{Name: "Message", Type: &schema.String{}},
+					},
+				},
+			}},
+		},
+	}
+
+	expected := `// HTTP request structure used for HTTP ingress verbs.
+export data HttpRequest<Body> {
+  method String
+  path String
+  pathParameters {String: String}
+  query {String: [String]}
+  headers {String: [String]}
+  body Body
+}
+
+data FooRequest {
+  Name String
+}
+
+// HTTP response structure used for HTTP ingress verbs.
+export data HttpResponse<Body, Error> {
+  status Int
+  headers {String: [String]}
+  // Either "body" or "error" must be present, not both.
+  body Body?
+  error Error?
+}
+
+data FooResponse {
+  Message String
+}
+
+verb Ingress(builtin.HttpRequest<foo.FooRequest>) builtin.HttpResponse<foo.FooResponse, String>  
+  +ingress http GET /foo`
 
 	schemaString, err := verbSchemaString(sch, verb)
 	assert.NoError(t, err)


### PR DESCRIPTION
Fixes #1578 

We might want more protection around refs not being found, but I wasn't sure how to make this allow for `TypeParameters` and also keep that protection. This fix gets things working again, but we might want to revisit this as well.