### PR TITLE
docs: add `Publish` example to pubsub docs

### DIFF
--- a/docs/content/docs/reference/pubsub.md
+++ b/docs/content/docs/reference/pubsub.md
@@ -36,5 +36,11 @@ func SendInvoiceEmail(ctx context.Context, in Invoice) error {
 }
 ```
 
+Events can be published to a topic like so:
+
+```go
+invoicesTopic.Publish(ctx, Invoice{...})
+```
+
 > **NOTE!**
 > PubSub topics cannot be published to from outside the module that declared them, they can only be subscribed to. That is, if a topic is declared in module `A`, module `B` cannot publish to it.


### PR DESCRIPTION
<img width="854" alt="image" src="https://github.com/TBD54566975/ftl/assets/4887440/a54530e5-2335-43f6-b8ea-91fe0b53e6c7">
