### PR TITLE
chore: ensure that errors aren't ignored via _

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -85,6 +85,8 @@ linters-settings:
   gocritic:
     disabled-checks:
       - ifElseChain
+  errcheck:
+    check-blank: true
   depguard:
     rules:
       main:

--- a/authn/authn.go
+++ b/authn/authn.go
@@ -140,7 +140,10 @@ func checkAuth(ctx context.Context, logger *log.Logger, endpoint *url.URL, creds
 	}
 	defer resp.Body.Close() //nolint:gosec
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read response body: %w", err)
+		}
 		logger.Tracef("Endpoint returned %d for authenticated request", resp.StatusCode)
 		logger.Tracef("Response headers: %s", resp.Header)
 		logger.Tracef("Response body: %s", body)

--- a/backend/controller/admin/admin.go
+++ b/backend/controller/admin/admin.go
@@ -56,7 +56,10 @@ func (s *AdminService) ConfigList(ctx context.Context, req *connect.Request[ftlv
 			if err != nil {
 				return nil, err
 			}
-			cv, _ = json.Marshal(value)
+			cv, err = json.Marshal(value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal value for %s: %w", ref, err)
+			}
 		}
 
 		configs = append(configs, &ftlv1.ListConfigResponse_Config{
@@ -139,7 +142,10 @@ func (s *AdminService) SecretsList(ctx context.Context, req *connect.Request[ftl
 			if err != nil {
 				return nil, err
 			}
-			sv, _ = json.Marshal(value)
+			sv, err = json.Marshal(value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal value for %s: %w", ref, err)
+			}
 		}
 		secrets = append(secrets, &ftlv1.ListSecretsResponse_Secret{
 			RefPath: ref,

--- a/backend/controller/cronjobs/cronjobs.go
+++ b/backend/controller/cronjobs/cronjobs.go
@@ -166,7 +166,7 @@ func (s *Service) NewCronJobsForModule(ctx context.Context, module *schemapb.Mod
 // the newly created cron jobs until other controllers have a chance to resync their list of jobs and start sharing responsibility of the new cron jobs.
 func (s *Service) CreatedOrReplacedDeloyment(ctx context.Context, newDeploymentKey model.DeploymentKey) {
 	// Rather than finding old/new cron jobs and updating our state, we can just resync the list of jobs
-	_ = s.syncJobsWithNewDeploymentKey(ctx, optional.Some(newDeploymentKey))
+	_ = s.syncJobsWithNewDeploymentKey(ctx, optional.Some(newDeploymentKey)) //nolint:errcheck // TODO(matt2e) is this valid?
 }
 
 // SyncJobs is run periodically via a scheduled task

--- a/backend/controller/cronjobs/cronjobs_utils_test.go
+++ b/backend/controller/cronjobs/cronjobs_utils_test.go
@@ -205,7 +205,7 @@ func newControllers(ctx context.Context, count int, dal DAL, clockFactory func()
 					Key: ctrl.key,
 				}
 			}))
-			_, _ = s.syncJobs(ctx)
+			_, _ = s.syncJobs(ctx) //nolint:errcheck
 		}()
 	}
 

--- a/backend/controller/dal/dal_test.go
+++ b/backend/controller/dal/dal_test.go
@@ -361,7 +361,8 @@ func TestDAL(t *testing.T) {
 			{Message: optional.Some(Deployment{Language: "go", Module: "test", Schema: &schema.Module{Name: "test"}})},
 			{Message: optional.Some(Deployment{Language: "go", Module: "test", MinReplicas: 1, Schema: &schema.Module{Name: "test"}})},
 		}
-		_ = wg.Wait()
+		err = wg.Wait()
+		assert.NoError(t, err)
 		assert.Equal(t, expectedDeploymentChanges, deploymentChanges,
 			assert.Exclude[model.DeploymentKey](), assert.Exclude[time.Time](), assert.IgnoreGoStringer())
 	})

--- a/backend/controller/sql/conn.go
+++ b/backend/controller/sql/conn.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -86,7 +87,7 @@ func (t *Tx) Rollback(ctx context.Context) error {
 //	}
 func (t *Tx) CommitOrRollback(ctx context.Context, err *error) {
 	if *err != nil {
-		_ = t.Rollback(ctx)
+		*err = errors.Join(*err, t.Rollback(ctx))
 	} else {
 		*err = t.Commit(ctx)
 	}

--- a/backend/controller/sql/databasetesting/devel.go
+++ b/backend/controller/sql/databasetesting/devel.go
@@ -60,8 +60,7 @@ func CreateForDevel(ctx context.Context, dsn string, recreate bool) (*pgxpool.Po
 		}
 	}
 
-	// PG doesn't support "IF NOT EXISTS" so instead we just ignore any error.
-	_, _ = conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %q", config.Database))
+	_, _ = conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %q", config.Database)) //nolint:errcheck // PG doesn't support "IF NOT EXISTS" so instead we just ignore any error.
 
 	err = sql.Migrate(ctx, dsn)
 	if err != nil {

--- a/backend/controller/sql/sqltest/testing.go
+++ b/backend/controller/sql/sqltest/testing.go
@@ -22,7 +22,7 @@ func OpenForTesting(ctx context.Context, t testing.TB) *pgxpool.Pool {
 	lockPath := filepath.Join(os.TempDir(), "ftl-db-test.lock")
 	release, err := flock.Acquire(ctx, lockPath, 10*time.Second)
 	assert.NoError(t, err)
-	t.Cleanup(func() { _ = release() })
+	t.Cleanup(func() { _ = release() }) //nolint:errcheck
 
 	testDSN := "postgres://localhost:15432/ftl-test?user=postgres&password=secret&sslmode=disable"
 	conn, err := databasetesting.CreateForDevel(ctx, testDSN, true)

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -458,7 +458,7 @@ func (s *Service) streamLogsLoop(ctx context.Context, send func(request *ftlv1.S
 
 func (s *Service) getDeploymentLogger(ctx context.Context, deploymentKey model.DeploymentKey) *log.Logger {
 	attrs := map[string]string{"deployment": deploymentKey.String()}
-	if requestKey, _ := rpc.RequestKeyFromContext(ctx); requestKey.Ok() {
+	if requestKey, _ := rpc.RequestKeyFromContext(ctx); requestKey.Ok() { //nolint:errcheck // best effort
 		attrs["request"] = requestKey.MustGet().String()
 	}
 

--- a/backend/schema/fsm.go
+++ b/backend/schema/fsm.go
@@ -46,7 +46,10 @@ func (f *FSM) TerminalStates() []*Ref {
 	}
 	for key := range all {
 		if _, ok := in[key]; !ok {
-			ref, _ := ParseRef(key)
+			ref, err := ParseRef(key)
+			if err != nil {
+				panic(err) // key must be valid
+			}
 			out = append(out, ref)
 		}
 	}

--- a/backend/schema/module.go
+++ b/backend/schema/module.go
@@ -190,7 +190,7 @@ func (m *Module) Data() []*Data {
 // Imports returns the modules imported by this module.
 func (m *Module) Imports() []string {
 	imports := map[string]bool{}
-	_ = Visit(m, func(n Node, next func() error) error {
+	_ = Visit(m, func(n Node, next func() error) error { //nolint:errcheck
 		switch n := n.(type) {
 		case *Ref:
 			if n.Module != "" && n.Module != m.Name {

--- a/backend/schema/normalise.go
+++ b/backend/schema/normalise.go
@@ -7,7 +7,7 @@ import (
 // Normalise clones and normalises (zeroes) positional information in schema Nodes.
 func Normalise[T Node](n T) T {
 	ni := reflect.DeepCopy(n)
-	_ = Visit(ni, func(n Node, next func() error) error {
+	_ = Visit(ni, func(n Node, next func() error) error { //nolint:errcheck
 		switch n := n.(type) {
 		case *Bool:
 			n.Bool = false

--- a/backend/schema/protobuf.go
+++ b/backend/schema/protobuf.go
@@ -95,8 +95,8 @@ func generateStruct(t reflect.Type, messages map[string]string) {
 		if aid == "-" || bid == "-" {
 			return strings.Compare(aid, bid)
 		}
-		an, _ := strconv.Atoi(aid)
-		bn, _ := strconv.Atoi(bid)
+		an, _ := strconv.Atoi(aid) //nolint:errcheck // 0 is fine
+		bn, _ := strconv.Atoi(bid) //nolint:errcheck // 0 is fine
 		return an - bn
 	})
 	// Filter out fields with protobuf tag "-"

--- a/backend/schema/validate.go
+++ b/backend/schema/validate.go
@@ -265,7 +265,7 @@ func ValidateModule(module *Module) error {
 	// Key is <type>:<name>
 	duplicateDecls := map[string]Decl{}
 
-	_ = Visit(module, func(n Node, next func() error) error {
+	_ = Visit(module, func(n Node, next func() error) error { //nolint:errcheck
 		if scoped, ok := n.(Scoped); ok {
 			pop := scopes
 			scopes = scopes.PushScope(scoped.Scope())

--- a/buildengine/build_kotlin.go
+++ b/buildengine/build_kotlin.go
@@ -9,10 +9,11 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/TBD54566975/scaffolder"
 	"github.com/beevik/etree"
 	sets "github.com/deckarep/golang-set/v2"
 	"golang.org/x/exp/maps"
+
+	"github.com/TBD54566975/scaffolder"
 
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/schema"
@@ -156,7 +157,7 @@ var scaffoldFuncs = scaffolder.FuncMap{
 	},
 	"imports": func(m *schema.Module) []string {
 		imports := sets.NewSet[string]()
-		_ = schema.VisitExcludingMetadataChildren(m, func(n schema.Node, next func() error) error {
+		_ = schema.VisitExcludingMetadataChildren(m, func(n schema.Node, next func() error) error { //nolint:errcheck
 			switch n.(type) {
 			case *schema.Data:
 				imports.Add("xyz.block.ftl.Data")

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -133,7 +133,7 @@ func main() {
 		sig := <-sigch
 		logger.Debugf("FTL terminating with signal %s", sig)
 		cancel()
-		_ = syscall.Kill(-syscall.Getpid(), sig.(syscall.Signal)) //nolint:forcetypeassert
+		_ = syscall.Kill(-syscall.Getpid(), sig.(syscall.Signal)) //nolint:forcetypeassert,errcheck // best effort
 		os.Exit(0)
 	}()
 

--- a/common/plugin/serve.go
+++ b/common/plugin/serve.go
@@ -128,7 +128,7 @@ func Start[Impl any, Iface any, Config any](
 		sig := <-sigch
 		logger.Debugf("Terminated by signal %s", sig)
 		cancel()
-		_ = syscall.Kill(-syscall.Getpid(), sig.(syscall.Signal)) //nolint:forcetypeassert
+		_ = syscall.Kill(-syscall.Getpid(), sig.(syscall.Signal)) //nolint:forcetypeassert,errcheck // best effort
 		os.Exit(0)
 	}()
 

--- a/common/plugin/spawn.go
+++ b/common/plugin/spawn.go
@@ -151,7 +151,7 @@ func Spawn[Client PingableClient](
 	defer func() {
 		if err != nil {
 			logger.Warnf("Plugin failed to start, terminating pid %d", cmd.Process.Pid)
-			_ = cmd.Kill(syscall.SIGTERM)
+			_ = cmd.Kill(syscall.SIGTERM) //nolint:errcheck // best effort
 		}
 	}()
 

--- a/frontend/local.go
+++ b/frontend/local.go
@@ -16,7 +16,7 @@ import (
 	"github.com/TBD54566975/ftl/internal/log"
 )
 
-var proxyURL, _ = url.Parse("http://localhost:5173")
+var proxyURL, _ = url.Parse("http://localhost:5173") //nolint:errcheck
 var proxy = httputil.NewSingleHostReverseProxy(proxyURL)
 
 func Server(ctx context.Context, timestamp time.Time, publicURL *url.URL, allowOrigin *url.URL) (http.Handler, error) {

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -262,7 +262,7 @@ var scaffoldFuncs = scaffolder.FuncMap{
 	},
 	"imports": func(m *schema.Module) map[string]string {
 		imports := map[string]string{}
-		_ = schema.VisitExcludingMetadataChildren(m, func(n schema.Node, next func() error) error {
+		_ = schema.VisitExcludingMetadataChildren(m, func(n schema.Node, next func() error) error { //nolint:errcheck
 			switch n := n.(type) {
 			case *schema.Ref:
 				if n.Module == "" || n.Module == m.Name {
@@ -273,7 +273,7 @@ var scaffoldFuncs = scaffolder.FuncMap{
 				for _, tp := range n.TypeParameters {
 					tpRef, err := schema.ParseRef(tp.String())
 					if err != nil {
-						return err
+						panic(err)
 					}
 					if tpRef.Module != "" && tpRef.Module != m.Name {
 						imports[path.Join("ftl", tpRef.Module)] = "ftl" + tpRef.Module
@@ -657,7 +657,7 @@ func updateTransitiveVisibility(d schema.Decl, module *schema.Module) {
 		return
 	}
 
-	_ = schema.Visit(d, func(n schema.Node, next func() error) error {
+	_ = schema.Visit(d, func(n schema.Node, next func() error) error { //nolint:errcheck
 		ref, ok := n.(*schema.Ref)
 		if !ok {
 			return next()

--- a/go-runtime/compile/schema.go
+++ b/go-runtime/compile/schema.go
@@ -1551,7 +1551,7 @@ func (p *parseContext) getDeclForTypeName(name string) optional.Option[schema.De
 }
 
 func (p *parseContext) markAsExported(node schema.Node) {
-	_ = schema.Visit(node, func(n schema.Node, next func() error) error {
+	_ = schema.Visit(node, func(n schema.Node, next func() error) error { //nolint:errcheck
 		if decl, ok := n.(schema.Decl); ok {
 			switch decl := decl.(type) {
 			case *schema.Enum:

--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/TBD54566975/golang-tools/go/packages"
 	"github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/participle/v2/lexer"
+
+	"github.com/TBD54566975/golang-tools/go/packages"
 
 	"github.com/TBD54566975/ftl/backend/schema"
 	extract "github.com/TBD54566975/ftl/go-runtime/schema"
@@ -343,7 +344,7 @@ func TestExtractModuleSchemaParent(t *testing.T) {
 	assert.Equal(t, nil, r.Errors, "expected no schema errors")
 	actual := schema.Normalise(r.Module)
 	expected := `module parent {
-		export typealias ChildAlias String 
+		export typealias ChildAlias String
 
 		export data ChildStruct {
 			name parent.ChildAlias?
@@ -379,7 +380,7 @@ func TestExtractModulePubSub(t *testing.T) {
         export data PayinEvent {
         	name String
         }
-        
+
 		export verb broadcast(Unit) Unit
 
         verb payin(Unit) Unit
@@ -498,12 +499,12 @@ func TestErrorReporting(t *testing.T) {
 		t.SkipNow()
 	}
 
-	// prebuild so we have external_module.go for pubsub module, but ignore these initial errors
-	_ = prebuildTestModule(t, "testdata/failing", "testdata/pubsub")
+	_ = prebuildTestModule(t, "testdata/failing", "testdata/pubsub") //nolint:errcheck // prebuild so we have external_module.go for pubsub module, but ignore these initial errors
 
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	pwd, _ := os.Getwd()
-	err := exec.Command(ctx, log.Debug, "testdata/failing", "go", "mod", "tidy").RunBuffered(ctx)
+	pwd, err := os.Getwd()
+	assert.NoError(t, err)
+	err = exec.Command(ctx, log.Debug, "testdata/failing", "go", "mod", "tidy").RunBuffered(ctx)
 	assert.NoError(t, err)
 	r, err := ExtractModuleSchema("testdata/failing", &schema.Schema{})
 	assert.NoError(t, err)
@@ -578,8 +579,9 @@ func TestValidationFailures(t *testing.T) {
 		t.SkipNow()
 	}
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	pwd, _ := os.Getwd()
-	err := exec.Command(ctx, log.Debug, "testdata/validation", "go", "mod", "tidy").RunBuffered(ctx)
+	pwd, err := os.Getwd()
+	assert.NoError(t, err)
+	err = exec.Command(ctx, log.Debug, "testdata/validation", "go", "mod", "tidy").RunBuffered(ctx)
 	assert.NoError(t, err)
 	_, err = ExtractModuleSchema("testdata/validation", &schema.Schema{})
 	assert.Error(t, err)

--- a/go-runtime/schema/extract.go
+++ b/go-runtime/schema/extract.go
@@ -149,7 +149,7 @@ func updateTransitiveVisibility(d schema.Decl, module *schema.Module) {
 		return
 	}
 
-	_ = schema.Visit(d, func(n schema.Node, next func() error) error {
+	_ = schema.Visit(d, func(n schema.Node, next func() error) error { //nolint:errcheck
 		ref, ok := n.(*schema.Ref)
 		if !ok {
 			return next()
@@ -183,7 +183,7 @@ func updateTransitiveVisibility(d schema.Decl, module *schema.Module) {
 // surfacing errors all the way up the schema chain.
 func propagateTypeErrors(module *schema.Module, failedRefs map[schema.RefKey]types.Object) []*schema.Error {
 	var errs []*schema.Error
-	_ = schema.VisitWithParent(module, nil, func(n schema.Node, p schema.Node, next func() error) error {
+	_ = schema.VisitWithParent(module, nil, func(n schema.Node, p schema.Node, next func() error) error { //nolint:errcheck
 		if p == nil {
 			return next()
 		}

--- a/internal/flock/flock.go
+++ b/internal/flock/flock.go
@@ -32,7 +32,7 @@ func Acquire(ctx context.Context, path string, timeout time.Duration) (release f
 			return nil, fmt.Errorf("failed to acquire lock %s: %w", absPath, err)
 		}
 		if time.Now().After(end) {
-			pid, _ := os.ReadFile(absPath)
+			pid, _ := os.ReadFile(absPath) //nolint:errcheck
 			return nil, fmt.Errorf("timed out acquiring lock %s, locked by pid %s: %w", absPath, pid, err)
 		}
 		select {

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -175,7 +175,10 @@ func RetryStreamingClientStream[Req, Resp any](
 		}
 
 		// We've hit an error.
-		_, _ = stream.CloseAndReceive()
+		_, closeErr := stream.CloseAndReceive()
+		if closeErr != nil {
+			logger.Logf(logLevel, "Failed to close stream: %s", closeErr)
+		}
 
 		errored = true
 		delay := retry.Duration()

--- a/internal/zip_relative.go
+++ b/internal/zip_relative.go
@@ -33,7 +33,10 @@ func ZipRelativeToCaller(relativePath string) *zip.Reader {
 	if err != nil {
 		panic(err)
 	}
-	_, _ = w.Seek(0, 0)
+	_, err = w.Seek(0, 0)
+	if err != nil {
+		panic(err)
+	}
 	zr, err := zip.NewReader(w, info.Size())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Forces use of a `//nolint:errcheck // <reason>` directive, so future me doesn't wonder why I ignored the error.