### PR TITLE
refactor: pull config from FTL runtime abstraction

### DIFF
--- a/go-runtime/ftl/config.go
+++ b/go-runtime/ftl/config.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
-	"github.com/TBD54566975/ftl/internal/modulecontext"
+	"github.com/TBD54566975/ftl/go-runtime/internal"
 )
 
 // ConfigType is a type that can be used as a configuration value.
@@ -33,7 +33,7 @@ func (c ConfigValue[T]) GoString() string {
 
 // Get returns the value of the configuration key from FTL.
 func (c ConfigValue[T]) Get(ctx context.Context) (out T) {
-	err := modulecontext.FromContext(ctx).GetConfig(c.Name, &out)
+	err := internal.FromContext(ctx).GetConfig(ctx, c.Name, &out)
 	if err != nil {
 		panic(fmt.Errorf("failed to get %s: %w", c, err))
 	}

--- a/go-runtime/ftl/config_test.go
+++ b/go-runtime/ftl/config_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alecthomas/assert/v2"
 
+	"github.com/TBD54566975/ftl/go-runtime/internal"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/modulecontext"
 )
@@ -22,8 +23,7 @@ func TestConfig(t *testing.T) {
 	data, err := json.Marshal(C{"one", "two"})
 	assert.NoError(t, err)
 
-	moduleCtx := modulecontext.NewBuilder("test").AddConfigs(map[string][]byte{"test": data}).Build()
-	ctx = moduleCtx.ApplyToContext(ctx)
+	ctx = internal.WithContext(ctx, internal.New(modulecontext.NewBuilder("test").AddConfigs(map[string][]byte{"test": data}).Build()))
 
 	config := Config[C]("test")
 	assert.Equal(t, C{"one", "two"}, config.Get(ctx))

--- a/go-runtime/ftl/map_test.go
+++ b/go-runtime/ftl/map_test.go
@@ -6,8 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/TBD54566975/ftl/go-runtime/internal"
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/go-runtime/internal"
+	"github.com/TBD54566975/ftl/internal/modulecontext"
 )
 
 type intHandle int
@@ -15,7 +17,7 @@ type intHandle int
 func (s intHandle) Get(ctx context.Context) int { return int(s) }
 
 func TestMapPanic(t *testing.T) {
-	ctx := internal.WithContext(context.Background(), internal.New())
+	ctx := internal.WithContext(context.Background(), internal.New(modulecontext.Empty("test")))
 	n := intHandle(1)
 	once := Map(n, func(ctx context.Context, n int) (string, error) {
 		return "", fmt.Errorf("test error %d", n)
@@ -26,7 +28,7 @@ func TestMapPanic(t *testing.T) {
 }
 
 func TestMapGet(t *testing.T) {
-	ctx := internal.WithContext(context.Background(), internal.New())
+	ctx := internal.WithContext(context.Background(), internal.New(modulecontext.Empty("test")))
 	n := intHandle(1)
 	once := Map(n, func(ctx context.Context, n int) (string, error) {
 		return strconv.Itoa(n), nil

--- a/go-runtime/internal/api.go
+++ b/go-runtime/internal/api.go
@@ -20,6 +20,9 @@ type FTL interface {
 
 	// CallMap calls Get on an instance of an ftl.Map.
 	CallMap(ctx context.Context, mapper any, mapImpl func(context.Context) (any, error)) any
+
+	// GetConfig unmarshals a configuration value into dest.
+	GetConfig(ctx context.Context, name string, dest any) error
 }
 
 type ftlContextKey struct{}

--- a/go-runtime/internal/impl.go
+++ b/go-runtime/internal/impl.go
@@ -13,16 +13,23 @@ import (
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/go-runtime/encoding"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+	"github.com/TBD54566975/ftl/internal/modulecontext"
 	"github.com/TBD54566975/ftl/internal/rpc"
 )
 
 // RealFTL is the real implementation of the [internal.FTL] interface using the Controller.
-type RealFTL struct{}
+type RealFTL struct {
+	mctx modulecontext.ModuleContext
+}
 
 // New creates a new [RealFTL]
-func New() *RealFTL { return &RealFTL{} }
+func New(mctx modulecontext.ModuleContext) *RealFTL { return &RealFTL{mctx: mctx} }
 
 var _ FTL = &RealFTL{}
+
+func (r *RealFTL) GetConfig(ctx context.Context, name string, dest any) error {
+	return r.mctx.GetConfig(name, dest)
+}
 
 func (r *RealFTL) FSMSend(ctx context.Context, fsm, instance string, event any) error {
 	client := rpc.ClientFromContext[ftlv1connect.VerbServiceClient](ctx)

--- a/go-runtime/server/server.go
+++ b/go-runtime/server/server.go
@@ -33,7 +33,6 @@ type UserVerbConfig struct {
 // This function is intended to be used by the code generator.
 func NewUserVerbServer(moduleName string, handlers ...Handler) plugin.Constructor[ftlv1connect.VerbServiceHandler, UserVerbConfig] {
 	return func(ctx context.Context, uc UserVerbConfig) (context.Context, ftlv1connect.VerbServiceHandler, error) {
-		ctx = internal.WithContext(ctx, internal.New())
 		verbServiceClient := rpc.Dial(ftlv1connect.NewVerbServiceClient, uc.FTLEndpoint.String(), log.Error)
 		ctx = rpc.ContextWithClient(ctx, verbServiceClient)
 
@@ -48,6 +47,7 @@ func NewUserVerbServer(moduleName string, handlers ...Handler) plugin.Constructo
 			return nil, nil, err
 		}
 		ctx = moduleCtx.ApplyToContext(ctx)
+		ctx = internal.WithContext(ctx, internal.New(moduleCtx))
 
 		err = observability.Init(ctx, moduleName, "HEAD", uc.ObservabilityConfig)
 		if err != nil {

--- a/internal/modulecontext/module_context.go
+++ b/internal/modulecontext/module_context.go
@@ -40,6 +40,10 @@ type Builder ModuleContext
 
 type contextKeyModuleContext struct{}
 
+func Empty(module string) ModuleContext {
+	return NewBuilder(module).Build()
+}
+
 // NewBuilder creates a new blank Builder for the given module.
 func NewBuilder(module string) *Builder {
 	return &Builder{


### PR DESCRIPTION
This doesn't refactor secrets, but the same pattern can be applied there.

Also switched to forcing a type assertion on `fakeFTL` as it's an invariant of the testing system.

cc @matt2e 