### PR TITLE
fix: add `--insecure` to skip TLS certificate verification

### DIFF
--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -30,6 +30,7 @@ type CLI struct {
 	ConfigFlag string           `name:"config" short:"C" help:"Path to FTL project configuration file." env:"FTL_CONFIG" placeholder:"FILE"`
 
 	Authenticators map[string]string `help:"Authenticators to use for FTL endpoints." mapsep:"," env:"FTL_AUTHENTICATORS" placeholder:"HOST=EXE,…"`
+	Insecure       bool              `help:"Skip TLS certificate verification. Caution: susceptible to machine-in-the-middle attacks."`
 
 	Ping     pingCmd     `cmd:"" help:"Ping the FTL cluster."`
 	Status   statusCmd   `cmd:"" help:"Show FTL status."`
@@ -74,7 +75,7 @@ func main() {
 		},
 	)
 
-	rpc.InitialiseClients(cli.Authenticators)
+	rpc.InitialiseClients(cli.Authenticators, cli.Insecure)
 
 	// Set some envars for child processes.
 	os.Setenv("LOG_LEVEL", cli.LogConfig.Level.String())
@@ -83,6 +84,10 @@ func main() {
 
 	logger := log.Configure(os.Stderr, cli.LogConfig)
 	ctx = log.ContextWithLogger(ctx, logger)
+
+	if cli.Insecure {
+		logger.Warnf("--insecure skips TLS certificate verification")
+	}
 
 	configPath := cli.ConfigFlag
 	if configPath == "" {

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -31,9 +31,8 @@ func InitialiseClients(authenticators map[string]string, allowInsecure bool) {
 	h2cClient = &http.Client{
 		Transport: authn.Transport(&http2.Transport{
 			AllowHTTP: true,
-			// #nosec G402
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: allowInsecure,
+				InsecureSkipVerify: allowInsecure, // #nosec G402
 			},
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
 				conn, err := dialer.Dial(network, addr)
@@ -43,9 +42,8 @@ func InitialiseClients(authenticators map[string]string, allowInsecure bool) {
 	}
 	tlsClient = &http.Client{
 		Transport: authn.Transport(&http2.Transport{
-			// #nosec G402
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: allowInsecure,
+				InsecureSkipVerify: allowInsecure, // #nosec G402
 			},
 			DialTLSContext: func(ctx context.Context, network, addr string, config *tls.Config) (net.Conn, error) {
 				tlsDialer := tls.Dialer{Config: config, NetDialer: dialer}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -31,6 +31,7 @@ func InitialiseClients(authenticators map[string]string, allowInsecure bool) {
 	h2cClient = &http.Client{
 		Transport: authn.Transport(&http2.Transport{
 			AllowHTTP: true,
+			// #nosec G402
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: allowInsecure,
 			},
@@ -42,6 +43,7 @@ func InitialiseClients(authenticators map[string]string, allowInsecure bool) {
 	}
 	tlsClient = &http.Client{
 		Transport: authn.Transport(&http2.Transport{
+			// #nosec G402
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: allowInsecure,
 			},


### PR DESCRIPTION
Fixes #1738