### PR TITLE
fix: allow optional values in query params

### DIFF
--- a/backend/controller/ingress/ingress_integration_test.go
+++ b/backend/controller/ingress/ingress_integration_test.go
@@ -53,6 +53,16 @@ func TestHttpIngress(t *testing.T) {
 			assert.Equal(t, map[string]any{}, resp.JsonBody)
 		}),
 
+		in.HttpCall(http.MethodGet, "/queryparams?foo=bar", in.JsonData(t, in.Obj{}), func(t testing.TB, resp *in.HTTPResponse) {
+			assert.Equal(t, 200, resp.Status)
+			assert.Equal(t, "bar", string(resp.BodyBytes))
+		}),
+
+		in.HttpCall(http.MethodGet, "/queryparams", in.JsonData(t, in.Obj{}), func(t testing.TB, resp *in.HTTPResponse) {
+			assert.Equal(t, 200, resp.Status)
+			assert.Equal(t, "No value", string(resp.BodyBytes))
+		}),
+
 		in.HttpCall(http.MethodGet, "/html", in.JsonData(t, in.Obj{}), func(t testing.TB, resp *in.HTTPResponse) {
 			assert.Equal(t, 200, resp.Status)
 			assert.Equal(t, []string{"text/html; charset=utf-8"}, resp.Headers["Content-Type"])

--- a/backend/controller/ingress/ingress_test.go
+++ b/backend/controller/ingress/ingress_test.go
@@ -176,9 +176,9 @@ func TestParseQueryParams(t *testing.T) {
 		{query: "array=2", request: obj{"array": []string{"2"}}},
 		{query: "array=10&array=11", request: obj{"array": []string{"10", "11"}}},
 		{query: "int=10&array=11&array=12", request: obj{"int": "10", "array": []string{"11", "12"}}},
-		{query: "int=1&int=2", request: nil, err: "multiple values for \"int\" are not supported"},
+		{query: "int=1&int=2", request: nil, err: `failed to parse query parameter "int": multiple values are not supported`},
 		{query: "[a,b]=c", request: nil, err: "complex key \"[a,b]\" is not supported, use '@json=' instead"},
-		{query: "array=[1,2]", request: nil, err: "complex value \"[1,2]\" is not supported, use '@json=' instead"},
+		{query: "array=[1,2]", request: nil, err: `failed to parse query parameter "array": complex value "[1,2]" is not supported, use '@json=' instead`},
 	}
 
 	for _, test := range tests {

--- a/backend/controller/ingress/request_test.go
+++ b/backend/controller/ingress/request_test.go
@@ -24,6 +24,10 @@ type PathParameterRequest struct {
 	Username string
 }
 
+type QueryParameterRequest struct {
+	Foo ftl.Option[string] `json:"foo,omitempty"`
+}
+
 type MissingTypes struct {
 	Optional ftl.Option[string] `json:"optional,omitempty"`
 	Array    []string           `json:"array,omitempty"`
@@ -53,6 +57,10 @@ func TestBuildRequestBody(t *testing.T) {
 				aliased String +alias json "alias"
 			}
 
+			data QueryParameterRequest {
+				foo String?
+			}
+
 			data PathParameterRequest {
 				username String
 			}
@@ -74,6 +82,9 @@ func TestBuildRequestBody(t *testing.T) {
 
 			export verb getPath(HttpRequest<test.PathParameterRequest>) HttpResponse<Empty, Empty>
 				+ingress http GET /getPath/{username}
+
+			export verb optionalQuery(HttpRequest<test.QueryParameterRequest>) HttpResponse<Empty, Empty>
+				+ingress http GET /optionalQuery
 
 			export verb postMissingTypes(HttpRequest<test.MissingTypes>) HttpResponse<Empty, Empty>
 				+ingress http POST /postMissingTypes
@@ -140,6 +151,25 @@ func TestBuildRequestBody(t *testing.T) {
 				Method: "POST",
 				Path:   "/postJsonPayload",
 				Body:   PostJSONPayload{Foo: "bar"},
+			},
+		},
+		{name: "OptionalQueryParameter",
+			verb:      "optionalQuery",
+			method:    "GET",
+			path:      "/optionalQuery",
+			routePath: "/optionalQuery",
+			query: map[string][]string{
+				"foo": {"bar"},
+			},
+			expected: HTTPRequest[QueryParameterRequest]{
+				Method: "GET",
+				Path:   "/optionalQuery",
+				Query: map[string][]string{
+					"foo": {"bar"},
+				},
+				Body: QueryParameterRequest{
+					Foo: ftl.Some("bar"),
+				},
 			},
 		},
 		{name: "PathParameterDecoding",

--- a/backend/controller/ingress/testdata/go/httpingress/httpingress.go
+++ b/backend/controller/ingress/testdata/go/httpingress/httpingress.go
@@ -97,6 +97,17 @@ func Delete(ctx context.Context, req builtin.HttpRequest[DeleteRequest]) (builti
 	}, nil
 }
 
+type QueryParamRequest struct {
+	Foo ftl.Option[string] `json:"foo"`
+}
+
+//ftl:ingress http GET /queryparams
+func Query(ctx context.Context, req builtin.HttpRequest[QueryParamRequest]) (builtin.HttpResponse[string, string], error) {
+	return builtin.HttpResponse[string, string]{
+		Body: ftl.Some(req.Body.Foo.Default("No value")),
+	}, nil
+}
+
 type HtmlRequest struct{}
 
 //ftl:ingress http GET /html

--- a/integration/actions.go
+++ b/integration/actions.go
@@ -373,7 +373,9 @@ func HttpCall(method string, path string, body []byte, onResponse func(t testing
 		baseURL, err := url.Parse(fmt.Sprintf("http://localhost:8891"))
 		assert.NoError(t, err)
 
-		r, err := http.NewRequestWithContext(ic, method, baseURL.JoinPath(path).String(), bytes.NewReader(body))
+		u, err := baseURL.Parse(path)
+		assert.NoError(t, err)
+		r, err := http.NewRequestWithContext(ic, method, u.String(), bytes.NewReader(body))
 		assert.NoError(t, err)
 
 		r.Header.Add("Content-Type", "application/json")


### PR DESCRIPTION
Fixes #1686

Here's the test I used:

```go
type GetRequest struct {
	UserID string             `json:"userId"`
	PostID string             `json:"postId"`
	Tag    ftl.Option[string] `json:"tag"`
}

type GetResponse struct {
}

// Example:       curl -i http://localhost:8891/http/users/123/posts?postId=456&tag=foo
//
//ftl:ingress http GET /http/users/{userId}/posts
func Get(ctx context.Context, req builtin.HttpRequest[GetRequest]) (builtin.HttpResponse[GetResponse, string], error) {
	tag := req.Body.Tag.Default("No value")
	ftl.LoggerFromContext(ctx).Infof("Received request with tag: %s", tag)
	return builtin.HttpResponse[GetResponse, string]{
		Headers: map[string][]string{"Get": {"Header from FTL"}},
		Body:    ftl.Some(GetResponse{}),
	}, nil
}
```

```bash
curl -i http://localhost:8891/http/users/123/posts\?postId\=456\&tag\=foo

info:echo: Received request with tag: foo
```