### PR TITLE
feat: alter semantics for determining a default ftl-project.toml

### DIFF
--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -91,11 +91,9 @@ func main() {
 
 	configPath := cli.ConfigFlag
 	if configPath == "" {
-		var ok bool
-		configPath, ok = projectconfig.DefaultConfigPath().Get()
-		if !ok {
-			kctx.Fatalf("could not determine default config path, either place an ftl-project.toml file in the root of your project, use --config=FILE, or set the FTL_CONFIG envar")
-		}
+		var err error
+		configPath, err = projectconfig.DefaultConfigPath()
+		kctx.FatalIfErrorf(err, "could not determine default ftl-project.toml path")
 	}
 
 	os.Setenv("FTL_CONFIG", configPath)

--- a/common/configuration/projectconfig_resolver_test.go
+++ b/common/configuration/projectconfig_resolver_test.go
@@ -15,8 +15,8 @@ import (
 )
 
 func TestSet(t *testing.T) {
-	defaultPath, ok := projectconfig.DefaultConfigPath().Get()
-	assert.True(t, ok)
+	defaultPath, err := projectconfig.DefaultConfigPath()
+	assert.NoError(t, err)
 	origConfigBytes, err := os.ReadFile(defaultPath)
 	assert.NoError(t, err)
 

--- a/go-runtime/ftl/ftltest/ftltest.go
+++ b/go-runtime/ftl/ftltest/ftltest.go
@@ -78,11 +78,7 @@ func WithProjectFile(path string) Option {
 	// Convert to absolute path immediately in case working directory changes
 	var preprocessingErr error
 	if path == "" {
-		var ok bool
-		path, ok = pc.DefaultConfigPath().Get()
-		if !ok {
-			preprocessingErr = fmt.Errorf("could not find default project file in $FTL_CONFIG or git")
-		}
+		path, preprocessingErr = pc.DefaultConfigPath()
 	}
 	return func(ctx context.Context, state *OptionsState) error {
 		if preprocessingErr != nil {


### PR DESCRIPTION
The rationale here is that if a file is manually created, we want to use it, but we also want to pick a default location when possible.

The semantics are the following:

1. If the `FTL_CONFIG` environment variable is set, it is returned  whether the config file exists or not.
2. Otherwise the parent directories are searched for an existing file.
3. If not found and a git root is present, ${GIT_ROOT}/ftl-project.toml is returned whether the config file exists or not.
4. Finally if not found elsewhere, the current directory is used whether the config file exists or not.

Basically under all circumstances, a config file path will be returned.