### PR TITLE
revert: "fix: add a build.lock file to gate the buildengine (#1670)"

### DIFF
--- a/buildengine/engine_test.go
+++ b/buildengine/engine_test.go
@@ -58,13 +58,3 @@ func TestEngine(t *testing.T) {
 	err = engine.Build(ctx)
 	assert.NoError(t, err)
 }
-
-func TestDissallowMultipleEngines(t *testing.T) {
-	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	engine, err := buildengine.New(ctx, nil, []string{"testdata/projects/alpha"}, nil)
-	assert.NoError(t, err)
-	defer engine.Close()
-
-	_, err = buildengine.New(ctx, nil, []string{"testdata/projects/alpha"}, nil)
-	assert.Error(t, err)
-}


### PR DESCRIPTION
This reverts commit e711523cabbc597ea7acaf0434c9e89106adb263.

```
=== Failed
=== FAIL: buildengine TestDissallowMultipleEngines (0.00s)
    /home/runner/work/ftl/ftl/buildengine/engine_test.go:65: Did not expect an error but got:
        failed to lock file at: /home/runner/.ftl/build.lock

DONE 383 tests, 1 skipped, 1 failure in 115.533s
Error: === RUN   TestDissallowMultipleEngines
    buildengine/engine_test.go:65: Did not expect an error but got:
        failed to lock file at: /home/runner/.ftl/build.lock
```

cc @safeer 

This is occurring because `go test` runs each packages tests in parallel, so multiple tests will be running concurrently and thus multiple build engines.