### PR TITLE
fix: start one ingress server per controller

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -84,13 +84,15 @@ func (s *serveCmd) Run(ctx context.Context) error {
 
 	wg, ctx := errgroup.WithContext(ctx)
 
-	bindAllocator, err := bind.NewBindAllocator(s.Bind)
+	bindAllocator, err := bind.NewBindAllocator(s.IngressBind)
 	if err != nil {
 		return err
 	}
 
 	controllerAddresses := make([]*url.URL, 0, s.Controllers)
+	ingressAddresses := make([]*url.URL, 0, s.Controllers)
 	for range s.Controllers {
+		ingressAddresses = append(ingressAddresses, bindAllocator.Next())
 		controllerAddresses = append(controllerAddresses, bindAllocator.Next())
 	}
 
@@ -102,7 +104,7 @@ func (s *serveCmd) Run(ctx context.Context) error {
 		config := controller.Config{
 			CommonConfig: s.CommonConfig,
 			Bind:         controllerAddresses[i],
-			IngressBind:  s.IngressBind,
+			IngressBind:  ingressAddresses[i],
 			Key:          model.NewLocalControllerKey(i),
 			DSN:          dsn,
 		}

--- a/examples/go/echo/go.sum
+++ b/examples/go/echo/go.sum
@@ -4,6 +4,8 @@ connectrpc.com/grpcreflect v1.2.0 h1:Q6og1S7HinmtbEuBvARLNwYmTbhEGRpHDhqrPNlmK+U
 connectrpc.com/grpcreflect v1.2.0/go.mod h1:nwSOKmE8nU5u/CidgHtPYk1PFI3U9ignz7iDMxOYkSY=
 connectrpc.com/otelconnect v0.7.0 h1:ZH55ZZtcJOTKWWLy3qmL4Pam4RzRWBJFOqTPyAqCXkY=
 connectrpc.com/otelconnect v0.7.0/go.mod h1:Bt2ivBymHZHqxvo4HkJ0EwHuUzQN6k2l0oH+mp/8nwc=
+github.com/TBD54566975/scaffolder v1.0.0 h1:QUFSy2wVzumLDg7IHcKC6AP+IYyqWe9Wxiu72nZn5qU=
+github.com/TBD54566975/scaffolder v1.0.0/go.mod h1:auVpczIbOAdIhYDVSruIw41DanxOKB9bSvjf6MEl7Fs=
 github.com/alecthomas/assert/v2 v2.10.0 h1:jjRCHsj6hBJhkmhznrCzoNpbA3zqy0fYiUcYZP/GkPY=
 github.com/alecthomas/assert/v2 v2.10.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/concurrency v0.0.2 h1:Q3kGPtLbleMbH9lHX5OBFvJygfyFw29bXZKBg+IEVuo=
@@ -62,6 +64,8 @@ github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9
 github.com/multiformats/go-base36 v0.2.0/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
 github.com/ncruces/go-strftime v0.1.9 h1:bY0MQC28UADQmHmaF5dgpLmImcShSi2kHU9XLdhx/f4=
 github.com/ncruces/go-strftime v0.1.9/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
+github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=


### PR DESCRIPTION
Fixes #1643

This change will increment the port for each `ingress` and `controller` being created. One ingress server per controller. The result would look something like this (keeping the `8892` and `8891` ports respectively)

```bash
info: Starting FTL with 5 controller(s)
info:controller2: Web console available at: http://localhost:8896
info:controller4: Web console available at: http://localhost:8900
info:controller0: Web console available at: http://localhost:8892
info:controller3: Web console available at: http://localhost:8898
info:controller1: Web console available at: http://localhost:8894
info:controller4: HTTP ingress server listening on: http://localhost:8899
info:controller2: HTTP ingress server listening on: http://localhost:8895
info:controller0: HTTP ingress server listening on: http://localhost:8891
info:controller3: HTTP ingress server listening on: http://localhost:8897
info:controller1: HTTP ingress server listening on: http://localhost:8893
```

