### PR TITLE
fix: use path from where vscode was launched

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -25,7 +25,6 @@
       "properties": {
         "ftl.executablePath": {
           "type": "string",
-          "default": "ftl",
           "description": "Path to the FTL executable. Leave as 'ftl' to use the system PATH."
         },
         "ftl.devCommandFlags": {


### PR DESCRIPTION
Fixes #1621

This seems to better identify which ftl to use based on what `which ftl` returns for a given workspace.

> [!NOTE]  
> The path will not be detected correctly if a workspace is changed via File->Open...
