### PR TITLE
test: fix flaky fsm retry test

### DIFF
--- a/backend/controller/dal/testdata/go/fsmretry/fsmretry.go
+++ b/backend/controller/dal/testdata/go/fsmretry/fsmretry.go
@@ -7,7 +7,7 @@ import (
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 )
 
-//ftl:retry 3 1s 3s
+//ftl:retry 2 2s 3s
 var fsm = ftl.FSM("fsm",
 	ftl.Start(State1),
 	ftl.Transition(State1, State2),
@@ -32,7 +32,7 @@ func State1(ctx context.Context, in StartEvent) error {
 }
 
 //ftl:verb
-//ftl:retry 3 1s 1s
+//ftl:retry 2 2s 2s
 func State2(ctx context.Context, in TransitionToTwoEvent) error {
 	return fmt.Errorf("transition will never succeed")
 }


### PR DESCRIPTION
fsm retry test was sometimes failing because the async task was not picked up within the 1s interval that the test expected.
Now the interval is 1.5s. Retries in the test have also been increased to 2s with less retries so that the interval is still less than the retry frequency, and so we aren't approaching the 30s timeout.
Example of flakiness: https://github.com/TBD54566975/ftl/actions/runs/9494930873/job/26166196434?pr=1765#logs