### PR TITLE
fix: subscription names not unique

### DIFF
--- a/backend/controller/sql/schema/001_init.sql
+++ b/backend/controller/sql/schema/001_init.sql
@@ -397,7 +397,7 @@ CREATE TABLE topic_subscriptions (
     module_id BIGINT NOT NULL REFERENCES modules(id),
 
     -- Name of the subscription.
-    name TEXT UNIQUE NOT NULL,
+    name TEXT NOT NULL,
 
     -- Cursor pointing into the topic_events table.
     cursor BIGINT REFERENCES topic_events(id) ON DELETE CASCADE,


### PR DESCRIPTION
Was causes db errors deplying modules that use the same name for a subscription