### PR TITLE
fix: check for invalid function calls into external modules

### DIFF
--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -327,7 +327,7 @@ func extractTopicDecl(pctx *parseContext, node *ast.CallExpr, stack []ast.Node) 
 }
 
 func visitCallExpr(pctx *parseContext, node *ast.CallExpr, stack []ast.Node) {
-	validateCallExpr(pctx, node, stack)
+	validateCallExpr(pctx, node)
 
 	_, fn := deref[*types.Func](pctx.pkg, node.Fun)
 	if fn == nil {
@@ -359,12 +359,11 @@ func visitCallExpr(pctx *parseContext, node *ast.CallExpr, stack []ast.Node) {
 // checks if the is directly:
 // - calling external verbs
 // - publishing to an external module's topic
-func validateCallExpr(pctx *parseContext, node *ast.CallExpr, stack []ast.Node) {
+func validateCallExpr(pctx *parseContext, node *ast.CallExpr) {
 	selExpr, ok := node.Fun.(*ast.SelectorExpr)
 	if !ok {
 		return
 	}
-
 	var lhsIdent *ast.Ident
 	if expr, ok := selExpr.X.(*ast.SelectorExpr); ok {
 		lhsIdent = expr.Sel
@@ -373,19 +372,16 @@ func validateCallExpr(pctx *parseContext, node *ast.CallExpr, stack []ast.Node) 
 	} else {
 		return
 	}
-
 	lhsObject := pctx.pkg.TypesInfo.ObjectOf(lhsIdent)
 	if lhsObject == nil {
 		return
 	}
-
 	var lhsPkgPath string
 	if pkgName, ok := lhsObject.(*types.PkgName); ok {
 		lhsPkgPath = pkgName.Imported().Path()
 	} else {
 		lhsPkgPath = lhsObject.Pkg().Path()
 	}
-
 	var lhsIsExternal bool
 	if !pctx.isPathInPkg(lhsPkgPath) {
 		lhsIsExternal = true

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -356,9 +356,9 @@ func visitCallExpr(pctx *parseContext, node *ast.CallExpr, stack []ast.Node) {
 }
 
 // validateCallExpr validates all function calls
-// checks if the is directly:
-// - calling external verbs
-// - publishing to an external module's topic
+// checks if the function call is:
+// - a direct verb call to an external module
+// - a direct publish call on an external module's topic
 func validateCallExpr(pctx *parseContext, node *ast.CallExpr) {
 	selExpr, ok := node.Fun.(*ast.SelectorExpr)
 	if !ok {

--- a/go-runtime/compile/testdata/failing/failing.go
+++ b/go-runtime/compile/testdata/failing/failing.go
@@ -5,6 +5,8 @@ import (
 
 	lib "github.com/TBD54566975/ftl/go-runtime/compile/testdata"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
+
+	ps "ftl/pubsub"
 )
 
 var empty = ftl.Config[string](1)
@@ -159,4 +161,18 @@ func GoodCron(ctx context.Context) error {
 //ftl:cron 0 0 0 0 0
 func BadCron(ctx context.Context) error {
 	return nil
+}
+
+//ftl:verb
+func ExternalPublish(ctx context.Context) error {
+	return ps.PublicBroadcast.Publish(ctx, ps.PayinEvent{Name: "Test"})
+}
+
+//ftl:verb
+func ObfuscatedPublish(ctx context.Context) error {
+	return obfuscatedTopic().Publish(ctx, ps.PayinEvent{Name: "Test"})
+}
+
+func obfuscatedTopic() ftl.TopicHandle[ps.PayinEvent] {
+	return ps.PublicBroadcast
 }

--- a/go-runtime/compile/testdata/failing/failing.go
+++ b/go-runtime/compile/testdata/failing/failing.go
@@ -164,15 +164,7 @@ func BadCron(ctx context.Context) error {
 }
 
 //ftl:verb
-func ExternalPublish(ctx context.Context) error {
-	return ps.PublicBroadcast.Publish(ctx, ps.PayinEvent{Name: "Test"})
-}
-
-//ftl:verb
-func ObfuscatedPublish(ctx context.Context) error {
-	return obfuscatedTopic().Publish(ctx, ps.PayinEvent{Name: "Test"})
-}
-
-func obfuscatedTopic() ftl.TopicHandle[ps.PayinEvent] {
-	return ps.PublicBroadcast
+func BadPublish(ctx context.Context) error {
+	ps.PublicBroadcast.Publish(ctx, ps.PayinEvent{Name: "Test"})
+	return ps.Broadcast(ctx)
 }

--- a/go-runtime/compile/testdata/pubsub/pubsub.go
+++ b/go-runtime/compile/testdata/pubsub/pubsub.go
@@ -38,7 +38,7 @@ var _ = ftl.Subscription(broadcast, "broadcastSubscription")
 //ftl:export
 var broadcast = ftl.Topic[PayinEvent]("publicBroadcast")
 
-//ftl:verb
+//ftl:verb export
 func Broadcast(ctx context.Context) error {
 	if err := broadcast.Publish(ctx, PayinEvent{Name: "Broadcast"}); err != nil {
 		return fmt.Errorf("failed to publish broadcast event: %w", err)


### PR DESCRIPTION
Closes https://github.com/TBD54566975/ftl/issues/1640
Checks for:
- publishing directly to an external module's exported topic
- directly calling an external module's verb, rather than using `ftl.Call(...)`
    - This already fails at runtime, but it's nice to have this as a compile error

Both of these compile-time checks are not fool proof, any indirection will mean these checks don't catch it. But it is good to catch what we can.
eg:
```go
var extTopic = external.Topic
extTopic.Publish(...) // compiler believes this is a local topic
```
Added a separate issue for this for pubsub as it may not be as high a priority: https://github.com/TBD54566975/ftl/issues/1703