### PR TITLE
fix: provide a better error if go verb isn't upper camel case

### DIFF
--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -1224,6 +1224,11 @@ func visitFuncDecl(pctx *parseContext, node *ast.FuncDecl) (verb *schema.Verb) {
 		return nil
 	}
 
+	if expVerbName := strcase.ToUpperCamel(node.Name.Name); node.Name.Name != expVerbName {
+		pctx.errors.add(errorf(node, "unexpected verb name %q, did you mean to use %q instead?", node.Name.Name, expVerbName))
+		return nil
+	}
+
 	for _, name := range pctx.nativeNames {
 		if name == node.Name.Name {
 			pctx.errors.add(noEndColumnErrorf(node.Pos(), "duplicate verb name %q", node.Name.Name))


### PR DESCRIPTION
Fixes #1742