### PR TITLE
feat: improve error propagation for LSP in new schema extractor

### DIFF
--- a/backend/schema/visit.go
+++ b/backend/schema/visit.go
@@ -12,6 +12,18 @@ func Visit(n Node, visit func(n Node, next func() error) error) error {
 	})
 }
 
+// VisitWithParent all nodes in the schema providing the parent node when visiting its schema children.
+func VisitWithParent(n Node, parent Node, visit func(n Node, parent Node, next func() error) error) error {
+	return visit(n, parent, func() error {
+		for _, child := range n.schemaChildren() {
+			if err := VisitWithParent(child, n, visit); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
 // VisitExcludingMetadataChildren visits all nodes in the schema except the children of metadata nodes.
 // This is used when generating external modules to avoid adding imports only referenced in the bodies of
 // stubbed verbs.

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -16,10 +16,9 @@ import (
 	"github.com/alecthomas/types/optional"
 	"golang.org/x/exp/maps"
 
-	"github.com/TBD54566975/ftl/go-runtime/schema/finalize"
-
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/backend/schema/strcase"
+	extract "github.com/TBD54566975/ftl/go-runtime/schema"
 	"github.com/TBD54566975/ftl/internal/goast"
 	"github.com/TBD54566975/golang-tools/go/ast/astutil"
 	"github.com/TBD54566975/golang-tools/go/packages"
@@ -93,7 +92,7 @@ func (e errorSet) add(err *schema.Error) {
 	e[err.Error()] = err
 }
 
-func legacyExtractModuleSchema(dir string, sch *schema.Schema, out *finalize.Result) error {
+func legacyExtractModuleSchema(dir string, sch *schema.Schema, out *extract.Result) error {
 	pkgs, err := packages.Load(&packages.Config{
 		Dir:  dir,
 		Fset: fset,
@@ -1467,7 +1466,7 @@ type parseContext struct {
 	topicsByPos    map[schema.Position]*schema.Topic
 }
 
-func newParseContext(pkg *packages.Package, pkgs []*packages.Package, sch *schema.Schema, out *finalize.Result) *parseContext {
+func newParseContext(pkg *packages.Package, pkgs []*packages.Package, sch *schema.Schema, out *extract.Result) *parseContext {
 	if out.NativeNames == nil {
 		out.NativeNames = NativeNames{}
 	}

--- a/go-runtime/compile/testdata/failing/child/child.go
+++ b/go-runtime/compile/testdata/failing/child/child.go
@@ -1,0 +1,5 @@
+package child
+
+type BadChildStruct struct {
+	Body uint64
+}

--- a/go-runtime/compile/testdata/failing/failing.go
+++ b/go-runtime/compile/testdata/failing/failing.go
@@ -6,6 +6,7 @@ import (
 	lib "github.com/TBD54566975/ftl/go-runtime/compile/testdata"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 
+	"ftl/failing/child"
 	ps "ftl/pubsub"
 )
 
@@ -177,4 +178,9 @@ func BadPublish(ctx context.Context) error {
 //ftl:data
 type UnexportedFieldStruct struct {
 	unexported string
+}
+
+//ftl:data
+type BadChildField struct {
+	Child child.BadChildStruct
 }

--- a/go-runtime/schema/common/common.go
+++ b/go-runtime/schema/common/common.go
@@ -195,24 +195,6 @@ func ExtractType(pass *analysis.Pass, pos token.Pos, tnode types.Type) optional.
 	}
 }
 
-func InferDeclType(pass *analysis.Pass, node ast.Node, obj types.Object) optional.Option[schema.Decl] {
-	ts, ok := node.(*ast.TypeSpec)
-	if !ok {
-		return optional.None[schema.Decl]()
-	}
-	if _, ok := ts.Type.(*ast.InterfaceType); ok {
-		return optional.Some[schema.Decl](&schema.Enum{})
-	}
-	t, ok := ExtractTypeForNode(pass, obj, ts.Type, nil).Get()
-	if !ok {
-		return optional.None[schema.Decl]()
-	}
-	if !IsSelfReference(pass, obj, t) {
-		return optional.Some[schema.Decl](&schema.TypeAlias{})
-	}
-	return optional.Some[schema.Decl](&schema.Data{})
-}
-
 func ExtractFuncForDecl(t schema.Decl) (ExtractDeclFunc[schema.Decl, ast.Node], error) {
 	if f, ok := extractorRegistery.Load(reflect.TypeOf(t)); ok {
 		return f, nil
@@ -468,4 +450,8 @@ func isLocalRef(pass *analysis.Pass, ref *schema.Ref) bool {
 		return false
 	}
 	return ref.Module == "" || ref.Module == moduleName
+}
+
+func GetNativeName(obj types.Object) string {
+	return obj.Pkg().Path() + "." + obj.Name()
 }

--- a/go-runtime/schema/common/fact.go
+++ b/go-runtime/schema/common/fact.go
@@ -176,6 +176,20 @@ func GetFactsForObject[T SchemaFactValue](pass *analysis.Pass, obj types.Object)
 	return facts
 }
 
+func GetFacts[T SchemaFactValue](pass *analysis.Pass) map[types.Object]T {
+	facts := make(map[types.Object]T)
+	for _, fact := range allFactsForPass(pass) {
+		sf, ok := fact.Fact.(SchemaFact)
+		if !ok {
+			continue
+		}
+		if f, ok := sf.Get().(T); ok {
+			facts[fact.Object] = f
+		}
+	}
+	return facts
+}
+
 // GetFactForObject returns the first fact of the provided type marked on the object.
 func GetFactForObject[T SchemaFactValue](pass *analysis.Pass, obj types.Object) optional.Option[T] {
 	for _, fact := range allFactsForPass(pass) {

--- a/go-runtime/schema/metadata/analyzer.go
+++ b/go-runtime/schema/metadata/analyzer.go
@@ -3,6 +3,7 @@ package metadata
 import (
 	"go/ast"
 	"go/token"
+	"go/types"
 	"reflect"
 
 	"github.com/alecthomas/types/optional"
@@ -29,20 +30,29 @@ func Extract(pass *analysis.Pass) (interface{}, error) {
 	}
 	in.Preorder(nodeFilter, func(n ast.Node) {
 		var doc *ast.CommentGroup
+		var name string
 		switch n := n.(type) {
 		case *ast.TypeSpec:
 			doc = n.Doc
+			name = n.Name.Name
 		case *ast.GenDecl:
 			doc = n.Doc
-			if doc == nil && len(n.Specs) > 0 {
-				if ts, ok := n.Specs[0].(*ast.TypeSpec); ok {
+			if ts, ok := n.Specs[0].(*ast.TypeSpec); len(n.Specs) > 0 && ok {
+				if doc == nil {
 					doc = ts.Doc
 				}
+				name = ts.Name.Name
 			}
 		case *ast.FuncDecl:
 			doc = n.Doc
+			name = n.Name.Name
 		}
 		if mdFact, ok := extractMetadata(pass, n, doc).Get(); ok {
+			if prev, ok := getDuplicate(pass, name, mdFact).Get(); ok {
+				common.Errorf(pass, n, "duplicate declaration of %q at %s", name,
+					common.GoPosToSchemaPos(pass.Fset, prev.Pos()))
+			}
+
 			obj, ok := common.GetObjectForNode(pass.TypesInfo, n).Get()
 			if !ok {
 				return
@@ -181,4 +191,13 @@ func isAnnotatingValidGoNode(dir common.Directive, node ast.Node) bool {
 		}
 	}
 	return false
+}
+
+func getDuplicate(pass *analysis.Pass, name string, newMd *common.ExtractedMetadata) optional.Option[types.Object] {
+	for obj, md := range common.GetFacts[*common.ExtractedMetadata](pass) {
+		if reflect.TypeOf(md.Type) == reflect.TypeOf(newMd.Type) && obj.Name() == name {
+			return optional.Some(obj)
+		}
+	}
+	return optional.None[types.Object]()
 }

--- a/go-runtime/schema/typealias/analyzer.go
+++ b/go-runtime/schema/typealias/analyzer.go
@@ -20,6 +20,7 @@ func Extract(pass *analysis.Pass, node *ast.TypeSpec, obj types.Object) optional
 	if !ok {
 		return optional.None[*schema.TypeAlias]()
 	}
+	// type aliases must have an underlying type, and the type cannot be a reference to the alias itself.
 	if common.IsSelfReference(pass, obj, schType) {
 		return optional.None[*schema.TypeAlias]()
 	}
@@ -29,9 +30,6 @@ func Extract(pass *analysis.Pass, node *ast.TypeSpec, obj types.Object) optional
 		Type: schType,
 	}
 	if md, ok := common.GetFactForObject[*common.ExtractedMetadata](pass, obj).Get(); ok {
-		if _, ok := md.Type.(*schema.TypeAlias); !ok {
-			return optional.None[*schema.TypeAlias]()
-		}
 		alias.Comments = md.Comments
 		alias.Export = md.IsExported
 	}

--- a/go-runtime/schema/verb/analyzer.go
+++ b/go-runtime/schema/verb/analyzer.go
@@ -41,11 +41,11 @@ func Extract(pass *analysis.Pass, root *ast.FuncDecl, obj types.Object) optional
 	reqt, respt := checkSignature(pass, root, sig)
 	req := optional.Some[schema.Type](&schema.Unit{})
 	if reqt.Ok() {
-		req = common.ExtractType(pass, root.Pos(), params.At(1).Type())
+		req = common.ExtractType(pass, params.At(1).Pos(), params.At(1).Type())
 	}
 	resp := optional.Some[schema.Type](&schema.Unit{})
 	if respt.Ok() {
-		resp = common.ExtractType(pass, root.Pos(), results.At(0).Type())
+		resp = common.ExtractType(pass, results.At(0).Pos(), results.At(0).Type())
 	}
 	reqV, ok := req.Get()
 	if !ok {


### PR DESCRIPTION
propagate failed extractions in the aggregate `extract.go` rather than via finalize.Analyzer, which is scoped to a single package