### PR TITLE
refactor: use declarative naming for topic/subscription functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,8 @@ examples/**/go.work
 examples/**/go.work.sum
 testdata/**/go.work
 testdata/**/go.work.sum
-**/_ftl
-!go-runtime/compile/external-module-template/_ftl
+**/testdata/**/_ftl
+**/examples/**/_ftl
 buildengine/.gitignore
 go.work*
 junit*.xml

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -383,7 +383,7 @@ var scaffoldFuncs = scaffolder.FuncMap{
 	"needsFTLImport": func(m *schema.Module) bool {
 		for _, d := range m.Decls {
 			if topic, ok := d.(*schema.Topic); ok && topic.IsExported() {
-				// uses ftl.RegisterTopic(...) function calls
+				// uses ftl.Topic(...) function calls
 				return true
 			}
 		}

--- a/go-runtime/compile/external-module-template/_ftl/go/modules/{{ range .NonMainModules }}{{ push .Name . }}{{ end }}/external_module.go.tmpl
+++ b/go-runtime/compile/external-module-template/_ftl/go/modules/{{ range .NonMainModules }}{{ push .Name . }}{{ end }}/external_module.go.tmpl
@@ -27,7 +27,7 @@ var _ = context.Background
 {{- end}}
 {{- if .IsExported}}
 {{- if is "Topic" .}}
-var {{.Name|title}} = ftl.RegisterTopic[{{type $ .Event}}]("{{.Name}}")
+var {{.Name|title}} = ftl.Topic[{{type $ .Event}}]("{{.Name}}")
 {{- else if and (is "Enum" .) .IsValueEnum}}
 {{- $enumName := .Name}}
 //ftl:enum

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -43,8 +43,8 @@ var (
 	ftlPostgresDBFuncPath   = "github.com/TBD54566975/ftl/go-runtime/ftl.PostgresDatabase"
 	ftlUnitTypePath         = "github.com/TBD54566975/ftl/go-runtime/ftl.Unit"
 	ftlOptionTypePath       = "github.com/TBD54566975/ftl/go-runtime/ftl.Option"
-	ftlTopicFuncPath        = "github.com/TBD54566975/ftl/go-runtime/ftl.RegisterTopic"
-	ftlSubscriptionFuncPath = "github.com/TBD54566975/ftl/go-runtime/ftl.RegisterSubscription"
+	ftlTopicFuncPath        = "github.com/TBD54566975/ftl/go-runtime/ftl.Topic"
+	ftlSubscriptionFuncPath = "github.com/TBD54566975/ftl/go-runtime/ftl.Subscription"
 	aliasFieldTag           = "json"
 )
 
@@ -334,7 +334,7 @@ func extractStringLiteralArg(node *ast.CallExpr, argIndex int) (string, *schema.
 	return s, nil
 }
 
-// extractTopicDecl expects: _ = ftl.RegisterTopic[EventType]("name_literal")
+// extractTopicDecl expects: _ = ftl.Topic[EventType]("name_literal")
 func extractTopicDecl(pctx *parseContext, node *ast.CallExpr, stack []ast.Node) {
 	name, nameErr := extractStringLiteralArg(node, 0)
 	if nameErr != nil {
@@ -639,7 +639,7 @@ func parseDatabaseDecl(pctx *parseContext, node *ast.CallExpr, dbType string) {
 	pctx.module.Decls = append(pctx.module.Decls, decl)
 }
 
-// parseTopicDecl expects: _ = ftl.RegisterTopic[EventType]("name_literal")
+// parseTopicDecl expects: _ = ftl.Topic[EventType]("name_literal")
 func parseTopicDecl(pctx *parseContext, node *ast.CallExpr) {
 	// already extracted topic in the initial pass of the ast graph
 	// we did not do event type resolution yet, so we need to do that now
@@ -670,7 +670,7 @@ func parseTopicDecl(pctx *parseContext, node *ast.CallExpr) {
 	topic.Event = typeParamType
 }
 
-// parseSubscriptionDecl expects: var _ = ftl.RegisterSubscription(topicHandle, "name_literal")
+// parseSubscriptionDecl expects: var _ = ftl.Subscription(topicHandle, "name_literal")
 func parseSubscriptionDecl(pctx *parseContext, node *ast.CallExpr) {
 	var name string
 	var topicRef *schema.Ref

--- a/go-runtime/compile/testdata/pubsub/pubsub.go
+++ b/go-runtime/compile/testdata/pubsub/pubsub.go
@@ -26,17 +26,17 @@ func ProcessPayin(ctx context.Context, event PayinEvent) error {
 	return nil
 }
 
-var _ = ftl.RegisterSubscription(payinsVar, "paymentProcessing")
+var _ = ftl.Subscription(payinsVar, "paymentProcessing")
 
-var payinsVar = ftl.RegisterTopic[PayinEvent]("payins")
+var payinsVar = ftl.Topic[PayinEvent]("payins")
 
-var _ = ftl.RegisterSubscription(broadcast, "broadcastSubscription")
+var _ = ftl.Subscription(broadcast, "broadcastSubscription")
 
 // publicBroadcast is a topic that broadcasts payin events to the public.
 // out of order with subscription registration to test ordering doesn't matter.
 //
 //ftl:export
-var broadcast = ftl.RegisterTopic[PayinEvent]("publicBroadcast")
+var broadcast = ftl.Topic[PayinEvent]("publicBroadcast")
 
 //ftl:verb
 func Broadcast(ctx context.Context) error {

--- a/go-runtime/compile/testdata/subscriber/subscriber.go
+++ b/go-runtime/compile/testdata/subscriber/subscriber.go
@@ -7,7 +7,7 @@ import (
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 )
 
-var _ = ftl.RegisterSubscription(pubsub.PublicBroadcast, "subscriptionToExternalTopic")
+var _ = ftl.Subscription(pubsub.PublicBroadcast, "subscriptionToExternalTopic")
 
 //ftl:subscribe subscriptionToExternalTopic
 func ConsumesSubscriptionFromExternalTopic(ctx context.Context, req pubsub.PayinEvent) error {

--- a/go-runtime/ftl/pubsub.go
+++ b/go-runtime/ftl/pubsub.go
@@ -6,29 +6,29 @@ import (
 	"github.com/TBD54566975/ftl/go-runtime/internal"
 )
 
-// RegisterTopic declares a topic
+// Topic declares a topic
 //
 // Topics publish events, and subscriptions can listen to them.
-func RegisterTopic[E any](name string) Topic[E] {
-	return Topic[E]{name: name}
+func Topic[E any](name string) TopicHandle[E] {
+	return TopicHandle[E]{name: name}
 }
 
-type Topic[E any] struct {
+type TopicHandle[E any] struct {
 	name string
 }
 
 // Publish publishes an event to a topic
-func (t Topic[E]) Publish(ctx context.Context, event E) error {
+func (t TopicHandle[E]) Publish(ctx context.Context, event E) error {
 	return internal.FromContext(ctx).PublishEvent(ctx, t.name, event)
 }
 
-// RegisterSubscription declares a subscription to a topic
+// Subscription declares a subscription to a topic
 //
 // Sinks can consume events from the subscription by including a "ftl:subscibe <subscription_name>" directive
-func RegisterSubscription[E any](topic Topic[E], name string) Subscription[E] {
-	return Subscription[E]{name: name}
+func Subscription[E any](topic TopicHandle[E], name string) SubscriptionHandle[E] {
+	return SubscriptionHandle[E]{name: name}
 }
 
-type Subscription[E any] struct {
+type SubscriptionHandle[E any] struct {
 	name string
 }


### PR DESCRIPTION
And the types are named TopicHandle/SubscriptionHandle. This aligns more with the existing naming conventions, eg. `Map()` -> `MapHandle`, etc.