### PR TITLE
fix: parse cron components without panic

### DIFF
--- a/backend/schema/metadatacronjob.go
+++ b/backend/schema/metadatacronjob.go
@@ -11,7 +11,7 @@ import (
 type MetadataCronJob struct {
 	Pos Position `parser:"" protobuf:"1,optional"`
 
-	Cron string `parser:"'+' 'cron' Whitespace @(' ' | ~EOL)*" protobuf:"2"`
+	Cron string `parser:"'+' 'cron' Whitespace @(' ' | ~EOL)+" protobuf:"2"`
 }
 
 var _ Metadata = (*MetadataCronJob)(nil)

--- a/internal/cron/pattern.go
+++ b/internal/cron/pattern.go
@@ -40,7 +40,7 @@ var (
 type Pattern struct {
 	Duration   *string     `parser:"@(Number ('s' | 'm' | 'h'))"`
 	DayOfWeek  *DayOfWeek  `parser:"| @('Mon' | 'Tue' | 'Wed' | 'Thu' | 'Fri' | 'Sat' | 'Sun')"`
-	Components []Component `parser:"| @@*"`
+	Components []Component `parser:"| @@+"`
 }
 
 func (p Pattern) String() string {


### PR DESCRIPTION
Fixes #1807

Was crashing when having random words in each component.