### PR TITLE
chore: make AWS ASM tests integration tests

### DIFF
--- a/common/configuration/asm_test.go
+++ b/common/configuration/asm_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package configuration
 
 import (


### PR DESCRIPTION
Not because they're slow, but just so we don't need localstack running during day-to-day development.