### PR TITLE
fix: use db clock for delaying event consumption

### DIFF
--- a/backend/controller/dal/pubsub.go
+++ b/backend/controller/dal/pubsub.go
@@ -58,7 +58,7 @@ func (d *DAL) ProgressSubscriptions(ctx context.Context, eventConsumptionDelay t
 
 	successful := 0
 	for _, subscription := range subs {
-		nextCursor, err := tx.db.GetNextEventForSubscription(ctx, eventConsumptionDelay.Seconds(), subscription.Topic, subscription.Cursor)
+		nextCursor, err := tx.db.GetNextEventForSubscription(ctx, eventConsumptionDelay, subscription.Topic, subscription.Cursor)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get next cursor: %w", translatePGError(err))
 		}

--- a/backend/controller/dal/pubsub.go
+++ b/backend/controller/dal/pubsub.go
@@ -58,7 +58,7 @@ func (d *DAL) ProgressSubscriptions(ctx context.Context, eventConsumptionDelay t
 
 	successful := 0
 	for _, subscription := range subs {
-		nextCursor, err := tx.db.GetNextEventForSubscription(ctx, float64(eventConsumptionDelay), subscription.Topic, subscription.Cursor)
+		nextCursor, err := tx.db.GetNextEventForSubscription(ctx, eventConsumptionDelay.Seconds(), subscription.Topic, subscription.Cursor)
 		if err != nil {
 			return 0, fmt.Errorf("failed to get next cursor: %w", translatePGError(err))
 		}

--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -63,7 +63,7 @@ type Querier interface {
 	GetIngressRoutes(ctx context.Context, method string) ([]GetIngressRoutesRow, error)
 	GetModuleConfiguration(ctx context.Context, module optional.Option[string], name string) ([]byte, error)
 	GetModulesByID(ctx context.Context, ids []int64) ([]Module, error)
-	GetNextEventForSubscription(ctx context.Context, consumptionDelay float64, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error)
+	GetNextEventForSubscription(ctx context.Context, consumptionDelay time.Duration, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error)
 	GetProcessList(ctx context.Context) ([]GetProcessListRow, error)
 	GetRandomSubscriber(ctx context.Context, key model.SubscriptionKey) (GetRandomSubscriberRow, error)
 	// Retrieve routing information for a runner.

--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -63,7 +63,7 @@ type Querier interface {
 	GetIngressRoutes(ctx context.Context, method string) ([]GetIngressRoutesRow, error)
 	GetModuleConfiguration(ctx context.Context, module optional.Option[string], name string) ([]byte, error)
 	GetModulesByID(ctx context.Context, ids []int64) ([]Module, error)
-	GetNextEventForSubscription(ctx context.Context, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error)
+	GetNextEventForSubscription(ctx context.Context, consumptionDelay float64, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error)
 	GetProcessList(ctx context.Context) ([]GetProcessListRow, error)
 	GetRandomSubscriber(ctx context.Context, key model.SubscriptionKey) (GetRandomSubscriberRow, error)
 	// Retrieve routing information for a runner.

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -717,7 +717,8 @@ WITH cursor AS (
 )
 SELECT events."key" as event,
         events.payload,
-        events.created_at
+        events.created_at,
+        (EXTRACT(EPOCH FROM (NOW() - events.created_at))::double precision >= sqlc.arg('consumption_delay')) AS ready
 FROM topics
 LEFT JOIN topic_events as events ON events.topic_id = topics.id
 WHERE topics.key = sqlc.arg('topic')::topic_key

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -718,7 +718,7 @@ WITH cursor AS (
 SELECT events."key" as event,
         events.payload,
         events.created_at,
-        (EXTRACT(EPOCH FROM (NOW() - events.created_at))::double precision >= sqlc.arg('consumption_delay')) AS ready
+        NOW() - events.created_at >= sqlc.arg('consumption_delay')::interval AS ready
 FROM topics
 LEFT JOIN topic_events as events ON events.topic_id = topics.id
 WHERE topics.key = sqlc.arg('topic')::topic_key

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -1194,7 +1194,7 @@ WITH cursor AS (
 SELECT events."key" as event,
         events.payload,
         events.created_at,
-        (EXTRACT(EPOCH FROM (NOW() - events.created_at))::double precision >= $1) AS ready
+        NOW() - events.created_at >= $1::interval AS ready
 FROM topics
 LEFT JOIN topic_events as events ON events.topic_id = topics.id
 WHERE topics.key = $2::topic_key
@@ -1210,7 +1210,7 @@ type GetNextEventForSubscriptionRow struct {
 	Ready     bool
 }
 
-func (q *Queries) GetNextEventForSubscription(ctx context.Context, consumptionDelay float64, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error) {
+func (q *Queries) GetNextEventForSubscription(ctx context.Context, consumptionDelay time.Duration, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error) {
 	row := q.db.QueryRow(ctx, getNextEventForSubscription, consumptionDelay, topic, cursor)
 	var i GetNextEventForSubscriptionRow
 	err := row.Scan(

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -1189,14 +1189,15 @@ WITH cursor AS (
     created_at,
     id
   FROM topic_events
-  WHERE "key" = $2::topic_event_key
+  WHERE "key" = $3::topic_event_key
 )
 SELECT events."key" as event,
         events.payload,
-        events.created_at
+        events.created_at,
+        (EXTRACT(EPOCH FROM (NOW() - events.created_at))::double precision >= $1) AS ready
 FROM topics
 LEFT JOIN topic_events as events ON events.topic_id = topics.id
-WHERE topics.key = $1::topic_key
+WHERE topics.key = $2::topic_key
   AND (events.created_at, events.id) > (SELECT COALESCE(MAX(cursor.created_at), '1900-01-01'), COALESCE(MAX(cursor.id), 0) FROM cursor)
 ORDER BY events.created_at, events.id
 LIMIT 1
@@ -1206,12 +1207,18 @@ type GetNextEventForSubscriptionRow struct {
 	Event     optional.Option[model.TopicEventKey]
 	Payload   []byte
 	CreatedAt optional.Option[time.Time]
+	Ready     bool
 }
 
-func (q *Queries) GetNextEventForSubscription(ctx context.Context, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error) {
-	row := q.db.QueryRow(ctx, getNextEventForSubscription, topic, cursor)
+func (q *Queries) GetNextEventForSubscription(ctx context.Context, consumptionDelay float64, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error) {
+	row := q.db.QueryRow(ctx, getNextEventForSubscription, consumptionDelay, topic, cursor)
 	var i GetNextEventForSubscriptionRow
-	err := row.Scan(&i.Event, &i.Payload, &i.CreatedAt)
+	err := row.Scan(
+		&i.Event,
+		&i.Payload,
+		&i.CreatedAt,
+		&i.Ready,
+	)
 	return i, err
 }
 


### PR DESCRIPTION
We have a small delay between when a topic event is published and when we allow subscriptions to consume it to guarantee no new events will be inserted in-between.

Previously this check was done by the controller, comparing the db row's created_at with the controller's clock.
It seems there are cases where the controller thinks that enough time has passed, but not according to the db clock.
This PR moves these checks to the db layer. This should make our integration test more reliable as it also relies on comparing two timestamps generated by the db clock.

Example flaky integration test: https://github.com/TBD54566975/ftl/actions/runs/9432792904/job/25983007930#step:8:1
