### PR TITLE
fix: remove unused [executables] from ftl-project.toml

### DIFF
--- a/backend/controller/sql/testdata/go/database/ftl-project.toml
+++ b/backend/controller/sql/testdata/go/database/ftl-project.toml
@@ -7,7 +7,4 @@ ftl-min-version = ""
     [modules.database.secrets]
       FTL_DSN_DATABASE_TESTDB = "inline://InBvc3RncmVzOi8vcG9zdGdyZXM6c2VjcmV0QGxvY2FsaG9zdDo1NDMyMC90ZXN0ZGI_c3NsbW9kZT1kaXNhYmxlIg"
 
-[executables]
-  ftl = ""
-
 [commands]

--- a/common/projectconfig/merge.go
+++ b/common/projectconfig/merge.go
@@ -50,9 +50,6 @@ func mergeRootKeys(a, b Config) Config {
 	if b.ExternalDirs != nil {
 		a.ExternalDirs = b.ExternalDirs
 	}
-	if b.Executables.FTL != "" {
-		a.Executables.FTL = b.Executables.FTL
-	}
 	if len(b.Commands.Startup) > 0 {
 		a.Commands.Startup = b.Commands.Startup
 	}

--- a/common/projectconfig/merge_test.go
+++ b/common/projectconfig/merge_test.go
@@ -29,9 +29,6 @@ func TestMerge(t *testing.T) {
 		},
 		ModuleDirs:   []string{"a/b/c"},
 		ExternalDirs: []string{"e/f"},
-		Executables: Executables{
-			FTL: "ftl",
-		},
 		Commands: Commands{
 			Startup: []string{"echo 'Before'"},
 		},
@@ -62,9 +59,6 @@ func TestMerge(t *testing.T) {
 		},
 		ModuleDirs:   []string{"d"},
 		ExternalDirs: []string{"g/h"},
-		Executables: Executables{
-			FTL: "./bin/ftl",
-		},
 		Commands: Commands{
 			Startup: []string{"echo 'After'"},
 		},
@@ -97,9 +91,6 @@ func TestMerge(t *testing.T) {
 		},
 		ModuleDirs:   []string{"d"},
 		ExternalDirs: []string{"g/h"},
-		Executables: Executables{
-			FTL: "./bin/ftl",
-		},
 		Commands: Commands{
 			Startup: []string{"echo 'After'"},
 		},

--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -16,10 +16,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/log"
 )
 
-type Executables struct {
-	FTL string `toml:"ftl"`
-}
-
 type Commands struct {
 	Startup []string `toml:"startup"`
 }
@@ -34,7 +30,6 @@ type Config struct {
 	Modules       map[string]ConfigAndSecrets `toml:"modules"`
 	ModuleDirs    []string                    `toml:"module-dirs"`
 	ExternalDirs  []string                    `toml:"external-dirs"`
-	Executables   Executables                 `toml:"executables"`
 	Commands      Commands                    `toml:"commands"`
 	FTLMinVersion string                      `toml:"ftl-min-version"`
 }

--- a/common/projectconfig/projectconfig_test.go
+++ b/common/projectconfig/projectconfig_test.go
@@ -27,9 +27,6 @@ func TestProjectConfig(t *testing.T) {
 		},
 		ModuleDirs:   []string{"a/b/c", "d"},
 		ExternalDirs: []string{"e/f", "g/h"},
-		Executables: Executables{
-			FTL: "ftl",
-		},
 		Commands: Commands{
 			Startup: []string{"echo 'Executing global pre-build command'"},
 		},

--- a/common/projectconfig/testdata/ftl-project.toml
+++ b/common/projectconfig/testdata/ftl-project.toml
@@ -10,6 +10,3 @@ external-dirs = ["e/f", "g/h"]
 
 [commands]
   startup = ["echo 'Executing global pre-build command'"]
-
-[executables]
-  ftl = "ftl"

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project-test-1.toml
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project-test-1.toml
@@ -6,7 +6,4 @@ ftl-min-version = ""
   [global.secrets]
     secret = "inline://ImJhciI"
 
-[executables]
-  ftl = ""
-
 [commands]

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project-test-2.toml
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project-test-2.toml
@@ -6,7 +6,4 @@ ftl-min-version = ""
   [global.secrets]
     secret = "inline://ImZvb2JhciI"
 
-[executables]
-  ftl = ""
-
 [commands]

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project.toml
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project.toml
@@ -6,7 +6,4 @@ ftl-min-version = ""
   [global.secrets]
     secret = "inline://ImJhemJheiI"
 
-[executables]
-  ftl = ""
-
 [commands]


### PR DESCRIPTION
This is unused since you have to issue `ftl` commands to do anything so we already know where that executable is. We originally added this to be used by extensions, but we can use `settings.json` for that instead.