### PR TITLE
fix: refactor manager.go to use provider key instead of MutableProviders, adds `--opvault=VAULT` controller flag

### DIFF
--- a/cmd/ftl-controller/main.go
+++ b/cmd/ftl-controller/main.go
@@ -26,7 +26,7 @@ var cli struct {
 	ConfigFlag          []string             `name:"config" short:"C" help:"Paths to FTL project configuration files." env:"FTL_CONFIG" placeholder:"FILE[,FILE,...]"`
 
 	// Specify the 1Password vault to access secrets from.
-	Vault string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"secretwriter" placeholder:"VAULT"`
+	Vault string `name:"opvault" help:"1Password vault to be used for secrets. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." placeholder:"VAULT"`
 }
 
 func main() {

--- a/cmd/ftl-controller/main.go
+++ b/cmd/ftl-controller/main.go
@@ -24,6 +24,9 @@ var cli struct {
 	LogConfig           log.Config           `embed:"" prefix:"log-"`
 	ControllerConfig    controller.Config    `embed:""`
 	ConfigFlag          []string             `name:"config" short:"C" help:"Paths to FTL project configuration files." env:"FTL_CONFIG" placeholder:"FILE[,FILE,...]"`
+
+	// Specify the 1Password vault to access secrets from.
+	Vault string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"secretwriter" placeholder:"VAULT"`
 }
 
 func main() {
@@ -56,7 +59,7 @@ func main() {
 	ctx = cf.ContextWithConfig(ctx, cm)
 
 	// Add secrets manager to context.
-	sm, err := cf.NewSecretsManager(ctx, sr)
+	sm, err := cf.NewSecretsManager(ctx, sr, cli.Vault)
 	if err != nil {
 		kctx.Fatalf(err.Error())
 	}

--- a/cmd/ftl/cmd_config.go
+++ b/cmd/ftl/cmd_config.go
@@ -43,7 +43,7 @@ type configListCmd struct {
 	Module string `optional:"" arg:"" placeholder:"MODULE" help:"List configuration only in this module."`
 }
 
-func (s *configListCmd) Run(ctx context.Context, scmd *configCmd, cr cf.Resolver[cf.Configuration]) error {
+func (s *configListCmd) Run(ctx context.Context, cr cf.Resolver[cf.Configuration]) error {
 	sm, err := cf.NewConfigurationManager(ctx, cr)
 	if err != nil {
 		return err
@@ -89,7 +89,7 @@ Returns a JSON-encoded configuration value.
 `
 }
 
-func (s *configGetCmd) Run(ctx context.Context, scmd *configCmd, cr cf.Resolver[cf.Configuration]) error {
+func (s *configGetCmd) Run(ctx context.Context, cr cf.Resolver[cf.Configuration]) error {
 	sm, err := cf.NewConfigurationManager(ctx, cr)
 	if err != nil {
 		return err

--- a/cmd/ftl/cmd_config.go
+++ b/cmd/ftl/cmd_config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	cf "github.com/TBD54566975/ftl/common/configuration"
+	"github.com/alecthomas/types/optional"
 )
 
 type configCmd struct {
@@ -137,7 +138,7 @@ func (s *configSetCmd) Run(ctx context.Context, scmd *configCmd, cr cf.Resolver[
 	} else {
 		configValue = string(config)
 	}
-	return sm.Set(ctx, providerKey, s.Ref, configValue)
+	return sm.Set(ctx, providerKey, optional.None[string](), s.Ref, configValue)
 }
 
 type configUnsetCmd struct {

--- a/cmd/ftl/cmd_secret.go
+++ b/cmd/ftl/cmd_secret.go
@@ -23,7 +23,7 @@ type secretCmd struct {
 	Inline   bool `help:"Write values inline in the configuration file." group:"Provider:" xor:"secretwriter"`
 	Keychain bool `help:"Write to the system keychain." group:"Provider:" xor:"secretwriter"`
 
-	//TODO: with AdminService, the following will move to the controller as "vault" and "op" will be a bool flag.
+	//TODO: with AdminService, the controller will accept --opvault=VAULT and the following should be replaced with an --op bool flag.
 	Vault string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"secretwriter" placeholder:"VAULT"`
 }
 

--- a/cmd/ftl/cmd_secret.go
+++ b/cmd/ftl/cmd_secret.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 
-	"github.com/alecthomas/types/optional"
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
 
@@ -15,17 +14,17 @@ import (
 )
 
 type secretCmd struct {
-	cf.DefaultSecretsMixin
-
 	List  secretListCmd  `cmd:"" help:"List secrets."`
 	Get   secretGetCmd   `cmd:"" help:"Get a secret."`
 	Set   secretSetCmd   `cmd:"" help:"Set a secret."`
 	Unset secretUnsetCmd `cmd:"" help:"Unset a secret."`
 
-	Envar    bool   `help:"Print configuration as environment variables." group:"Provider:" xor:"secretwriter"`
-	Inline   bool   `help:"Write values inline in the configuration file." group:"Provider:" xor:"secretwriter"`
-	Keychain bool   `help:"Write to the system keychain." group:"Provider:" xor:"secretwriter"`
-	Vault    string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"secretwriter" placeholder:"VAULT"`
+	Envar    bool `help:"Write configuration as environment variables." group:"Provider:" xor:"secretwriter"`
+	Inline   bool `help:"Write values inline in the configuration file." group:"Provider:" xor:"secretwriter"`
+	Keychain bool `help:"Write to the system keychain." group:"Provider:" xor:"secretwriter"`
+
+	//TODO: with AdminService, the following will move to the controller as "vault" and "op" will be a bool flag.
+	Vault string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"secretwriter" placeholder:"VAULT"`
 }
 
 func (s *secretCmd) Help() string {
@@ -38,13 +37,26 @@ variables, and so on.
 `
 }
 
+func (s *secretCmd) providerKey() string {
+	if s.Envar {
+		return "envar"
+	} else if s.Inline {
+		return "inline"
+	} else if s.Keychain {
+		return "keychain"
+	} else if s.Vault != "" {
+		return "op"
+	}
+	return ""
+}
+
 type secretListCmd struct {
 	Values bool   `help:"List secret values."`
 	Module string `optional:"" arg:"" placeholder:"MODULE" help:"List secrets only in this module."`
 }
 
 func (s *secretListCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[cf.Secrets]) error {
-	sm, err := scmd.NewSecretsManager(ctx, sr)
+	sm, err := cf.NewSecretsManager(ctx, sr, scmd.Vault)
 	if err != nil {
 		return err
 	}
@@ -90,7 +102,7 @@ Returns a JSON-encoded secret value.
 }
 
 func (s *secretGetCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[cf.Secrets]) error {
-	sm, err := scmd.NewSecretsManager(ctx, sr)
+	sm, err := cf.NewSecretsManager(ctx, sr, scmd.Vault)
 	if err != nil {
 		return err
 	}
@@ -115,22 +127,9 @@ type secretSetCmd struct {
 }
 
 func (s *secretSetCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[cf.Secrets]) error {
-	sm, err := scmd.NewSecretsManager(ctx, sr)
+	sm, err := cf.NewSecretsManager(ctx, sr, scmd.Vault)
 	if err != nil {
 		return err
-	}
-
-	var providerKey string
-	host := optional.None[string]()
-	if scmd.Envar {
-		providerKey = "envar"
-	} else if scmd.Inline {
-		providerKey = "inline"
-	} else if scmd.Keychain {
-		providerKey = "keychain"
-	} else if scmd.Vault != "" {
-		providerKey = "op"
-		host = optional.Some[string](scmd.Vault)
 	}
 
 	// Prompt for a secret if stdin is a terminal, otherwise read from stdin.
@@ -157,7 +156,7 @@ func (s *secretSetCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[
 	} else {
 		secretValue = string(secret)
 	}
-	return sm.Set(ctx, providerKey, host, s.Ref, secretValue)
+	return sm.Set(ctx, scmd.providerKey(), s.Ref, secretValue)
 }
 
 type secretUnsetCmd struct {
@@ -165,21 +164,9 @@ type secretUnsetCmd struct {
 }
 
 func (s *secretUnsetCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[cf.Secrets]) error {
-	sm, err := scmd.NewSecretsManager(ctx, sr)
+	sm, err := cf.NewSecretsManager(ctx, sr, scmd.Vault)
 	if err != nil {
 		return err
 	}
-
-	var providerKey string
-	if scmd.Envar {
-		providerKey = "envar"
-	} else if scmd.Inline {
-		providerKey = "inline"
-	} else if scmd.Keychain {
-		providerKey = "keychain"
-	} else if scmd.Vault != "" {
-		providerKey = "op"
-	}
-
-	return sm.Unset(ctx, providerKey, s.Ref)
+	return sm.Unset(ctx, scmd.providerKey(), s.Ref)
 }

--- a/cmd/ftl/cmd_secret.go
+++ b/cmd/ftl/cmd_secret.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/alecthomas/types/optional"
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
 
@@ -120,6 +121,7 @@ func (s *secretSetCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[
 	}
 
 	var providerKey string
+	host := optional.None[string]()
 	if scmd.Envar {
 		providerKey = "envar"
 	} else if scmd.Inline {
@@ -128,6 +130,7 @@ func (s *secretSetCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[
 		providerKey = "keychain"
 	} else if scmd.Vault != "" {
 		providerKey = "op"
+		host = optional.Some[string](scmd.Vault)
 	}
 
 	// Prompt for a secret if stdin is a terminal, otherwise read from stdin.
@@ -154,7 +157,7 @@ func (s *secretSetCmd) Run(ctx context.Context, scmd *secretCmd, sr cf.Resolver[
 	} else {
 		secretValue = string(secret)
 	}
-	return sm.Set(ctx, providerKey, s.Ref, secretValue)
+	return sm.Set(ctx, providerKey, host, s.Ref, secretValue)
 }
 
 type secretUnsetCmd struct {

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -44,6 +44,9 @@ type CLI struct {
 	Download downloadCmd `cmd:"" help:"Download a deployment."`
 	Secret   secretCmd   `cmd:"" help:"Manage secrets."`
 	Config   configCmd   `cmd:"" help:"Manage configuration."`
+
+	// Specify the 1Password vault to access secrets from.
+	Vault string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"secretwriter" placeholder:"VAULT"`
 }
 
 var cli CLI
@@ -98,7 +101,7 @@ func main() {
 	ctx = cf.ContextWithConfig(ctx, cm)
 
 	// Add secrets manager to context.
-	sm, err := cf.NewSecretsManager(ctx, sr)
+	sm, err := cf.NewSecretsManager(ctx, sr, cli.Vault)
 	if err != nil {
 		kctx.Fatalf(err.Error())
 	}

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -46,7 +46,7 @@ type CLI struct {
 	Config   configCmd   `cmd:"" help:"Manage configuration."`
 
 	// Specify the 1Password vault to access secrets from.
-	Vault string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"secretwriter" placeholder:"VAULT"`
+	Vault string `name:"opvault" help:"1Password vault to be used for secrets. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." placeholder:"VAULT"`
 }
 
 var cli CLI

--- a/common/configuration/1password_provider.go
+++ b/common/configuration/1password_provider.go
@@ -19,10 +19,9 @@ import (
 // OnePasswordProvider is a configuration provider that reads passwords from
 // 1Password vaults via the "op" command line tool.
 type OnePasswordProvider struct {
-	Vault string `name:"op" help:"Store a secret in this 1Password vault. The name of the 1Password item will be the <ref> and the secret will be stored in the password field." group:"Provider:" xor:"configwriter" placeholder:"VAULT"`
+	// TODO(saf): this was set via CLI, now needs to be set via an arg.
+	Vault string ""
 }
-
-var _ MutableProvider[Secrets] = OnePasswordProvider{}
 
 func (OnePasswordProvider) Role() Secrets                               { return Secrets{} }
 func (o OnePasswordProvider) Key() string                               { return "op" }
@@ -90,8 +89,6 @@ func (o OnePasswordProvider) Store(ctx context.Context, ref Ref, value []byte) (
 
 	return url, nil
 }
-
-func (o OnePasswordProvider) Writer() bool { return o.Vault != "" }
 
 func checkOpBinary() error {
 	_, err := exec.LookPath("op")

--- a/common/configuration/api.go
+++ b/common/configuration/api.go
@@ -89,26 +89,6 @@ type Provider[R Role] interface {
 	Role() R
 	Key() string
 	Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error)
-}
-
-// A MutableProvider is a Provider that can update configuration.
-type MutableProvider[R Role] interface {
-	Provider[R]
-	// Writer returns true if this provider should be used to store configuration.
-	//
-	// Only one provider should return true.
-	//
-	// To be usable from the CLI, each provider must be a Kong-compatible struct
-	// containing a flag that this method should return. For example:
-	//
-	// 	type InlineProvider struct {
-	// 		Inline bool `help:"Write values inline." group:"Provider:" xor:"configwriter"`
-	// 	}
-	//
-	//	func (i InlineProvider) Writer() bool { return i.Inline }
-	//
-	// The "xor" tag is used to ensure that only one writer is selected.
-	Writer() bool
 	// Store a configuration value and return its key.
 	Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error)
 	// Delete a configuration value.

--- a/common/configuration/api.go
+++ b/common/configuration/api.go
@@ -90,7 +90,7 @@ type Provider[R Role] interface {
 	Key() string
 	Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error)
 	// Store a configuration value and return its key.
-	Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error)
+	Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error)
 	// Delete a configuration value.
 	Delete(ctx context.Context, ref Ref) error
 }

--- a/common/configuration/api.go
+++ b/common/configuration/api.go
@@ -90,7 +90,7 @@ type Provider[R Role] interface {
 	Key() string
 	Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error)
 	// Store a configuration value and return its key.
-	Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error)
+	Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error)
 	// Delete a configuration value.
 	Delete(ctx context.Context, ref Ref) error
 }

--- a/common/configuration/db_config_provider.go
+++ b/common/configuration/db_config_provider.go
@@ -19,8 +19,6 @@ type DBConfigProviderDAL interface {
 	UnsetModuleConfiguration(ctx context.Context, module optional.Option[string], name string) error
 }
 
-var _ MutableProvider[Configuration] = DBConfigProvider{}
-
 func NewDBConfigProvider(dal DBConfigProviderDAL) DBConfigProvider {
 	return DBConfigProvider{
 		dal: dal,
@@ -29,7 +27,6 @@ func NewDBConfigProvider(dal DBConfigProviderDAL) DBConfigProvider {
 
 func (DBConfigProvider) Role() Configuration { return Configuration{} }
 func (DBConfigProvider) Key() string         { return "db" }
-func (DBConfigProvider) Writer() bool        { return true }
 
 func (d DBConfigProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
 	value, err := d.dal.GetModuleConfiguration(ctx, ref.Module, ref.Name)

--- a/common/configuration/defaults.go
+++ b/common/configuration/defaults.go
@@ -2,52 +2,26 @@ package configuration
 
 import (
 	"context"
-
-	"github.com/alecthomas/kong"
 )
-
-// NewConfigurationManager constructs a new [Manager] with the default providers for configuration.
-func NewConfigurationManager(ctx context.Context, resolver Resolver[Configuration]) (*Manager[Configuration], error) {
-	conf := DefaultConfigMixin{}
-	_ = kong.ApplyDefaults(&conf)
-	return conf.NewConfigurationManager(ctx, resolver)
-}
 
 // DefaultConfigMixin is a Kong mixin that provides the default configuration manager.
 type DefaultConfigMixin struct {
-	InlineProvider[Configuration]
-	EnvarProvider[Configuration]
 }
 
 // NewConfigurationManager creates a new configuration manager with the default configuration providers.
-func (d DefaultConfigMixin) NewConfigurationManager(ctx context.Context, resolver Resolver[Configuration]) (*Manager[Configuration], error) {
+func NewConfigurationManager(ctx context.Context, resolver Resolver[Configuration]) (*Manager[Configuration], error) {
 	return New(ctx, resolver, []Provider[Configuration]{
-		d.InlineProvider,
-		d.EnvarProvider,
+		InlineProvider[Configuration]{},
+		EnvarProvider[Configuration]{},
 	})
 }
 
-// NewSecretsManager constructs a new [Manager] with the default providers for secrets.
-func NewSecretsManager(ctx context.Context, resolver Resolver[Secrets]) (*Manager[Secrets], error) {
-	conf := DefaultSecretsMixin{}
-	_ = kong.ApplyDefaults(&conf)
-	return conf.NewSecretsManager(ctx, resolver)
-}
-
-// DefaultSecretsMixin is a Kong mixin that provides the default secrets manager.
-type DefaultSecretsMixin struct {
-	InlineProvider[Secrets]
-	EnvarProvider[Secrets]
-	KeychainProvider
-	OnePasswordProvider
-}
-
 // NewSecretsManager creates a new secrets manager with the default secret providers.
-func (d DefaultSecretsMixin) NewSecretsManager(ctx context.Context, resolver Resolver[Secrets]) (*Manager[Secrets], error) {
+func NewSecretsManager(ctx context.Context, resolver Resolver[Secrets], opVault string) (*Manager[Secrets], error) {
 	return New(ctx, resolver, []Provider[Secrets]{
-		d.InlineProvider,
-		d.EnvarProvider,
-		d.KeychainProvider,
-		d.OnePasswordProvider,
+		InlineProvider[Secrets]{},
+		EnvarProvider[Secrets]{},
+		KeychainProvider{},
+		OnePasswordProvider{Vault: opVault},
 	})
 }

--- a/common/configuration/envar_provider.go
+++ b/common/configuration/envar_provider.go
@@ -10,11 +10,7 @@ import (
 
 // EnvarProvider is a configuration provider that reads secrets or configuration
 // from environment variables.
-type EnvarProvider[R Role] struct {
-	Envar bool `help:"Print configuration as environment variables." xor:"configwriter" group:"Provider:"`
-}
-
-var _ MutableProvider[Configuration] = EnvarProvider[Configuration]{}
+type EnvarProvider[R Role] struct{}
 
 func (EnvarProvider[R]) Role() R     { var r R; return r }
 func (EnvarProvider[R]) Key() string { return "envar" }
@@ -39,8 +35,6 @@ func (e EnvarProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*ur
 	fmt.Printf("%s=%s\n", envar, base64.RawURLEncoding.EncodeToString(value))
 	return &url.URL{Scheme: "envar", Host: ref.Name}, nil
 }
-
-func (e EnvarProvider[R]) Writer() bool { return e.Envar }
 
 func (e EnvarProvider[R]) key(ref Ref) string {
 	key := e.prefix()

--- a/common/configuration/envar_provider.go
+++ b/common/configuration/envar_provider.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-
-	"github.com/alecthomas/types/optional"
 )
 
 // EnvarProvider is a configuration provider that reads secrets or configuration
@@ -32,8 +30,8 @@ func (e EnvarProvider[R]) Delete(ctx context.Context, ref Ref) error {
 	return nil
 }
 
-func (e EnvarProvider[R]) Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error) {
-	envar := host.Default(e.key(ref))
+func (e EnvarProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+	envar := e.key(ref)
 	fmt.Printf("%s=%s\n", envar, base64.RawURLEncoding.EncodeToString(value))
 	return &url.URL{Scheme: "envar", Host: ref.Name}, nil
 }

--- a/common/configuration/envar_provider.go
+++ b/common/configuration/envar_provider.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+
+	"github.com/alecthomas/types/optional"
 )
 
 // EnvarProvider is a configuration provider that reads secrets or configuration
@@ -30,8 +32,8 @@ func (e EnvarProvider[R]) Delete(ctx context.Context, ref Ref) error {
 	return nil
 }
 
-func (e EnvarProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
-	envar := e.key(ref)
+func (e EnvarProvider[R]) Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error) {
+	envar := host.Default(e.key(ref))
 	fmt.Printf("%s=%s\n", envar, base64.RawURLEncoding.EncodeToString(value))
 	return &url.URL{Scheme: "envar", Host: ref.Name}, nil
 }

--- a/common/configuration/inline_provider.go
+++ b/common/configuration/inline_provider.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+
+	"github.com/alecthomas/types/optional"
 )
 
 // InlineProvider is a configuration provider that stores configuration in its key.
@@ -21,7 +23,10 @@ func (InlineProvider[R]) Load(ctx context.Context, ref Ref, key *url.URL) ([]byt
 	return data, nil
 }
 
-func (InlineProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+func (InlineProvider[R]) Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error) {
+	if h, ok := host.Get(); ok && h != "" {
+		return nil, fmt.Errorf("inline configuration does not support host: %s", h)
+	}
 	b64 := base64.RawURLEncoding.EncodeToString(value)
 	return &url.URL{Scheme: "inline", Host: b64}, nil
 }

--- a/common/configuration/inline_provider.go
+++ b/common/configuration/inline_provider.go
@@ -8,16 +8,10 @@ import (
 )
 
 // InlineProvider is a configuration provider that stores configuration in its key.
-type InlineProvider[R Role] struct {
-	Inline bool `help:"Write values inline in the configuration file." group:"Provider:" xor:"configwriter"`
-}
-
-var _ MutableProvider[Configuration] = InlineProvider[Configuration]{}
+type InlineProvider[R Role] struct{}
 
 func (InlineProvider[R]) Role() R     { var r R; return r }
 func (InlineProvider[R]) Key() string { return "inline" }
-
-func (i InlineProvider[R]) Writer() bool { return i.Inline }
 
 func (InlineProvider[R]) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
 	data, err := base64.RawURLEncoding.DecodeString(key.Host)

--- a/common/configuration/inline_provider.go
+++ b/common/configuration/inline_provider.go
@@ -5,8 +5,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
-
-	"github.com/alecthomas/types/optional"
 )
 
 // InlineProvider is a configuration provider that stores configuration in its key.
@@ -23,10 +21,7 @@ func (InlineProvider[R]) Load(ctx context.Context, ref Ref, key *url.URL) ([]byt
 	return data, nil
 }
 
-func (InlineProvider[R]) Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error) {
-	if h, ok := host.Get(); ok && h != "" {
-		return nil, fmt.Errorf("inline configuration does not support host: %s", h)
-	}
+func (InlineProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
 	b64 := base64.RawURLEncoding.EncodeToString(value)
 	return &url.URL{Scheme: "inline", Host: b64}, nil
 }

--- a/common/configuration/keychain_provider.go
+++ b/common/configuration/keychain_provider.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/alecthomas/types/optional"
 	keyring "github.com/zalando/go-keyring"
 )
 
@@ -26,12 +27,12 @@ func (k KeychainProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([]by
 	return []byte(value), nil
 }
 
-func (k KeychainProvider) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
-	err := keyring.Set(k.serviceName(ref), ref.Name, string(value))
+func (k KeychainProvider) Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error) {
+	err := keyring.Set(k.serviceName(ref), host.Default(ref.Name), string(value))
 	if err != nil {
 		return nil, err
 	}
-	return &url.URL{Scheme: "keychain", Host: ref.Name}, nil
+	return &url.URL{Scheme: "keychain", Host: host.Default(ref.Name)}, nil
 }
 
 func (k KeychainProvider) Delete(ctx context.Context, ref Ref) error {

--- a/common/configuration/keychain_provider.go
+++ b/common/configuration/keychain_provider.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/alecthomas/types/optional"
 	keyring "github.com/zalando/go-keyring"
 )
 
@@ -27,12 +26,12 @@ func (k KeychainProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([]by
 	return []byte(value), nil
 }
 
-func (k KeychainProvider) Store(ctx context.Context, host optional.Option[string], ref Ref, value []byte) (*url.URL, error) {
-	err := keyring.Set(k.serviceName(ref), host.Default(ref.Name), string(value))
+func (k KeychainProvider) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+	err := keyring.Set(k.serviceName(ref), ref.Name, string(value))
 	if err != nil {
 		return nil, err
 	}
-	return &url.URL{Scheme: "keychain", Host: host.Default(ref.Name)}, nil
+	return &url.URL{Scheme: "keychain", Host: ref.Name}, nil
 }
 
 func (k KeychainProvider) Delete(ctx context.Context, ref Ref) error {

--- a/common/configuration/keychain_provider.go
+++ b/common/configuration/keychain_provider.go
@@ -10,16 +10,10 @@ import (
 	keyring "github.com/zalando/go-keyring"
 )
 
-type KeychainProvider struct {
-	Keychain bool `help:"Write to the system keychain." group:"Provider:" xor:"configwriter"`
-}
-
-var _ MutableProvider[Secrets] = KeychainProvider{}
+type KeychainProvider struct{}
 
 func (KeychainProvider) Role() Secrets { return Secrets{} }
 func (k KeychainProvider) Key() string { return "keychain" }
-
-func (k KeychainProvider) Writer() bool { return k.Keychain }
 
 func (k KeychainProvider) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
 	value, err := keyring.Get(k.serviceName(ref), key.Host)

--- a/common/configuration/manager.go
+++ b/common/configuration/manager.go
@@ -101,7 +101,7 @@ func (m *Manager[R]) Get(ctx context.Context, ref Ref, value any) error {
 }
 
 // Set a configuration value.
-func (m *Manager[R]) Set(ctx context.Context, pkey string, ref Ref, value any) error {
+func (m *Manager[R]) Set(ctx context.Context, pkey string, host optional.Option[string], ref Ref, value any) error {
 	provider, ok := m.providers[pkey]
 	if !ok {
 		return fmt.Errorf("no provider for key %q", pkey)
@@ -110,7 +110,7 @@ func (m *Manager[R]) Set(ctx context.Context, pkey string, ref Ref, value any) e
 	if err != nil {
 		return err
 	}
-	key, err := provider.Store(ctx, ref, data)
+	key, err := provider.Store(ctx, host, ref, data)
 	if err != nil {
 		return err
 	}

--- a/common/configuration/manager.go
+++ b/common/configuration/manager.go
@@ -40,16 +40,16 @@ func ConfigFromEnvironment() []string {
 
 // NewDefaultSecretsManagerFromConfig creates a new secrets manager from
 // the project config found in the config paths.
-func NewDefaultSecretsManagerFromConfig(ctx context.Context, config []string) (*Manager[Secrets], error) {
+func NewDefaultSecretsManagerFromConfig(ctx context.Context, config []string, opVault string) (*Manager[Secrets], error) {
 	var cr Resolver[Secrets] = ProjectConfigResolver[Secrets]{Config: config}
-	return DefaultSecretsMixin{}.NewSecretsManager(ctx, cr)
+	return NewSecretsManager(ctx, cr, opVault)
 }
 
 // NewDefaultConfigurationManagerFromConfig creates a new configuration manager from
 // the project config found in the config paths.
 func NewDefaultConfigurationManagerFromConfig(ctx context.Context, config []string) (*Manager[Configuration], error) {
 	cr := ProjectConfigResolver[Configuration]{Config: config}
-	return DefaultConfigMixin{}.NewConfigurationManager(ctx, cr)
+	return NewConfigurationManager(ctx, cr)
 }
 
 // New configuration manager.
@@ -101,7 +101,7 @@ func (m *Manager[R]) Get(ctx context.Context, ref Ref, value any) error {
 }
 
 // Set a configuration value.
-func (m *Manager[R]) Set(ctx context.Context, pkey string, host optional.Option[string], ref Ref, value any) error {
+func (m *Manager[R]) Set(ctx context.Context, pkey string, ref Ref, value any) error {
 	provider, ok := m.providers[pkey]
 	if !ok {
 		return fmt.Errorf("no provider for key %q", pkey)
@@ -110,7 +110,7 @@ func (m *Manager[R]) Set(ctx context.Context, pkey string, host optional.Option[
 	if err != nil {
 		return err
 	}
-	key, err := provider.Store(ctx, host, ref, data)
+	key, err := provider.Store(ctx, ref, data)
 	if err != nil {
 		return err
 	}

--- a/common/configuration/manager_test.go
+++ b/common/configuration/manager_test.go
@@ -22,7 +22,7 @@ func TestManager(t *testing.T) {
 
 	t.Run("Secrets", func(t *testing.T) {
 		kcp := KeychainProvider{}
-		_, err := kcp.Store(ctx, optional.None[string](), Ref{Name: "mutable"}, []byte("hello"))
+		_, err := kcp.Store(ctx, Ref{Name: "mutable"}, []byte("hello"))
 		assert.NoError(t, err)
 		cf, err := New(ctx,
 			ProjectConfigResolver[Secrets]{Config: []string{config}},
@@ -77,12 +77,12 @@ func TestMapPriority(t *testing.T) {
 		globalStrValue := "GlobalHelloWorld"
 		if i%2 == 0 {
 			// sometimes try setting the module config first
-			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.Some(moduleName), Name: key}, strValue))
-			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.None[string](), Name: key}, globalStrValue))
+			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.Some(moduleName), Name: key}, strValue))
+			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.None[string](), Name: key}, globalStrValue))
 		} else {
 			// other times try setting the global config first
-			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.None[string](), Name: key}, globalStrValue))
-			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.Some(moduleName), Name: key}, strValue))
+			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.None[string](), Name: key}, globalStrValue))
+			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.Some(moduleName), Name: key}, strValue))
 		}
 	}
 	result, err := cm.MapForModule(ctx, moduleName)
@@ -146,7 +146,7 @@ func testManager[R Role](
 	assert.IsError(t, err, ErrNotFound)
 
 	// Change value.
-	err = cf.Set(ctx, providerKey, optional.None[string](), Ref{Name: "mutable"}, "hello")
+	err = cf.Set(ctx, providerKey, Ref{Name: "mutable"}, "hello")
 	assert.NoError(t, err)
 
 	err = cf.Get(ctx, Ref{Name: "mutable"}, &fooValue)

--- a/common/configuration/manager_test.go
+++ b/common/configuration/manager_test.go
@@ -22,7 +22,7 @@ func TestManager(t *testing.T) {
 
 	t.Run("Secrets", func(t *testing.T) {
 		kcp := KeychainProvider{}
-		_, err := kcp.Store(ctx, Ref{Name: "mutable"}, []byte("hello"))
+		_, err := kcp.Store(ctx, optional.None[string](), Ref{Name: "mutable"}, []byte("hello"))
 		assert.NoError(t, err)
 		cf, err := New(ctx,
 			ProjectConfigResolver[Secrets]{Config: []string{config}},
@@ -77,12 +77,12 @@ func TestMapPriority(t *testing.T) {
 		globalStrValue := "GlobalHelloWorld"
 		if i%2 == 0 {
 			// sometimes try setting the module config first
-			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.Some(moduleName), Name: key}, strValue))
-			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.None[string](), Name: key}, globalStrValue))
+			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.Some(moduleName), Name: key}, strValue))
+			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.None[string](), Name: key}, globalStrValue))
 		} else {
 			// other times try setting the global config first
-			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.None[string](), Name: key}, globalStrValue))
-			assert.NoError(t, cm.Set(ctx, "inline", Ref{Module: optional.Some(moduleName), Name: key}, strValue))
+			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.None[string](), Name: key}, globalStrValue))
+			assert.NoError(t, cm.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.Some(moduleName), Name: key}, strValue))
 		}
 	}
 	result, err := cm.MapForModule(ctx, moduleName)
@@ -146,7 +146,7 @@ func testManager[R Role](
 	assert.IsError(t, err, ErrNotFound)
 
 	// Change value.
-	err = cf.Set(ctx, providerKey, Ref{Name: "mutable"}, "hello")
+	err = cf.Set(ctx, providerKey, optional.None[string](), Ref{Name: "mutable"}, "hello")
 	assert.NoError(t, err)
 
 	err = cf.Get(ctx, Ref{Name: "mutable"}, &fooValue)

--- a/common/configuration/projectconfig_resolver_test.go
+++ b/common/configuration/projectconfig_resolver_test.go
@@ -62,7 +62,7 @@ func TestGetGlobal(t *testing.T) {
 
 	var got *url.URL
 	want := URL("inline://qwertyqwerty")
-	err = cf.Set(ctx, "inline", Ref{Module: optional.None[string](), Name: "default"}, want)
+	err = cf.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.None[string](), Name: "default"}, want)
 	assert.NoError(t, err)
 	err = cf.Get(ctx, Ref{Module: optional.Some[string]("somemodule"), Name: "default"}, &got)
 	assert.NoError(t, err)
@@ -86,7 +86,7 @@ func setAndAssert(t *testing.T, module string, config []string) {
 
 	var got *url.URL
 	want := URL("inline://asdfasdf")
-	err = cf.Set(ctx, "inline", Ref{Module: optional.Some[string](module), Name: "default"}, want)
+	err = cf.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.Some[string](module), Name: "default"}, want)
 	assert.NoError(t, err)
 	err = cf.Get(ctx, Ref{Module: optional.Some[string](module), Name: "default"}, &got)
 	assert.NoError(t, err)

--- a/common/configuration/projectconfig_resolver_test.go
+++ b/common/configuration/projectconfig_resolver_test.go
@@ -56,13 +56,13 @@ func TestGetGlobal(t *testing.T) {
 		ProjectConfigResolver[Configuration]{Config: []string{config}},
 		[]Provider[Configuration]{
 			EnvarProvider[Configuration]{},
-			InlineProvider[Configuration]{Inline: true}, // Writer
+			InlineProvider[Configuration]{},
 		})
 	assert.NoError(t, err)
 
 	var got *url.URL
 	want := URL("inline://qwertyqwerty")
-	err = cf.Set(ctx, Ref{Module: optional.None[string](), Name: "default"}, want)
+	err = cf.Set(ctx, "inline", Ref{Module: optional.None[string](), Name: "default"}, want)
 	assert.NoError(t, err)
 	err = cf.Get(ctx, Ref{Module: optional.Some[string]("somemodule"), Name: "default"}, &got)
 	assert.NoError(t, err)
@@ -80,13 +80,13 @@ func setAndAssert(t *testing.T, module string, config []string) {
 		ProjectConfigResolver[Configuration]{Config: config},
 		[]Provider[Configuration]{
 			EnvarProvider[Configuration]{},
-			InlineProvider[Configuration]{Inline: true}, // Writer
+			InlineProvider[Configuration]{},
 		})
 	assert.NoError(t, err)
 
 	var got *url.URL
 	want := URL("inline://asdfasdf")
-	err = cf.Set(ctx, Ref{Module: optional.Some[string](module), Name: "default"}, want)
+	err = cf.Set(ctx, "inline", Ref{Module: optional.Some[string](module), Name: "default"}, want)
 	assert.NoError(t, err)
 	err = cf.Get(ctx, Ref{Module: optional.Some[string](module), Name: "default"}, &got)
 	assert.NoError(t, err)

--- a/common/configuration/projectconfig_resolver_test.go
+++ b/common/configuration/projectconfig_resolver_test.go
@@ -62,7 +62,7 @@ func TestGetGlobal(t *testing.T) {
 
 	var got *url.URL
 	want := URL("inline://qwertyqwerty")
-	err = cf.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.None[string](), Name: "default"}, want)
+	err = cf.Set(ctx, "inline", Ref{Module: optional.None[string](), Name: "default"}, want)
 	assert.NoError(t, err)
 	err = cf.Get(ctx, Ref{Module: optional.Some[string]("somemodule"), Name: "default"}, &got)
 	assert.NoError(t, err)
@@ -86,7 +86,7 @@ func setAndAssert(t *testing.T, module string, config []string) {
 
 	var got *url.URL
 	want := URL("inline://asdfasdf")
-	err = cf.Set(ctx, "inline", optional.None[string](), Ref{Module: optional.Some[string](module), Name: "default"}, want)
+	err = cf.Set(ctx, "inline", Ref{Module: optional.Some[string](module), Name: "default"}, want)
 	assert.NoError(t, err)
 	err = cf.Get(ctx, Ref{Module: optional.Some[string](module), Name: "default"}, &got)
 	assert.NoError(t, err)

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -111,7 +111,7 @@ func WithProjectFiles(paths ...string) Option {
 			state.configs[name] = data
 		}
 
-		sm, err := cf.NewDefaultSecretsManagerFromConfig(ctx, paths)
+		sm, err := cf.NewDefaultSecretsManagerFromConfig(ctx, paths, "")
 		if err != nil {
 			return fmt.Errorf("could not set up secrets: %w", err)
 		}


### PR DESCRIPTION
This change is a precursor to #1565. It removes the notion of `MutableProviders` and requires a provider be specified when calling mutable functions in the manager. It also allows a 1Password vault to be set at the controller & main.go levels by using `--opvault=VAULT`. To operate on 1P secrets via CLI, continue to use `ftl secret ... --op=VAULT`, but this should eventually change to a bool flag.