### PR TITLE
fix: default to root when module-dirs is not set

### DIFF
--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -19,7 +19,7 @@ type buildCmd struct {
 func (b *buildCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
 	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
 	if len(b.Dirs) == 0 && len(b.External) == 0 {
-		b.Dirs = projConfig.MustGetModuleDirs()
+		b.Dirs = projConfig.ModuleDirsOrDefault()
 		b.External = projConfig.ExternalDirs
 	}
 	if len(b.Dirs) == 0 && len(b.External) == 0 {

--- a/cmd/ftl/cmd_build.go
+++ b/cmd/ftl/cmd_build.go
@@ -19,7 +19,7 @@ type buildCmd struct {
 func (b *buildCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
 	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
 	if len(b.Dirs) == 0 && len(b.External) == 0 {
-		b.Dirs = projConfig.ModuleDirs
+		b.Dirs = projConfig.MustGetModuleDirs()
 		b.External = projConfig.ExternalDirs
 	}
 	if len(b.Dirs) == 0 && len(b.External) == 0 {

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -28,7 +28,7 @@ type devCmd struct {
 
 func (d *devCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
 	if len(d.Dirs) == 0 && len(d.External) == 0 {
-		d.Dirs = projConfig.ModuleDirs
+		d.Dirs = projConfig.MustGetModuleDirs()
 		d.External = projConfig.ExternalDirs
 	}
 	if len(d.Dirs) == 0 && len(d.External) == 0 {

--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -28,7 +28,7 @@ type devCmd struct {
 
 func (d *devCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
 	if len(d.Dirs) == 0 && len(d.External) == 0 {
-		d.Dirs = projConfig.MustGetModuleDirs()
+		d.Dirs = projConfig.ModuleDirsOrDefault()
 		d.External = projConfig.ExternalDirs
 	}
 	if len(d.Dirs) == 0 && len(d.External) == 0 {

--- a/common/projectconfig/integration_test.go
+++ b/common/projectconfig/integration_test.go
@@ -32,3 +32,14 @@ func TestCmdsCreateProjectTomlFilesIfNonexistent(t *testing.T) {
 	err = os.Remove(configPath)
 	assert.NoError(t, err)
 }
+
+func TestDefaultToRootWhenModuleDirsMissing(t *testing.T) {
+	in.Run(t, "no-module-dirs-ftl-project.toml",
+		in.CopyModule("echo"),
+		in.Exec("ftl", "build"), // Needs to be `ftl build`, not `ftl build echo`
+		in.Deploy("echo"),
+		in.Call("echo", "echo", in.Obj{"name": "Bob"}, func(t testing.TB, response in.Obj) {
+			assert.Equal(t, "Hello, Bob!", response["message"])
+		}),
+	)
+}

--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -34,6 +34,15 @@ type Config struct {
 	FTLMinVersion string                      `toml:"ftl-min-version"`
 }
 
+// MustGetModuleDirs returns the module-dirs field from the ftl-project.toml, unless that
+// is not defined, in which case it defaults to the root directory.
+func (c Config) MustGetModuleDirs() []string {
+	if len(c.ModuleDirs) > 0 {
+		return c.ModuleDirs
+	}
+	return []string{"."}
+}
+
 // ConfigPaths returns the computed list of configuration paths to load.
 func ConfigPaths(input []string) []string {
 	if len(input) > 0 {

--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -34,9 +34,9 @@ type Config struct {
 	FTLMinVersion string                      `toml:"ftl-min-version"`
 }
 
-// MustGetModuleDirs returns the module-dirs field from the ftl-project.toml, unless that
-// is not defined, in which case it defaults to the root directory.
-func (c Config) MustGetModuleDirs() []string {
+// ModuleDirsOrDefault returns the module-dirs field from the ftl-project.toml, unless
+// that is not defined, in which case it defaults to the root directory.
+func (c Config) ModuleDirsOrDefault() []string {
 	if len(c.ModuleDirs) > 0 {
 		return c.ModuleDirs
 	}

--- a/common/projectconfig/testdata/go/no-module-dirs-ftl-project.toml
+++ b/common/projectconfig/testdata/go/no-module-dirs-ftl-project.toml
@@ -1,0 +1,2 @@
+[commands]
+  startup = ["echo 'Executing global pre-build command'"]


### PR DESCRIPTION
Fixes https://github.com/TBD54566975/ftl/issues/1668

Note that this isn't usable in the `ftl` repo itself because `go-runtime/scaffolding/{{ .Name | camel | lower }}/ftl.toml` confuses the walker, so we do need to specify `examples/go` in our own `ftl-project.toml`. However, the change does WAI in normal repositories that don't have module templates.