### PR TITLE
fix: directive error positions and messages

### DIFF
--- a/go-runtime/compile/parser.go
+++ b/go-runtime/compile/parser.go
@@ -29,6 +29,7 @@ type directiveWrapper struct {
 type directive interface {
 	directive()
 	SetPosition(pos schema.Position)
+	GetPosition() schema.Position
 }
 
 type exportable interface {
@@ -46,6 +47,10 @@ func (*directiveVerb) directive() {}
 
 func (d *directiveVerb) SetPosition(pos schema.Position) {
 	d.Pos = pos
+}
+
+func (d *directiveVerb) GetPosition() schema.Position {
+	return d.Pos
 }
 
 func (d *directiveVerb) String() string {
@@ -71,6 +76,10 @@ func (d *directiveData) SetPosition(pos schema.Position) {
 	d.Pos = pos
 }
 
+func (d *directiveData) GetPosition() schema.Position {
+	return d.Pos
+}
+
 func (d *directiveData) String() string {
 	if d.Export {
 		return "ftl:data export"
@@ -94,6 +103,10 @@ func (d *directiveEnum) SetPosition(pos schema.Position) {
 	d.Pos = pos
 }
 
+func (d *directiveEnum) GetPosition() schema.Position {
+	return d.Pos
+}
+
 func (d *directiveEnum) String() string {
 	if d.Export {
 		return "ftl:enum export"
@@ -115,6 +128,10 @@ func (*directiveTypeAlias) directive() {}
 
 func (d *directiveTypeAlias) SetPosition(pos schema.Position) {
 	d.Pos = pos
+}
+
+func (d *directiveTypeAlias) GetPosition() schema.Position {
+	return d.Pos
 }
 
 func (d *directiveTypeAlias) String() string {
@@ -141,6 +158,10 @@ func (d *directiveIngress) SetPosition(pos schema.Position) {
 	d.Pos = pos
 }
 
+func (d *directiveIngress) GetPosition() schema.Position {
+	return d.Pos
+}
+
 func (d *directiveIngress) String() string {
 	w := &strings.Builder{}
 	fmt.Fprintf(w, "ftl:ingress %s", d.Method)
@@ -162,8 +183,12 @@ func (d *directiveCronJob) SetPosition(pos schema.Position) {
 	d.Pos = pos
 }
 
+func (d *directiveCronJob) GetPosition() schema.Position {
+	return d.Pos
+}
+
 func (d *directiveCronJob) String() string {
-	return fmt.Sprintf("cron %s", d.Cron)
+	return fmt.Sprintf("ftl:cron %s", d.Cron)
 }
 
 type directiveRetry struct {
@@ -178,6 +203,10 @@ func (*directiveRetry) directive() {}
 
 func (d *directiveRetry) SetPosition(pos schema.Position) {
 	d.Pos = pos
+}
+
+func (d *directiveRetry) GetPosition() schema.Position {
+	return d.Pos
 }
 
 func (d *directiveRetry) String() string {
@@ -205,6 +234,10 @@ func (d *directiveSubscriber) SetPosition(pos schema.Position) {
 	d.Pos = pos
 }
 
+func (d *directiveSubscriber) GetPosition() schema.Position {
+	return d.Pos
+}
+
 func (d *directiveSubscriber) String() string {
 	return fmt.Sprintf("subscribe %s", d.Name)
 }
@@ -222,8 +255,12 @@ func (d *directiveExport) SetPosition(pos schema.Position) {
 	d.Pos = pos
 }
 
+func (d *directiveExport) GetPosition() schema.Position {
+	return d.Pos
+}
+
 func (d *directiveExport) String() string {
-	return "export"
+	return "ftl:export"
 }
 
 var directiveParser = participle.MustBuild[directiveWrapper](

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -510,7 +510,7 @@ func TestErrorReporting(t *testing.T) {
 		`21:14-44: duplicate database declaration at 20:14-44`,
 		`24:2-10: unsupported type "error" for field "BadParam"`,
 		`27:2-17: unsupported type "uint64" for field "AnotherBadParam"`,
-		`31:1-2: unexpected directive *compile.directiveExport`,
+		`30:3-0: unexpected directive "ftl:export" attached for verb, did you mean to use '//ftl:verb export' instead`,
 		`36:36-39: unsupported request type "ftl/failing.Request"`,
 		`36:50-50: unsupported response type "ftl/failing.Response"`,
 		`37:16-29: call first argument must be a function but is an unresolved reference to lib.OtherFunc`,


### PR DESCRIPTION
Fixes #1635

I also noticed that the directive errors were being shown on the `func` instead of the location of the directive so added `GetPosition` to directives as well.

![Screenshot 2024-06-12 at 3 52 24 PM](https://github.com/TBD54566975/ftl/assets/51647/d5aaa6d2-2bba-4727-85b2-fd3965bb9ada)

and

![Screenshot 2024-06-12 at 3 53 31 PM](https://github.com/TBD54566975/ftl/assets/51647/a5d60dcb-c67b-4799-8445-529f36cfe724)
