### PR TITLE
fix: require a project toml for `ftl dev` and `ftl serve`

### DIFF
--- a/cmd/ftl/cmd_dev.go
+++ b/cmd/ftl/cmd_dev.go
@@ -34,6 +34,9 @@ func (d *devCmd) Run(ctx context.Context, projConfig projectconfig.Config) error
 	if len(d.Dirs) == 0 && len(d.External) == 0 {
 		return errors.New("no directories specified")
 	}
+	if len(projConfig.FilePaths()) == 0 {
+		return errors.New("configuration file not found, create an ftl-project.toml file or specify one with -C")
+	}
 
 	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
 
@@ -45,7 +48,7 @@ func (d *devCmd) Run(ctx context.Context, projConfig projectconfig.Config) error
 	}
 	if !d.NoServe {
 		if d.ServeCmd.Stop {
-			err := d.ServeCmd.Run(ctx)
+			err := d.ServeCmd.Run(ctx, projConfig)
 			if err != nil {
 				return err
 			}
@@ -55,7 +58,7 @@ func (d *devCmd) Run(ctx context.Context, projConfig projectconfig.Config) error
 			return errors.New(ftlRunningErrorMsg)
 		}
 
-		g.Go(func() error { return d.ServeCmd.Run(ctx) })
+		g.Go(func() error { return d.ServeCmd.Run(ctx, projConfig) })
 	}
 
 	g.Go(func() error {

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -22,6 +22,7 @@ import (
 	"github.com/TBD54566975/ftl/backend/controller/sql/databasetesting"
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/common/projectconfig"
 	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/container"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -44,7 +45,11 @@ type serveCmd struct {
 const ftlContainerName = "ftl-db-1"
 const ftlRunningErrorMsg = "FTL is already running. Use 'ftl serve --stop' to stop it"
 
-func (s *serveCmd) Run(ctx context.Context) error {
+func (s *serveCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
+	if len(projConfig.FilePaths()) == 0 {
+		return errors.New("configuration file not found, create an ftl-project.toml file or specify one with -C")
+	}
+
 	logger := log.FromContext(ctx)
 	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
 

--- a/common/projectconfig/merge.go
+++ b/common/projectconfig/merge.go
@@ -8,7 +8,7 @@ import (
 //
 // Config is merged left to right, with later files taking precedence over earlier files.
 func Merge(paths ...string) (Config, error) {
-	config := Config{}
+	config := Config{filePaths: paths}
 	for _, path := range paths {
 		partial, err := loadFile(path)
 		if err != nil {


### PR DESCRIPTION
Fixes #1669 by maintaining the list of configuration files that generated a project's `Config`, and adding a non-empty pre-condition for `ftl dev` and `ftl serve`.

This seemed cleaner than plumbing through the ConfigFlag to sub-commands, but I could use another opinion..