### PR TITLE
fix: when using module-dirs from project, make dirs absolute

### DIFF
--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -136,6 +136,21 @@ func loadFile(path string) (Config, error) {
 		}
 		return Config{}, fmt.Errorf("unknown configuration keys: %s", strings.Join(keys, ", "))
 	}
+
+	// make modules-dir absolute to mimic the behavior of the CLI
+	for i, dir := range config.ModuleDirs {
+		if !filepath.IsAbs(dir) {
+			config.ModuleDirs[i] = filepath.Join(filepath.Dir(path), dir)
+		}
+	}
+
+	// make external-dirs absolute to mimic the behavior of the CLI
+	for i, dir := range config.ExternalDirs {
+		if !filepath.IsAbs(dir) {
+			config.ExternalDirs[i] = filepath.Join(filepath.Dir(path), dir)
+		}
+	}
+
 	return config, nil
 }
 

--- a/common/projectconfig/projectconfig_test.go
+++ b/common/projectconfig/projectconfig_test.go
@@ -25,8 +25,8 @@ func TestProjectConfig(t *testing.T) {
 				},
 			},
 		},
-		ModuleDirs:   []string{"a/b/c", "d"},
-		ExternalDirs: []string{"e/f", "g/h"},
+		ModuleDirs:   []string{"testdata/a/b/c", "testdata/d"},
+		ExternalDirs: []string{"testdata/e/f", "testdata/g/h"},
 		Commands: Commands{
 			Startup: []string{"echo 'Executing global pre-build command'"},
 		},


### PR DESCRIPTION
I noticed an issue where the LSP was not clearing the diagnostics correctly for modules when rebuilding.

It turned out that the `module.Dir` was only relative when loaded from the project `toml` vs. absolute when used with `"."` or `ftl dev example/go`. This change makes sure we set the absolute paths on the `config.ModuleDirs` and `config.ExternalDirs` when loading them from `ftl-project.toml` files.

Before this change the `lsp` would try to clear files with the following path. This would result in LSP errors never being cleared.
```bash
lsp: Clearing diagnostics for file:///examples/go/echo
```

This update, ensures that path is absolute
```bash
lsp: Clearing diagnostics for file:///Users/wesbillman/dev/ftl/examples/go/echo
```