### PR TITLE
fix: pubsub schema fixes

### DIFF
--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -746,7 +746,7 @@ func parseSubscriptionDecl(pctx *parseContext, node *ast.CallExpr) {
 	for _, d := range pctx.module.Decls {
 		existing, ok := d.(*schema.Subscription)
 		if ok && existing.Name == name {
-			pctx.errors.add(errorf(node, "duplicate topic registration at %d:%d-%d", existing.Pos.Line, existing.Pos.Column, endCol))
+			pctx.errors.add(errorf(node, "duplicate subscription registration at %d:%d-%d", existing.Pos.Line, existing.Pos.Column, endCol))
 			return
 		}
 	}

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -410,7 +410,7 @@ func validateCallExpr(pctx *parseContext, node *ast.CallExpr) {
 	}
 
 	if lhsIsExternal && strings.HasPrefix(lhsPkgPath, "ftl/") {
-		if _, ok := pctx.pkg.TypesInfo.TypeOf(selExpr.Sel).(*types.Signature); ok {
+		if sig, ok := pctx.pkg.TypesInfo.TypeOf(selExpr.Sel).(*types.Signature); ok && sig.Recv() == nil {
 			// can not call functions in external modules directly
 			pctx.errors.add(errorf(node, "can not call verbs in other modules directly: use ftl.Call(…) instead"))
 		}

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -387,7 +387,7 @@ func validateCallExpr(pctx *parseContext, node *ast.CallExpr) {
 		lhsIsExternal = true
 	}
 
-	if lhsType, ok := pctx.pkg.TypesInfo.TypeOf(selExpr.X).(*types.Named); ok && lhsType.Obj().Pkg().Path() == ftlPkgPath {
+	if lhsType, ok := pctx.pkg.TypesInfo.TypeOf(selExpr.X).(*types.Named); ok && lhsType.Obj().Pkg() != nil && lhsType.Obj().Pkg().Path() == ftlPkgPath {
 		// Calling a function on an FTL type
 		if lhsType.Obj().Name() == ftlTopicHandleTypeName && selExpr.Sel.Name == "Publish" {
 			if lhsIsExternal {

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -286,9 +286,6 @@ func TestExtractModuleSchemaNamedTypes(t *testing.T) {
 		t.SkipNow()
 	}
 	assert.NoError(t, prebuildTestModule(t, "testdata/named", "testdata/namedext"))
-	if testing.Short() {
-		t.SkipNow()
-	}
 	r, err := ExtractModuleSchema("testdata/named", &schema.Schema{})
 	assert.NoError(t, err)
 	assert.Equal(t, nil, r.Errors, "expected no schema errors")
@@ -341,9 +338,6 @@ func TestExtractModuleSchemaParent(t *testing.T) {
 		t.SkipNow()
 	}
 	assert.NoError(t, prebuildTestModule(t, "testdata/parent"))
-	if testing.Short() {
-		t.SkipNow()
-	}
 	r, err := ExtractModuleSchema("testdata/parent", &schema.Schema{})
 	assert.NoError(t, err)
 	assert.Equal(t, nil, r.Errors, "expected no schema errors")
@@ -399,9 +393,6 @@ func TestExtractModuleSubscriber(t *testing.T) {
 		t.SkipNow()
 	}
 	assert.NoError(t, prebuildTestModule(t, "testdata/pubsub", "testdata/subscriber"))
-	if testing.Short() {
-		t.SkipNow()
-	}
 	r, err := ExtractModuleSchema("testdata/subscriber", &schema.Schema{})
 	assert.NoError(t, err)
 	assert.Equal(t, nil, r.Errors, "expected no schema errors")


### PR DESCRIPTION
includes fixes for the following cases:
- fix panic when validating if a call is valid if the call was to an inbuilt type (which has no package)
- fix issue finding a topic's name when declaring a subscription
    - the topic's var has a nil `.Obj` field, possibly because it was defined in a different file. Added a map from variable declaration position to the schema.Topic, and used that instead
- fix issue disambiguating between an illegal direct verb call (eg: `external.DoSomething(ctx)`, and an allowed field access (eg: `external.Data{}.Name`)