### PR TITLE
feat: log http ingress server address

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Once the Hermit environment is activated you can type the following to start a
 hot-reloading ftl agent:
 
 ```
-$ ftl dev ./examples/go
+$ ftl dev --recreate ./examples/go
 ```
 
 ## Development processes

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -138,6 +138,8 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 
 	g, ctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
+		logger.Infof("HTTP ingress server listening on: %s", config.IngressBind)
+
 		return ftlhttp.Serve(ctx, config.IngressBind, ingressHandler)
 	})
 


### PR DESCRIPTION
> [!WARNING]
> Highly controversial PR. 

JK 😄 

I recently bumped ftl in two projects and had to come look at what was merged recently to figure out where the http ingress server is listening. Thought it might be helpful to add an info log that prints the address so that folks know where it's running. 

Feel free to close this out if it's not desired!

```bash
❯ ftl dev --recreate ./examples/go
info: Starting FTL with 1 controller(s)
info:controller0: Web console available at: http://localhost:8892
info:controller0: HTTP ingress server listening on: http://localhost:8891
info: FTL startup command ⚡️
info:time: Building module
info:time: Deploying module
info:echo: Building module
info:echo: Deploying module
info:controller0: Deployed dpl-time-2kwcynci5qht7uyh
info:controller0: Deployed dpl-echo-bzjm9re0dy2kpjq
info: All modules deployed, watching for changes...
```