### PR TITLE
feat: cache asm secrets

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -20,7 +20,6 @@ import (
 	"github.com/alecthomas/types/either"
 	"github.com/alecthomas/types/optional"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jellydator/ttlcache/v3"
 	"github.com/jpillora/backoff"
 	"golang.org/x/exp/maps"
@@ -94,7 +93,7 @@ func (c *Config) SetDefaults() {
 }
 
 // Start the Controller. Blocks until the context is cancelled.
-func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScaling) error {
+func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScaling, dal *dal.DAL) error {
 	config.SetDefaults()
 
 	logger := log.FromContext(ctx)
@@ -113,16 +112,6 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 			return err
 		}
 		logger.Infof("Web console available at: %s", config.Bind)
-	}
-
-	// Bring up the DB connection and DAL.
-	conn, err := pgxpool.New(ctx, config.DSN)
-	if err != nil {
-		return err
-	}
-	dal, err := dal.New(ctx, conn)
-	if err != nil {
-		return err
 	}
 
 	svc, err := New(ctx, dal, config, runnerScaling)

--- a/backend/controller/dal/testdata/go/fsm/go.mod
+++ b/backend/controller/dal/testdata/go/fsm/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/backend/controller/dal/testdata/go/fsm/go.sum
+++ b/backend/controller/dal/testdata/go/fsm/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=

--- a/backend/controller/leader/leader.go
+++ b/backend/controller/leader/leader.go
@@ -173,7 +173,7 @@ func (c *Coordinator[P]) createFollower() (out P, err error) {
 			f.deadline = expiry
 			return f.value, nil
 		}
-		//retire old follower
+		// retire old follower
 		f.cancelCtx()
 		c.follower = optional.None[*follower[P]]()
 	}

--- a/backend/controller/leader/leader_test.go
+++ b/backend/controller/leader/leader_test.go
@@ -121,10 +121,10 @@ func TestSingleLeader(t *testing.T) {
 	ctxSlicesLock.Unlock()
 }
 
-func leaderFromCoordinators(t *testing.T, coordinators []*Coordinator[string]) (idx int, leaderStr string) {
+func leaderFromCoordinators(t *testing.T, coordinators []*Coordinator[string]) (leaderIdx int, leaderStr string) {
 	t.Helper()
 
-	leaderIdx := -1
+	leaderIdx = -1
 	for i := range 5 {
 		result, err := coordinators[i].Get()
 		assert.NoError(t, err)
@@ -135,7 +135,7 @@ func leaderFromCoordinators(t *testing.T, coordinators []*Coordinator[string]) (
 		}
 	}
 	assert.NotEqual(t, -1, leaderIdx)
-	return idx, leaderStr
+	return leaderIdx, leaderStr
 }
 
 func validateAllFollowTheLeader(t *testing.T, coordinators []*Coordinator[string], leaderIdx int) {

--- a/backend/controller/leases/testdata/go/leases/go.mod
+++ b/backend/controller/leases/testdata/go/leases/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/backend/controller/leases/testdata/go/leases/go.sum
+++ b/backend/controller/leases/testdata/go/leases/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=

--- a/backend/controller/sql/testdata/go/database/go.mod
+++ b/backend/controller/sql/testdata/go/database/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/backend/controller/sql/testdata/go/database/go.sum
+++ b/backend/controller/sql/testdata/go/database/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=

--- a/cmd/ftl-controller/main.go
+++ b/cmd/ftl-controller/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/controller"
+	"github.com/TBD54566975/ftl/backend/controller/dal"
 	"github.com/TBD54566975/ftl/backend/controller/scaling"
 	cf "github.com/TBD54566975/ftl/common/configuration"
 	cfdal "github.com/TBD54566975/ftl/common/configuration/dal"
@@ -47,10 +48,13 @@ func main() {
 	// The FTL controller currently only supports DB as a configuration provider/resolver.
 	conn, err := pgxpool.New(ctx, cli.ControllerConfig.DSN)
 	kctx.FatalIfErrorf(err)
-	dal, err := cfdal.New(ctx, conn)
+	dal, err := dal.New(ctx, conn)
 	kctx.FatalIfErrorf(err)
-	configProviders := []cf.Provider[cf.Configuration]{cf.NewDBConfigProvider(dal)}
-	configResolver := cf.NewDBConfigResolver(dal)
+
+	configDal, err := cfdal.New(ctx, conn)
+	kctx.FatalIfErrorf(err)
+	configProviders := []cf.Provider[cf.Configuration]{cf.NewDBConfigProvider(configDal)}
+	configResolver := cf.NewDBConfigResolver(configDal)
 	cm, err := cf.New[cf.Configuration](ctx, configResolver, configProviders)
 	kctx.FatalIfErrorf(err)
 

--- a/common/configuration/asm.go
+++ b/common/configuration/asm.go
@@ -48,7 +48,7 @@ func newASMForTesting(ctx context.Context, secretsClient *secretsmanager.Client,
 	}
 	followerFactory := func(ctx context.Context, url *url.URL) (client asmClient, err error) {
 		rpcClient := rpc.Dial(ftlv1connect.NewAdminServiceClient, url.String(), log.Error)
-		return &asmFollower{client: rpcClient}, nil
+		return newASMFollower(ctx, rpcClient, clock), nil
 	}
 	return &ASM{
 		coordinator: leader.NewCoordinator[asmClient](

--- a/common/configuration/asm.go
+++ b/common/configuration/asm.go
@@ -2,28 +2,61 @@ package configuration
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
+	"time"
 
-	"github.com/TBD54566975/ftl/internal/slices"
+	"github.com/TBD54566975/ftl/internal/rpc"
 
-	. "github.com/alecthomas/types/optional" //nolint:stylecheck
-	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/TBD54566975/ftl/backend/controller/leader"
+	"github.com/TBD54566975/ftl/backend/controller/leases"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/internal/log"
+
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
-	"github.com/aws/smithy-go"
 )
 
+type asmClient interface {
+	list(ctx context.Context) ([]Entry, error)
+	load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error)
+	store(ctx context.Context, ref Ref, value []byte) (*url.URL, error)
+	delete(ctx context.Context, ref Ref) error
+}
+
 // ASM implements Resolver and Provider for AWS Secrets Manager (ASM).
+// Only supports loading "string" secrets, not binary secrets.
 //
 // The resolver does a direct/proxy map from a Ref to a URL, module.name <-> asm://module.name and does not access ASM at all.
+//
+// One controller is elected as the leader and is responsible for syncing the cache of secrets from ASM (see asmLeader).
+// Others get secrets from the leader via AdminService (see asmFollower).
 type ASM struct {
-	Client secretsmanager.Client
+	coordinator *leader.Coordinator[asmClient]
 }
 
 var _ Resolver[Secrets] = &ASM{}
 var _ Provider[Secrets] = &ASM{}
+
+func NewASM(ctx context.Context, secretsClient *secretsmanager.Client, advertise *url.URL, leaser leases.Leaser) *ASM {
+	leaderFactory := func(ctx context.Context) (asmClient, error) {
+		return newASMLeader(ctx, secretsClient), nil
+	}
+	followerFactory := func(ctx context.Context, url *url.URL) (client asmClient, err error) {
+		rpcClient := rpc.Dial(ftlv1connect.NewAdminServiceClient, url.String(), log.Error)
+		return &asmFollower{client: rpcClient}, nil
+	}
+	return &ASM{
+		coordinator: leader.NewCoordinator[asmClient](
+			ctx,
+			advertise,
+			leases.SystemKey("asm"),
+			leaser,
+			time.Second*10,
+			leaderFactory,
+			followerFactory,
+		),
+	}
+}
 
 func asmURLForRef(ref Ref) *url.URL {
 	return &url.URL{
@@ -53,110 +86,41 @@ func (ASM) Set(ctx context.Context, ref Ref, key *url.URL) error {
 	return nil
 }
 
-// Unset does nothing because this resolver does not record any state.
 func (ASM) Unset(ctx context.Context, ref Ref) error {
+	// removing a secret is handled in Delete()
 	return nil
 }
 
-// List all secrets in the account. This might require multiple calls to the AWS API if there are more than 100 secrets.
-func (a ASM) List(ctx context.Context) ([]Entry, error) {
-	nextToken := None[string]()
-	entries := []Entry{}
-	for {
-		out, err := a.Client.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
-			MaxResults: aws.Int32(100),
-			NextToken:  nextToken.Ptr(),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("unable to list secrets: %w", err)
-		}
-
-		var activeSecrets = slices.Filter(out.SecretList, func(s types.SecretListEntry) bool {
-			return s.DeletedDate == nil
-		})
-		page, err := slices.MapErr(activeSecrets, func(s types.SecretListEntry) (Entry, error) {
-			var ref Ref
-			ref, err = ParseRef(*s.Name)
-			if err != nil {
-				return Entry{}, fmt.Errorf("unable to parse ref: %w", err)
-			}
-
-			return Entry{
-				Ref:      ref,
-				Accessor: asmURLForRef(ref),
-			}, nil
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		entries = append(entries, page...)
-
-		nextToken = Ptr[string](out.NextToken)
-		if !nextToken.Ok() {
-			break
-		}
+// List all secrets in the account
+func (a *ASM) List(ctx context.Context) ([]Entry, error) {
+	client, err := a.coordinator.Get()
+	if err != nil {
+		return nil, err
 	}
-
-	return entries, nil
+	return client.list(ctx)
 }
 
-// Load only supports loading "string" secrets, not binary secrets.
-func (a ASM) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
-	expectedKey := asmURLForRef(ref)
-	if key.String() != expectedKey.String() {
-		return nil, fmt.Errorf("key does not match expected key for ref: %s", expectedKey)
-	}
-
-	out, err := a.Client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
-		SecretId: aws.String(ref.String()),
-	})
+func (a *ASM) Load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
+	client, err := a.coordinator.Get()
 	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve secret: %w", err)
+		return nil, err
 	}
-
-	// Secret is a string
-	if out.SecretBinary != nil {
-		return nil, fmt.Errorf("secret is not a string")
-	}
-
-	return []byte(*out.SecretString), nil
+	return client.load(ctx, ref, key)
 }
 
 // Store and if the secret already exists, update it.
-func (a ASM) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
-	_, err := a.Client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-		Name:         aws.String(ref.String()),
-		SecretString: aws.String(string(value)),
-	})
-
-	// https://github.com/aws/aws-sdk-go-v2/issues/1110#issuecomment-1054643716
-	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "ResourceExistsException" {
-		_, err = a.Client.UpdateSecret(ctx, &secretsmanager.UpdateSecretInput{
-			SecretId:     aws.String(ref.String()),
-			SecretString: aws.String(string(value)),
-		})
-		if err != nil {
-			return nil, fmt.Errorf("unable to update secret: %w", err)
-		}
-
-	} else if err != nil {
-		return nil, fmt.Errorf("unable to store secret: %w", err)
+func (a *ASM) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+	client, err := a.coordinator.Get()
+	if err != nil {
+		return nil, err
 	}
-
-	return asmURLForRef(ref), nil
+	return client.store(ctx, ref, value)
 }
 
-func (a ASM) Delete(ctx context.Context, ref Ref) error {
-	var t = true
-	_, err := a.Client.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
-		SecretId:                   aws.String(ref.String()),
-		ForceDeleteWithoutRecovery: &t,
-	})
+func (a *ASM) Delete(ctx context.Context, ref Ref) error {
+	client, err := a.coordinator.Get()
 	if err != nil {
-		return fmt.Errorf("unable to delete secret: %w", err)
+		return err
 	}
-
-	return nil
+	return client.delete(ctx, ref)
 }

--- a/common/configuration/asm.go
+++ b/common/configuration/asm.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/TBD54566975/ftl/internal/rpc"
+	"github.com/benbjohnson/clock"
 
 	"github.com/TBD54566975/ftl/backend/controller/leader"
 	"github.com/TBD54566975/ftl/backend/controller/leases"
@@ -38,8 +39,12 @@ var _ Resolver[Secrets] = &ASM{}
 var _ Provider[Secrets] = &ASM{}
 
 func NewASM(ctx context.Context, secretsClient *secretsmanager.Client, advertise *url.URL, leaser leases.Leaser) *ASM {
+	return newASMForTesting(ctx, secretsClient, advertise, leaser, clock.New())
+}
+
+func newASMForTesting(ctx context.Context, secretsClient *secretsmanager.Client, advertise *url.URL, leaser leases.Leaser, clock clock.Clock) *ASM {
 	leaderFactory := func(ctx context.Context) (asmClient, error) {
-		return newASMLeader(ctx, secretsClient), nil
+		return newASMLeader(ctx, secretsClient, clock), nil
 	}
 	followerFactory := func(ctx context.Context, url *url.URL) (client asmClient, err error) {
 		rpcClient := rpc.Dial(ftlv1connect.NewAdminServiceClient, url.String(), log.Error)

--- a/common/configuration/asm_follower.go
+++ b/common/configuration/asm_follower.go
@@ -1,0 +1,97 @@
+package configuration
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"connectrpc.com/connect"
+	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/alecthomas/types/optional"
+)
+
+// asmFollower uses AdminService to get/set secrets from the leader
+type asmFollower struct {
+	client ftlv1connect.AdminServiceClient
+}
+
+var _ asmClient = &asmFollower{}
+
+func (f *asmFollower) list(ctx context.Context) ([]Entry, error) {
+	module := ""
+	includeValues := false
+	resp, err := f.client.SecretsList(ctx, connect.NewRequest(&ftlv1.ListSecretsRequest{
+		Module:        &module,
+		IncludeValues: &includeValues,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	entries := []Entry{}
+	for _, s := range resp.Msg.Secrets {
+		components := strings.Split(s.RefPath, ".")
+		var ref Ref
+		switch len(components) {
+		case 1:
+			ref = Ref{
+				Name: components[0],
+			}
+		case 2:
+			ref = Ref{
+				Module: optional.Some(components[0]),
+				Name:   components[1],
+			}
+		default:
+			return nil, fmt.Errorf("invalid ref path: %s", s.RefPath)
+		}
+		entries = append(entries, Entry{
+			Ref:      ref,
+			Accessor: asmURLForRef(ref),
+		})
+	}
+
+	return entries, nil
+}
+
+func (f *asmFollower) load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
+	resp, err := f.client.SecretGet(ctx, connect.NewRequest(&ftlv1.GetSecretRequest{
+		Ref: &ftlv1.ConfigRef{
+			Module: ref.Module.Ptr(),
+			Name:   ref.Name,
+		},
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg.Value, nil
+}
+
+func (f *asmFollower) store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+	provider := ftlv1.SecretProvider_SECRET_ASM
+	_, err := f.client.SecretSet(ctx, connect.NewRequest(&ftlv1.SetSecretRequest{
+		Provider: &provider,
+		Ref: &ftlv1.ConfigRef{
+			Module: ref.Module.Ptr(),
+			Name:   ref.Name,
+		},
+		Value: value,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return asmURLForRef(ref), nil
+}
+
+func (f *asmFollower) delete(ctx context.Context, ref Ref) error {
+	provider := ftlv1.SecretProvider_SECRET_ASM
+	_, err := f.client.SecretUnset(ctx, connect.NewRequest(&ftlv1.UnsetSecretRequest{
+		Provider: &provider,
+		Ref: &ftlv1.ConfigRef{
+			Module: ref.Module.Ptr(),
+			Name:   ref.Name,
+		},
+	}))
+	return err
+}

--- a/common/configuration/asm_follower.go
+++ b/common/configuration/asm_follower.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"connectrpc.com/connect"
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
-	"github.com/alecthomas/types/optional"
 )
 
 // asmFollower uses AdminService to get/set secrets from the leader
@@ -31,20 +29,9 @@ func (f *asmFollower) list(ctx context.Context) ([]Entry, error) {
 	}
 	entries := []Entry{}
 	for _, s := range resp.Msg.Secrets {
-		components := strings.Split(s.RefPath, ".")
-		var ref Ref
-		switch len(components) {
-		case 1:
-			ref = Ref{
-				Name: components[0],
-			}
-		case 2:
-			ref = Ref{
-				Module: optional.Some(components[0]),
-				Name:   components[1],
-			}
-		default:
-			return nil, fmt.Errorf("invalid ref path: %s", s.RefPath)
+		ref, err := ParseRef(s.RefPath)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ref %q: %w", s.RefPath, err)
 		}
 		entries = append(entries, Entry{
 			Ref:      ref,

--- a/common/configuration/asm_leader.go
+++ b/common/configuration/asm_leader.go
@@ -5,123 +5,43 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"sync"
 	"time"
 
 	"github.com/benbjohnson/clock"
 	"github.com/puzpuzpuz/xsync/v3"
 
-	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/slices"
 	"github.com/alecthomas/types/optional"
-	"github.com/alecthomas/types/pubsub"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/aws/smithy-go"
 )
 
-const (
-	syncInterval       = time.Minute * 5
-	syncInitialBackoff = time.Second * 5
-	loadSecretsTimeout = time.Second * 5
-)
-
-type asmSecretValue struct {
-	value []byte
-
-	// lastModified is retrieved from ASM when syncing.
-	// it is nil when our cache is updated after writing to ASM (lastModified is not returned when writing),
-	// until the next sync refetches it from ASM
-	lastModified optional.Option[time.Time]
-}
-
-type updateASMSecretEvent struct {
-	ref Ref
-	// value is nil when the secret was deleted
-	value optional.Option[[]byte]
-}
+const asmLeaderSyncInterval = time.Minute * 5
 
 type asmLeader struct {
 	client *secretsmanager.Client
-
-	// indicates if the initial sync with ASM has finished
-	loaded chan bool
-
-	// secrets is a map of secrets that have been loaded from ASM.
-	// optional is nil when not loaded yet
-	// it is updated via:
-	// - polling ASM
-	// - when we write to ASM
-	secrets *xsync.MapOf[Ref, asmSecretValue]
-
-	topic *pubsub.Topic[updateASMSecretEvent]
-	// used by tests to wait for events to be processed
-	topicWaitGroup sync.WaitGroup
+	cache  *secretsCache
 }
 
 var _ asmClient = &asmLeader{}
 
 func newASMLeader(ctx context.Context, client *secretsmanager.Client, clock clock.Clock) *asmLeader {
 	l := &asmLeader{
-		client:  client,
-		secrets: xsync.NewMapOf[Ref, asmSecretValue](),
-		topic:   pubsub.New[updateASMSecretEvent](),
-		loaded:  make(chan bool),
+		client: client,
+		cache:  newSecretsCache(),
 	}
-	go func() {
-		l.watchForUpdates(ctx, clock)
-	}()
+	go l.cache.sync(ctx, asmLeaderSyncInterval, func(ctx context.Context, secrets *xsync.MapOf[Ref, cachedSecret]) error {
+		return l.sync(ctx, secrets)
+	}, clock)
 	return l
 }
 
-func (l *asmLeader) watchForUpdates(ctx context.Context, clock clock.Clock) {
-	logger := log.FromContext(ctx)
-	events := make(chan updateASMSecretEvent, 64)
-	l.topic.Subscribe(events)
-	defer l.topic.Unsubscribe(events)
-
-	nextSync := clock.Now()
-	backOff := syncInitialBackoff
-	loaded := false
-	for {
-		select {
-		case <-ctx.Done():
-			return
-
-		case e := <-events:
-			if loaded {
-				l.processEvent(e)
-			}
-
-		case <-clock.After(clock.Until(nextSync)):
-			nextSync = clock.Now().Add(syncInterval)
-
-			err := l.sync(ctx)
-			if err == nil {
-				backOff = syncInitialBackoff
-				if !loaded {
-					loaded = true
-					close(l.loaded)
-				}
-				continue
-			}
-			// back off if we fail to sync
-			logger.Warnf("Unable to sync ASM secrets: %v", err)
-			nextSync = clock.Now().Add(backOff)
-			if nextSync.After(clock.Now().Add(syncInterval)) {
-				nextSync = clock.Now().Add(syncInterval)
-			} else {
-				backOff *= 2
-			}
-		}
-	}
-}
-
 // sync retrieves all secrets from ASM and updates the cache
-func (l *asmLeader) sync(ctx context.Context) error {
-	previous := map[Ref]asmSecretValue{}
-	l.secrets.Range(func(ref Ref, value asmSecretValue) bool {
+func (l *asmLeader) sync(ctx context.Context, secrets *xsync.MapOf[Ref, cachedSecret]) error {
+	previous := map[Ref]cachedSecret{}
+	secrets.Range(func(ref Ref, value cachedSecret) bool {
 		previous[ref] = value
 		return true
 	})
@@ -150,7 +70,7 @@ func (l *asmLeader) sync(ctx context.Context) error {
 			seen[ref] = true
 
 			// check if we already have the value from previous sync
-			if pValue, ok := previous[ref]; ok && pValue.lastModified == optional.Some(*s.LastChangedDate) {
+			if pValue, ok := previous[ref]; ok && pValue.versionToken == optional.Some[any](*s.LastChangedDate) {
 				continue
 			}
 			refsToLoad[ref] = *s.LastChangedDate
@@ -165,7 +85,7 @@ func (l *asmLeader) sync(ctx context.Context) error {
 	// remove secrets not found in ASM
 	for ref := range previous {
 		if _, ok := seen[ref]; !ok {
-			l.secrets.Delete(ref)
+			secrets.Delete(ref)
 		}
 	}
 
@@ -195,9 +115,9 @@ func (l *asmLeader) sync(ctx context.Context) error {
 				return fmt.Errorf("secret for %s is not a string", ref)
 			}
 			data := []byte(*s.SecretString)
-			l.secrets.Store(ref, asmSecretValue{
+			secrets.Store(ref, cachedSecret{
 				value:        data,
-				lastModified: optional.Some(refsToLoad[ref]),
+				versionToken: optional.Some[any](refsToLoad[ref]),
 			})
 			delete(refsToLoad, ref)
 		}
@@ -205,68 +125,23 @@ func (l *asmLeader) sync(ctx context.Context) error {
 	return nil
 }
 
-// processEvent updates the cache after writes to ASM
-func (l *asmLeader) processEvent(e updateASMSecretEvent) {
-	// waitGroup updated so testing can wait for events to be processed
-	defer l.topicWaitGroup.Done()
-
-	if data, ok := e.value.Get(); ok {
-		// updated value
-		l.secrets.Store(e.ref, asmSecretValue{
-			value:        data,
-			lastModified: optional.None[time.Time](),
-		})
-	} else {
-		// removed value
-		l.secrets.Delete(e.ref)
-	}
-}
-
-// publishes an event to update the cache
-//
-// Called after writing to ASM.
-// Wrapped in a method to ensure we always update topicWaitGroup
-func (l *asmLeader) publish(event updateASMSecretEvent) {
-	l.topicWaitGroup.Add(1)
-	l.topic.Publish(event)
-}
-
-// waitForSecrets waits until the initial sync of secrets has completed.
-//
-// If secrets have not yet been synced, this will retry until they are, returning an error if it takes too long.
-func (l *asmLeader) waitForSecrets() error {
-	select {
-	case <-time.After(loadSecretsTimeout):
-		return errors.New("secrets not synced from ASM yet")
-	case <-l.loaded:
-		return nil
-	}
-}
-
 // list all secrets in the account.
 func (l *asmLeader) list(ctx context.Context) ([]Entry, error) {
-	if err := l.waitForSecrets(); err != nil {
-		return nil, err
-	}
 	entries := []Entry{}
-	l.secrets.Range(func(ref Ref, value asmSecretValue) bool {
+	err := l.cache.iterate(func(ref Ref, _ []byte) {
 		entries = append(entries, Entry{
 			Ref:      ref,
 			Accessor: asmURLForRef(ref),
 		})
-		return true
 	})
+	if err != nil {
+		return nil, err
+	}
 	return entries, nil
 }
 
 func (l *asmLeader) load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
-	if err := l.waitForSecrets(); err != nil {
-		return nil, err
-	}
-	if v, ok := l.secrets.Load(ref); ok {
-		return v.value, nil
-	}
-	return nil, fmt.Errorf("secret not found: %s", ref)
+	return l.cache.getSecret(ref)
 }
 
 // store and if the secret already exists, update it.
@@ -290,10 +165,7 @@ func (l *asmLeader) store(ctx context.Context, ref Ref, value []byte) (*url.URL,
 	} else if err != nil {
 		return nil, fmt.Errorf("unable to store secret: %w", err)
 	}
-	l.publish(updateASMSecretEvent{
-		ref:   ref,
-		value: optional.Some(value),
-	})
+	l.cache.updatedSecret(ref, value)
 	return asmURLForRef(ref), nil
 }
 
@@ -306,9 +178,6 @@ func (l *asmLeader) delete(ctx context.Context, ref Ref) error {
 	if err != nil {
 		return fmt.Errorf("unable to delete secret: %w", err)
 	}
-	l.publish(updateASMSecretEvent{
-		ref:   ref,
-		value: optional.None[[]byte](),
-	})
+	l.cache.deletedSecret(ref)
 	return nil
 }

--- a/common/configuration/asm_leader.go
+++ b/common/configuration/asm_leader.go
@@ -107,7 +107,7 @@ func (l *asmLeader) watchForUpdates(ctx context.Context, clock clock.Clock) {
 				continue
 			}
 			// back off if we fail to sync
-			logger.Warnf("unable to sync ASM secrets: %v", err)
+			logger.Warnf("Unable to sync ASM secrets: %v", err)
 			nextSync = clock.Now().Add(backOff)
 			if nextSync.After(clock.Now().Add(syncInterval)) {
 				nextSync = clock.Now().Add(syncInterval)

--- a/common/configuration/asm_leader.go
+++ b/common/configuration/asm_leader.go
@@ -1,0 +1,314 @@
+package configuration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/alecthomas/atomic"
+	"github.com/puzpuzpuz/xsync/v3"
+
+	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/slices"
+	"github.com/alecthomas/types/optional"
+	"github.com/alecthomas/types/pubsub"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/aws/smithy-go"
+)
+
+const (
+	syncInterval       = time.Minute * 5
+	syncInitialBackoff = time.Second * 5
+	loadSecretsTimeout = time.Second * 5
+)
+
+type asmSecretValue struct {
+	value []byte
+
+	// lastModified is retrieved from ASM when syncing.
+	// it is nil when our cache is updated after writing to ASM (lastModified is not returned when writing),
+	// until the next sync refetches it from ASM
+	lastModified optional.Option[time.Time]
+}
+
+type updateASMSecretEvent struct {
+	ref Ref
+	// value is nil when the secret was deleted
+	value optional.Option[[]byte]
+}
+
+type asmLeader struct {
+	client *secretsmanager.Client
+
+	// indicates if the initial sync with ASM has finished
+	loaded atomic.Value[bool]
+
+	// secrets is a map of secrets that have been loaded from ASM.
+	// optional is nil when not loaded yet
+	// it is updated via:
+	// - polling ASM
+	// - when we write to ASM
+	secrets *xsync.MapOf[Ref, asmSecretValue]
+
+	topic *pubsub.Topic[updateASMSecretEvent]
+	// used by tests to wait for events to be processed
+	topicWaitGroup sync.WaitGroup
+}
+
+var _ asmClient = &asmLeader{}
+
+func newASMLeader(ctx context.Context, client *secretsmanager.Client) *asmLeader {
+	l := &asmLeader{
+		client:  client,
+		secrets: xsync.NewMapOf[Ref, asmSecretValue](),
+		topic:   pubsub.New[updateASMSecretEvent](),
+	}
+	go func() {
+		l.watchForUpdates(ctx)
+	}()
+	return l
+}
+
+func (l *asmLeader) watchForUpdates(ctx context.Context) {
+	logger := log.FromContext(ctx)
+	events := make(chan updateASMSecretEvent, 64)
+	l.topic.Subscribe(events)
+	defer l.topic.Unsubscribe(events)
+
+	nextSync := time.Now()
+	backOff := syncInitialBackoff
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case e := <-events:
+			l.processEvent(e)
+
+		case <-time.After(time.Until(nextSync)):
+			nextSync = time.Now().Add(syncInterval)
+
+			err := l.sync(ctx)
+			if err == nil {
+				backOff = syncInitialBackoff
+				continue
+			}
+			// back off if we fail to sync
+			logger.Warnf("unable to sync ASM secrets: %v", err)
+			nextSync = time.Now().Add(backOff)
+			if nextSync.After(time.Now().Add(syncInterval)) {
+				nextSync = time.Now().Add(syncInterval)
+			} else {
+				backOff *= 2
+			}
+		}
+	}
+}
+
+// sync retrieves all secrets from ASM and updates the cache
+func (l *asmLeader) sync(ctx context.Context) error {
+	previous := map[Ref]asmSecretValue{}
+	l.secrets.Range(func(ref Ref, value asmSecretValue) bool {
+		previous[ref] = value
+		return true
+	})
+	seen := map[Ref]bool{}
+
+	// get list of secrets
+	refsToLoad := map[Ref]time.Time{}
+	nextToken := optional.None[string]()
+	for {
+		out, err := l.client.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
+			MaxResults: aws.Int32(100),
+			NextToken:  nextToken.Ptr(),
+		})
+		if err != nil {
+			return fmt.Errorf("unable to list secrets: %w", err)
+		}
+
+		var activeSecrets = slices.Filter(out.SecretList, func(s types.SecretListEntry) bool {
+			return s.DeletedDate == nil
+		})
+		for _, s := range activeSecrets {
+			ref, err := ParseRef(*s.Name)
+			if err != nil {
+				return fmt.Errorf("unable to parse ref: %w", err)
+			}
+			seen[ref] = true
+
+			// check if we already have the value from previous sync
+			if pValue, ok := previous[ref]; ok && pValue.lastModified == optional.Some(*s.LastChangedDate) {
+				continue
+			}
+			refsToLoad[ref] = *s.LastChangedDate
+		}
+
+		nextToken = optional.Ptr[string](out.NextToken)
+		if !nextToken.Ok() {
+			break
+		}
+	}
+
+	// remove secrets not found in ASM
+	for ref := range previous {
+		if _, ok := seen[ref]; !ok {
+			l.secrets.Delete(ref)
+		}
+	}
+
+	// get values for new and updated secrets
+	for len(refsToLoad) > 0 {
+		batchSize := 20
+		secretIDs := []string{}
+		for ref := range refsToLoad {
+			secretIDs = append(secretIDs, ref.String())
+			if len(secretIDs) == batchSize {
+				break
+			}
+		}
+		out, err := l.client.BatchGetSecretValue(ctx, &secretsmanager.BatchGetSecretValueInput{
+			SecretIdList: secretIDs,
+		})
+		if err != nil {
+			return fmt.Errorf("unable to batch get secret values: %w", err)
+		}
+		for _, s := range out.SecretValues {
+			ref, err := ParseRef(*s.Name)
+			if err != nil {
+				return fmt.Errorf("unable to parse ref: %w", err)
+			}
+			// Expect secrets to be strings, not binary
+			if s.SecretBinary != nil {
+				return fmt.Errorf("secret for %s is not a string", ref)
+			}
+			data := []byte(*s.SecretString)
+			l.secrets.Store(ref, asmSecretValue{
+				value:        data,
+				lastModified: optional.Some(refsToLoad[ref]),
+			})
+			delete(refsToLoad, ref)
+		}
+	}
+
+	l.loaded.Store(true)
+	return nil
+}
+
+// processEvent updates the cache after writes to ASM
+func (l *asmLeader) processEvent(e updateASMSecretEvent) {
+	// waitGroup updated so testing can wait for events to be processed
+	defer l.topicWaitGroup.Done()
+
+	if !l.loaded.Load() {
+		// cache not loaded, nothing to update
+		return
+	}
+	if data, ok := e.value.Get(); ok {
+		// updated value
+		l.secrets.Store(e.ref, asmSecretValue{
+			value:        data,
+			lastModified: optional.None[time.Time](),
+		})
+	} else {
+		// removed value
+		l.secrets.Delete(e.ref)
+	}
+}
+
+// publishes an event to update the cache
+//
+// Called after writing to ASM.
+// Wrapped in a method to ensure we always update topicWaitGroup
+func (l *asmLeader) publish(event updateASMSecretEvent) {
+	l.topicWaitGroup.Add(1)
+	l.topic.Publish(event)
+}
+
+// waitForSecrets waits until the initial sync of secrets has completed.
+//
+// If secrets have not yet been synced, this will retry until they are, returning an error if it takes too long.
+func (l *asmLeader) waitForSecrets() error {
+	deadline := time.Now().Add(loadSecretsTimeout)
+	for deadline.After(time.Now()) {
+		if loaded := l.loaded.Load(); loaded {
+			return nil
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+	return errors.New("secrets not synced from ASM yet")
+}
+
+// list all secrets in the account.
+func (l *asmLeader) list(ctx context.Context) ([]Entry, error) {
+	if err := l.waitForSecrets(); err != nil {
+		return nil, err
+	}
+	entries := []Entry{}
+	l.secrets.Range(func(ref Ref, value asmSecretValue) bool {
+		entries = append(entries, Entry{
+			Ref:      ref,
+			Accessor: asmURLForRef(ref),
+		})
+		return true
+	})
+	return entries, nil
+}
+
+func (l *asmLeader) load(ctx context.Context, ref Ref, key *url.URL) ([]byte, error) {
+	if err := l.waitForSecrets(); err != nil {
+		return nil, err
+	}
+	if v, ok := l.secrets.Load(ref); ok {
+		return v.value, nil
+	}
+	return nil, fmt.Errorf("secret not found: %s", ref)
+}
+
+// store and if the secret already exists, update it.
+func (l *asmLeader) store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+	_, err := l.client.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+		Name:         aws.String(ref.String()),
+		SecretString: aws.String(string(value)),
+	})
+
+	// https://github.com/aws/aws-sdk-go-v2/issues/1110#issuecomment-1054643716
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "ResourceExistsException" {
+		_, err = l.client.UpdateSecret(ctx, &secretsmanager.UpdateSecretInput{
+			SecretId:     aws.String(ref.String()),
+			SecretString: aws.String(string(value)),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to update secret: %w", err)
+		}
+
+	} else if err != nil {
+		return nil, fmt.Errorf("unable to store secret: %w", err)
+	}
+	l.publish(updateASMSecretEvent{
+		ref:   ref,
+		value: optional.Some(value),
+	})
+	return asmURLForRef(ref), nil
+}
+
+func (l *asmLeader) delete(ctx context.Context, ref Ref) error {
+	var t = true
+	_, err := l.client.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+		SecretId:                   aws.String(ref.String()),
+		ForceDeleteWithoutRecovery: &t,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to delete secret: %w", err)
+	}
+	l.publish(updateASMSecretEvent{
+		ref:   ref,
+		value: optional.None[[]byte](),
+	})
+	return nil
+}

--- a/common/configuration/asm_test.go
+++ b/common/configuration/asm_test.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/TBD54566975/ftl/backend/controller/leases"
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/benbjohnson/clock"
 
 	"github.com/alecthomas/assert/v2"
 	. "github.com/alecthomas/types/optional"
@@ -19,24 +21,24 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 )
 
-func localstack(ctx context.Context, t *testing.T) (*ASM, *asmLeader) {
+func localstack(ctx context.Context, t *testing.T) (*ASM, *asmLeader, *secretsmanager.Client, *clock.Mock) {
 	t.Helper()
+	mockClock := clock.NewMock()
 	cc := aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider("test", "test", ""))
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithCredentialsProvider(cc), config.WithRegion("us-west-2"))
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	sm := secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
 		o.BaseEndpoint = aws.String("http://localhost:4566")
 	})
-	asm := NewASM(ctx, sm, URL("http://localhost:1234"), leases.NewFakeLeaser())
+	asm := newASMForTesting(ctx, sm, URL("http://localhost:1234"), leases.NewFakeLeaser(), mockClock)
 
 	leaderOrFollower, err := asm.coordinator.Get()
 	assert.NoError(t, err)
 	leader, ok := leaderOrFollower.(*asmLeader)
 	assert.True(t, ok, "expected test to get an asm leader not a follower")
-	return asm, leader
+	return asm, leader, sm, mockClock
 }
 
 func waitForUpdatesToProcess(l *asmLeader) {
@@ -45,7 +47,7 @@ func waitForUpdatesToProcess(l *asmLeader) {
 
 func TestASMWorkflow(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	asm, leader := localstack(ctx, t)
+	asm, leader, _, _ := localstack(ctx, t)
 	ref := Ref{Module: Some("foo"), Name: "bar"}
 	var mySecret = []byte("my secret")
 	manager, err := New(ctx, asm, []Provider[Secrets]{asm})
@@ -95,7 +97,7 @@ func TestASMWorkflow(t *testing.T) {
 // Suggest not running this against a real AWS account (especially in CI) due to the cost. Maybe costs a few $.
 func TestASMPagination(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	asm, leader := localstack(ctx, t)
+	asm, leader, _, _ := localstack(ctx, t)
 	manager, err := New(ctx, asm, []Provider[Secrets]{asm})
 	assert.NoError(t, err)
 
@@ -139,4 +141,117 @@ func TestASMPagination(t *testing.T) {
 	items, err = manager.List(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, len(items), 0)
+}
+
+func TestSync(t *testing.T) {
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	asm, leader, sm, clock := localstack(ctx, t)
+
+	// wait for initial load
+	err := leader.waitForSecrets()
+	assert.NoError(t, err)
+
+	// advance clock to half way between syncs
+	clock.Add(syncInterval / 2)
+
+	// write a secret via leader
+	leaderRef := Ref{Module: Some("sync"), Name: "set-by-leader"}
+	_, err = asm.Store(ctx, leaderRef, []byte("leader-first"))
+	assert.NoError(t, err)
+	waitForUpdatesToProcess(leader)
+	value, err := asm.Load(ctx, leaderRef, asmURLForRef(leaderRef))
+	assert.NoError(t, err, "failed to load secret via asm")
+	assert.Equal(t, value, []byte("leader-first"), "unexpected secret value")
+
+	// write another secret via sm directly
+	smRef := Ref{Module: Some("sync"), Name: "set-by-sm"}
+	_, err = sm.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+		Name:         aws.String(smRef.String()),
+		SecretString: aws.String(string("sm-first")),
+	})
+	assert.NoError(t, err, "failed to create secret via sm")
+	waitForUpdatesToProcess(leader)
+	value, err = asm.Load(ctx, smRef, asmURLForRef(smRef))
+	assert.Error(t, err, "expected to fail because asm leader has not synced secret yet")
+
+	// write a secret via leader and then by sm directly
+	leaderSmRef := Ref{Module: Some("sync"), Name: "set-by-leader-then-sm"}
+	_, err = asm.Store(ctx, leaderSmRef, []byte("leader-sm-first"))
+	assert.NoError(t, err)
+	_, err = sm.UpdateSecret(ctx, &secretsmanager.UpdateSecretInput{
+		SecretId:     aws.String(leaderSmRef.String()),
+		SecretString: aws.String("leader-sm-second"),
+	})
+	assert.NoError(t, err)
+	waitForUpdatesToProcess(leader)
+	value, err = asm.Load(ctx, leaderSmRef, asmURLForRef(leaderSmRef))
+	assert.NoError(t, err, "failed to load secret via asm")
+	assert.Equal(t, value, []byte("leader-sm-first"), "expected initial value before leader has a chance to sync newest value")
+
+	// write a secret via sm directly and then by leader
+	smLeaderRef := Ref{Module: Some("sync"), Name: "set-by-sm-then-leader"}
+	_, err = sm.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
+		Name:         aws.String(smLeaderRef.String()),
+		SecretString: aws.String(string("sm-leader-first")),
+	})
+	assert.NoError(t, err, "failed to create secret via sm")
+	_, err = asm.Store(ctx, smLeaderRef, []byte("sm-leader-second"))
+	assert.NoError(t, err)
+	waitForUpdatesToProcess(leader)
+	value, err = asm.Load(ctx, smLeaderRef, asmURLForRef(smLeaderRef))
+	assert.NoError(t, err, "failed to load secret via asm")
+	assert.Equal(t, value, []byte("sm-leader-second"), "unexpected secret value")
+
+	// give leader a change to sync
+	clock.Add(syncInterval)
+	time.Sleep(time.Second * 5)
+
+	// confirm that all secrets are up to date
+	list, err := asm.List(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, len(list), 4, "expected 4 secrets")
+	for _, entry := range list {
+		value, err = asm.Load(ctx, entry.Ref, asmURLForRef(entry.Ref))
+		assert.NoError(t, err, "failed to load secret via asm")
+		var expectedValue string
+		switch entry.Ref {
+		case leaderRef:
+			expectedValue = "leader-first"
+		case smRef:
+			expectedValue = "sm-first"
+		case leaderSmRef:
+			expectedValue = "leader-sm-second"
+		case smLeaderRef:
+			expectedValue = "sm-leader-second"
+		default:
+			t.Fatal(fmt.Sprintf("unexpected ref: %s", entry.Ref))
+		}
+		assert.Equal(t, expectedValue, string(value), "unexpected secret value for %s", entry.Ref)
+	}
+
+	// delete 2 secrets without leader knowing
+	tr := true
+	_, err = sm.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+		SecretId:                   aws.String(smRef.String()),
+		ForceDeleteWithoutRecovery: &tr,
+	})
+	assert.NoError(t, err)
+	_, err = sm.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+		SecretId:                   aws.String(smLeaderRef.String()),
+		ForceDeleteWithoutRecovery: &tr,
+	})
+	assert.NoError(t, err)
+
+	// give leader a change to sync
+	clock.Add(syncInterval)
+	time.Sleep(time.Second * 5)
+
+	// confirm secrets were deleted
+	list, err = asm.List(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, len(list), 2, "expected 2 secrets")
+	_, err = asm.Load(ctx, smRef, asmURLForRef(smRef))
+	assert.Error(t, err, "expected to fail because secret was deleted")
+	_, err = asm.Load(ctx, smLeaderRef, asmURLForRef(smLeaderRef))
+	assert.Error(t, err, "expected to fail because secret was deleted")
 }

--- a/common/configuration/asm_test.go
+++ b/common/configuration/asm_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/TBD54566975/ftl/backend/controller/leases"
+	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/benbjohnson/clock"
 
@@ -41,8 +43,8 @@ func localstack(ctx context.Context, t *testing.T) (*ASM, *asmLeader, *secretsma
 	return asm, leader, sm, mockClock
 }
 
-func waitForUpdatesToProcess(l *asmLeader) {
-	l.topicWaitGroup.Wait()
+func waitForUpdatesToProcess(c *secretsCache) {
+	c.topicWaitGroup.Wait()
 }
 
 func TestASMWorkflow(t *testing.T) {
@@ -62,7 +64,7 @@ func TestASMWorkflow(t *testing.T) {
 	assert.Equal(t, items, []Entry{})
 
 	err = manager.Set(ctx, "asm", ref, mySecret)
-	waitForUpdatesToProcess(leader)
+	waitForUpdatesToProcess(leader.cache)
 	assert.NoError(t, err)
 
 	items, err = manager.List(ctx)
@@ -75,7 +77,7 @@ func TestASMWorkflow(t *testing.T) {
 	// Set again to make sure it updates.
 	mySecret = []byte("hunter1")
 	err = manager.Set(ctx, "asm", ref, mySecret)
-	waitForUpdatesToProcess(leader)
+	waitForUpdatesToProcess(leader.cache)
 	assert.NoError(t, err)
 
 	err = manager.Get(ctx, ref, &gotSecret)
@@ -83,7 +85,7 @@ func TestASMWorkflow(t *testing.T) {
 	assert.Equal(t, gotSecret, mySecret)
 
 	err = manager.Unset(ctx, "asm", ref)
-	waitForUpdatesToProcess(leader)
+	waitForUpdatesToProcess(leader.cache)
 	assert.NoError(t, err)
 
 	items, err = manager.List(ctx)
@@ -135,7 +137,7 @@ func TestASMPagination(t *testing.T) {
 		err := manager.Unset(ctx, "asm", ref)
 		assert.NoError(t, err)
 	}
-	waitForUpdatesToProcess(leader)
+	waitForUpdatesToProcess(leader.cache)
 
 	// Make sure they are all gone
 	items, err = manager.List(ctx)
@@ -143,25 +145,60 @@ func TestASMPagination(t *testing.T) {
 	assert.Equal(t, len(items), 0)
 }
 
-func TestSync(t *testing.T) {
+func TestLeaderSync(t *testing.T) {
+	// test setting and getting values via the leader, as well as directly with ASM
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	asm, leader, sm, clock := localstack(ctx, t)
+	_, leader, sm, clock := localstack(ctx, t)
+	testClientSync(ctx, t, leader, leader.cache, sm, func(percentage float64) {
+		clock.Add(time.Duration(percentage) * asmLeaderSyncInterval)
+	})
+}
+
+func TestFollowerSync(t *testing.T) {
+	// Test setting and getting values via the follower, which is connected to a leader, as well as directly with ASM
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	asm, _, sm, leaderClock := localstack(ctx, t)
+
+	// fakeRPCClient connects the follower to the leader
+	fakeRPCClient := &fakeAdminClient{asm: asm}
+	followerClock := clock.NewMock()
+	follower := newASMFollower(ctx, fakeRPCClient, followerClock)
+
+	testClientSync(ctx, t, follower, follower.cache, sm, func(percentage float64) {
+		// sync leader
+		leaderClock.Add(time.Duration(percentage) * asmLeaderSyncInterval)
+		if percentage == 1.0 {
+			time.Sleep(time.Second * 5)
+		}
+
+		// then sync follower
+		followerClock.Add(time.Duration(percentage) * asmFollowerSyncInterval)
+	})
+}
+
+func testClientSync(ctx context.Context,
+	t *testing.T,
+	client asmClient,
+	cache *secretsCache,
+	sm *secretsmanager.Client,
+	progressByIntervalPercentage func(percentage float64)) {
+	t.Helper()
 
 	// wait for initial load
-	err := leader.waitForSecrets()
+	err := cache.waitForSecrets()
 	assert.NoError(t, err)
 
 	// advance clock to half way between syncs
-	clock.Add(syncInterval / 2)
+	progressByIntervalPercentage(0.5)
 
-	// write a secret via leader
-	leaderRef := Ref{Module: Some("sync"), Name: "set-by-leader"}
-	_, err = asm.Store(ctx, leaderRef, []byte("leader-first"))
+	// write a secret via asmClient
+	clientRef := Ref{Module: Some("sync"), Name: "set-by-client"}
+	_, err = client.store(ctx, clientRef, []byte("client-first"))
 	assert.NoError(t, err)
-	waitForUpdatesToProcess(leader)
-	value, err := asm.Load(ctx, leaderRef, asmURLForRef(leaderRef))
+	waitForUpdatesToProcess(cache)
+	value, err := client.load(ctx, clientRef, asmURLForRef(clientRef))
 	assert.NoError(t, err, "failed to load secret via asm")
-	assert.Equal(t, value, []byte("leader-first"), "unexpected secret value")
+	assert.Equal(t, value, []byte("client-first"), "unexpected secret value")
 
 	// write another secret via sm directly
 	smRef := Ref{Module: Some("sync"), Name: "set-by-sm"}
@@ -170,66 +207,66 @@ func TestSync(t *testing.T) {
 		SecretString: aws.String(string("sm-first")),
 	})
 	assert.NoError(t, err, "failed to create secret via sm")
-	waitForUpdatesToProcess(leader)
-	value, err = asm.Load(ctx, smRef, asmURLForRef(smRef))
-	assert.Error(t, err, "expected to fail because asm leader has not synced secret yet")
+	waitForUpdatesToProcess(cache)
+	value, err = client.load(ctx, smRef, asmURLForRef(smRef))
+	assert.Error(t, err, "expected to fail because asm client has not synced secret yet")
 
-	// write a secret via leader and then by sm directly
-	leaderSmRef := Ref{Module: Some("sync"), Name: "set-by-leader-then-sm"}
-	_, err = asm.Store(ctx, leaderSmRef, []byte("leader-sm-first"))
+	// write a secret via client and then by sm directly
+	clientSmRef := Ref{Module: Some("sync"), Name: "set-by-client-then-sm"}
+	_, err = client.store(ctx, clientSmRef, []byte("client-sm-first"))
 	assert.NoError(t, err)
 	_, err = sm.UpdateSecret(ctx, &secretsmanager.UpdateSecretInput{
-		SecretId:     aws.String(leaderSmRef.String()),
-		SecretString: aws.String("leader-sm-second"),
+		SecretId:     aws.String(clientSmRef.String()),
+		SecretString: aws.String("client-sm-second"),
 	})
 	assert.NoError(t, err)
-	waitForUpdatesToProcess(leader)
-	value, err = asm.Load(ctx, leaderSmRef, asmURLForRef(leaderSmRef))
+	waitForUpdatesToProcess(cache)
+	value, err = client.load(ctx, clientSmRef, asmURLForRef(clientSmRef))
 	assert.NoError(t, err, "failed to load secret via asm")
-	assert.Equal(t, value, []byte("leader-sm-first"), "expected initial value before leader has a chance to sync newest value")
+	assert.Equal(t, value, []byte("client-sm-first"), "expected initial value before client has a chance to sync newest value")
 
-	// write a secret via sm directly and then by leader
-	smLeaderRef := Ref{Module: Some("sync"), Name: "set-by-sm-then-leader"}
+	// write a secret via sm directly and then by client
+	smClientRef := Ref{Module: Some("sync"), Name: "set-by-sm-then-client"}
 	_, err = sm.CreateSecret(ctx, &secretsmanager.CreateSecretInput{
-		Name:         aws.String(smLeaderRef.String()),
-		SecretString: aws.String(string("sm-leader-first")),
+		Name:         aws.String(smClientRef.String()),
+		SecretString: aws.String(string("sm-client-first")),
 	})
 	assert.NoError(t, err, "failed to create secret via sm")
-	_, err = asm.Store(ctx, smLeaderRef, []byte("sm-leader-second"))
+	_, err = client.store(ctx, smClientRef, []byte("sm-client-second"))
 	assert.NoError(t, err)
-	waitForUpdatesToProcess(leader)
-	value, err = asm.Load(ctx, smLeaderRef, asmURLForRef(smLeaderRef))
+	waitForUpdatesToProcess(cache)
+	value, err = client.load(ctx, smClientRef, asmURLForRef(smClientRef))
 	assert.NoError(t, err, "failed to load secret via asm")
-	assert.Equal(t, value, []byte("sm-leader-second"), "unexpected secret value")
+	assert.Equal(t, value, []byte("sm-client-second"), "unexpected secret value")
 
-	// give leader a change to sync
-	clock.Add(syncInterval)
+	// give client a change to sync
+	progressByIntervalPercentage(1.0)
 	time.Sleep(time.Second * 5)
 
 	// confirm that all secrets are up to date
-	list, err := asm.List(ctx)
+	list, err := client.list(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, len(list), 4, "expected 4 secrets")
 	for _, entry := range list {
-		value, err = asm.Load(ctx, entry.Ref, asmURLForRef(entry.Ref))
+		value, err = client.load(ctx, entry.Ref, asmURLForRef(entry.Ref))
 		assert.NoError(t, err, "failed to load secret via asm")
 		var expectedValue string
 		switch entry.Ref {
-		case leaderRef:
-			expectedValue = "leader-first"
+		case clientRef:
+			expectedValue = "client-first"
 		case smRef:
 			expectedValue = "sm-first"
-		case leaderSmRef:
-			expectedValue = "leader-sm-second"
-		case smLeaderRef:
-			expectedValue = "sm-leader-second"
+		case clientSmRef:
+			expectedValue = "client-sm-second"
+		case smClientRef:
+			expectedValue = "sm-client-second"
 		default:
 			t.Fatal(fmt.Sprintf("unexpected ref: %s", entry.Ref))
 		}
 		assert.Equal(t, expectedValue, string(value), "unexpected secret value for %s", entry.Ref)
 	}
 
-	// delete 2 secrets without leader knowing
+	// delete 2 secrets without client knowing
 	tr := true
 	_, err = sm.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
 		SecretId:                   aws.String(smRef.String()),
@@ -237,21 +274,104 @@ func TestSync(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	_, err = sm.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
-		SecretId:                   aws.String(smLeaderRef.String()),
+		SecretId:                   aws.String(smClientRef.String()),
 		ForceDeleteWithoutRecovery: &tr,
 	})
 	assert.NoError(t, err)
 
-	// give leader a change to sync
-	clock.Add(syncInterval)
+	// give client a change to sync
+	progressByIntervalPercentage(1.0)
 	time.Sleep(time.Second * 5)
 
 	// confirm secrets were deleted
-	list, err = asm.List(ctx)
+	list, err = client.list(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, len(list), 2, "expected 2 secrets")
-	_, err = asm.Load(ctx, smRef, asmURLForRef(smRef))
+	_, err = client.load(ctx, smRef, asmURLForRef(smRef))
 	assert.Error(t, err, "expected to fail because secret was deleted")
-	_, err = asm.Load(ctx, smLeaderRef, asmURLForRef(smLeaderRef))
+	_, err = client.load(ctx, smClientRef, asmURLForRef(smClientRef))
 	assert.Error(t, err, "expected to fail because secret was deleted")
+}
+
+type fakeAdminClient struct {
+	asm *ASM
+}
+
+func (c *fakeAdminClient) Ping(ctx context.Context, req *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
+	return connect.NewResponse(&ftlv1.PingResponse{}), nil
+}
+
+// ConfigList returns the list of configuration values, optionally filtered by module.
+func (c *fakeAdminClient) ConfigList(ctx context.Context, req *connect.Request[ftlv1.ListConfigRequest]) (*connect.Response[ftlv1.ListConfigResponse], error) {
+	panic("not implemented")
+}
+
+func (c *fakeAdminClient) ConfigGet(ctx context.Context, req *connect.Request[ftlv1.GetConfigRequest]) (*connect.Response[ftlv1.GetConfigResponse], error) {
+	panic("not implemented")
+}
+
+func (c *fakeAdminClient) ConfigSet(ctx context.Context, req *connect.Request[ftlv1.SetConfigRequest]) (*connect.Response[ftlv1.SetConfigResponse], error) {
+	panic("not implemented")
+}
+
+func (c *fakeAdminClient) ConfigUnset(ctx context.Context, req *connect.Request[ftlv1.UnsetConfigRequest]) (*connect.Response[ftlv1.UnsetConfigResponse], error) {
+	panic("not implemented")
+}
+
+func (c *fakeAdminClient) SecretsList(ctx context.Context, req *connect.Request[ftlv1.ListSecretsRequest]) (*connect.Response[ftlv1.ListSecretsResponse], error) {
+	listing, err := c.asm.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	secrets := []*ftlv1.ListSecretsResponse_Secret{}
+	for _, secret := range listing {
+		module, ok := secret.Module.Get()
+		if *req.Msg.Module != "" && module != *req.Msg.Module {
+			continue
+		}
+		ref := secret.Name
+		if ok {
+			ref = fmt.Sprintf("%s.%s", module, secret.Name)
+		}
+		var sv []byte
+		if *req.Msg.IncludeValues {
+			sv, err = c.asm.Load(ctx, secret.Ref, asmURLForRef(secret.Ref))
+			if err != nil {
+				return nil, err
+			}
+		}
+		secrets = append(secrets, &ftlv1.ListSecretsResponse_Secret{
+			RefPath: ref,
+			Value:   sv,
+		})
+	}
+	return connect.NewResponse(&ftlv1.ListSecretsResponse{Secrets: secrets}), nil
+}
+
+// SecretGet returns the secret value for a given ref string.
+func (c *fakeAdminClient) SecretGet(ctx context.Context, req *connect.Request[ftlv1.GetSecretRequest]) (*connect.Response[ftlv1.GetSecretResponse], error) {
+	ref := NewRef(*req.Msg.Ref.Module, req.Msg.Ref.Name)
+	vb, err := c.asm.Load(ctx, ref, asmURLForRef(ref))
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&ftlv1.GetSecretResponse{Value: vb}), nil
+}
+
+// SecretSet sets the secret at the given ref to the provided value.
+func (c *fakeAdminClient) SecretSet(ctx context.Context, req *connect.Request[ftlv1.SetSecretRequest]) (*connect.Response[ftlv1.SetSecretResponse], error) {
+	_, err := c.asm.Store(ctx, NewRef(*req.Msg.Ref.Module, req.Msg.Ref.Name), req.Msg.Value)
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&ftlv1.SetSecretResponse{}), nil
+}
+
+// SecretUnset unsets the secret value at the given ref.
+func (c *fakeAdminClient) SecretUnset(ctx context.Context, req *connect.Request[ftlv1.UnsetSecretRequest]) (*connect.Response[ftlv1.UnsetSecretResponse], error) {
+	err := c.asm.Delete(ctx, NewRef(*req.Msg.Ref.Module, req.Msg.Ref.Name))
+	if err != nil {
+		return nil, err
+	}
+	return connect.NewResponse(&ftlv1.UnsetSecretResponse{}), nil
 }

--- a/common/configuration/asm_test.go
+++ b/common/configuration/asm_test.go
@@ -110,6 +110,8 @@ func TestASMPagination(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
+	waitForUpdatesToProcess(leader.cache)
+
 	items, err := manager.List(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, len(items), 210)

--- a/common/configuration/secrets_cache.go
+++ b/common/configuration/secrets_cache.go
@@ -1,0 +1,175 @@
+package configuration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/alecthomas/types/optional"
+	"github.com/alecthomas/types/pubsub"
+	"github.com/benbjohnson/clock"
+	"github.com/puzpuzpuz/xsync/v3"
+)
+
+const (
+	syncInitialBackoff = time.Second * 5
+	loadSecretsTimeout = time.Second * 5
+)
+
+type cachedSecret struct {
+	value []byte
+
+	// versionToken is a way of storing a version provided by the source of truth (eg: lastModified)
+	// it is nil when:
+	// - the owner of the cache is not using version tokens
+	// - the cache is updated after writing
+	versionToken optional.Option[any]
+}
+
+type updatedSecretEvent struct {
+	ref Ref
+	// value is nil when the secret was deleted
+	value optional.Option[[]byte]
+}
+
+type secretsCache struct {
+	// closed when secrets have been loaded from ASM for the first time
+	loaded chan bool
+
+	// secrets is a map of secrets that have been loaded from ASM.
+	// optional is nil when not loaded yet
+	// it is updated via:
+	// - polling ASM
+	// - when we write to ASM
+	secrets *xsync.MapOf[Ref, cachedSecret]
+
+	topic *pubsub.Topic[updatedSecretEvent]
+	// used by tests to wait for events to be processed
+	topicWaitGroup sync.WaitGroup
+}
+
+func newSecretsCache() *secretsCache {
+	return &secretsCache{
+		loaded:  make(chan bool),
+		secrets: xsync.NewMapOf[Ref, cachedSecret](),
+		topic:   pubsub.New[updatedSecretEvent](),
+	}
+}
+
+func (c *secretsCache) getSecret(ref Ref) ([]byte, error) {
+	if err := c.waitForSecrets(); err != nil {
+		return nil, err
+	}
+	result, ok := c.secrets.Load(ref)
+	if !ok {
+		return nil, fmt.Errorf("secret not found: %s", ref)
+	}
+	return result.value, nil
+}
+
+func (c *secretsCache) iterate(f func(ref Ref, value []byte)) error {
+	if err := c.waitForSecrets(); err != nil {
+		return err
+	}
+	c.secrets.Range(func(ref Ref, value cachedSecret) bool {
+		f(ref, value.value)
+		return true
+	})
+	return nil
+}
+
+func (c *secretsCache) updatedSecret(ref Ref, value []byte) {
+	c.topicWaitGroup.Add(1)
+	c.topic.Publish(updatedSecretEvent{
+		ref:   ref,
+		value: optional.Some(value),
+	})
+}
+
+func (c *secretsCache) deletedSecret(ref Ref) {
+	c.topicWaitGroup.Add(1)
+	c.topic.Publish(updatedSecretEvent{
+		ref:   ref,
+		value: optional.None[[]byte](),
+	})
+}
+
+// sync is used to update the secrets cache
+//
+// Blocks until the context is cancelled.
+// Synchronizer is a function that will be called to sync the secrets cache
+// Errors returned by synchronizer cause retries with exponential backoff.
+func (c *secretsCache) sync(ctx context.Context, frequency time.Duration, synchronizer func(ctx context.Context, secrets *xsync.MapOf[Ref, cachedSecret]) error, clock clock.Clock) {
+	logger := log.FromContext(ctx)
+	events := make(chan updatedSecretEvent, 64)
+	c.topic.Subscribe(events)
+	defer c.topic.Unsubscribe(events)
+
+	nextSync := clock.Now()
+	backOff := syncInitialBackoff
+	loaded := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case e := <-events:
+			if loaded {
+				c.processEvent(e)
+			}
+
+		case <-clock.After(clock.Until(nextSync)):
+			nextSync = clock.Now().Add(frequency)
+
+			err := synchronizer(ctx, c.secrets)
+			if err == nil {
+				backOff = syncInitialBackoff
+				if !loaded {
+					loaded = true
+					close(c.loaded)
+				}
+				continue
+			}
+			// back off if we fail to sync
+			logger.Warnf("Unable to sync ASM secrets: %v", err)
+			nextSync = clock.Now().Add(backOff)
+			if nextSync.After(clock.Now().Add(frequency)) {
+				nextSync = clock.Now().Add(frequency)
+			} else {
+				backOff *= 2
+			}
+		}
+	}
+}
+
+// processEvent updates the cache after updating the secret
+func (c *secretsCache) processEvent(e updatedSecretEvent) {
+	// waitGroup updated so testing can wait for events to be processed
+	defer c.topicWaitGroup.Done()
+
+	if data, ok := e.value.Get(); ok {
+		// updated value
+		c.secrets.Store(e.ref, cachedSecret{
+			value:        data,
+			versionToken: optional.None[any](),
+		})
+	} else {
+		// removed value
+		c.secrets.Delete(e.ref)
+	}
+}
+
+// waitForSecrets waits until the initial sync of secrets has completed.
+//
+// If secrets have not yet been synced, this will retry until they are, returning an error if it takes too long.
+func (c *secretsCache) waitForSecrets() error {
+	select {
+	case <-time.After(loadSecretsTimeout):
+		return errors.New("secrets not synced from ASM yet")
+	case <-c.loaded:
+		return nil
+	}
+}

--- a/go-runtime/ftl/ftltest/testdata/go/pubsub/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/pubsub/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/pubsub/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/pubsub/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=

--- a/go-runtime/ftl/ftltest/testdata/go/subscriber/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/subscriber/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/subscriber/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/subscriber/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=

--- a/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/verbtypes/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/go.mod
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/go.sum
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=

--- a/go-runtime/ftl/testdata/go/mapper/go.mod
+++ b/go-runtime/ftl/testdata/go/mapper/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.30.0 // indirect
 	github.com/aws/smithy-go v1.20.2 // indirect
+	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/danieljoos/wincred v1.2.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go-runtime/ftl/testdata/go/mapper/go.sum
+++ b/go-runtime/ftl/testdata/go/mapper/go.sum
@@ -50,6 +50,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.28.12 h1:M/1u4HBpwLuMtjlxuI2y6HoVLzF
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.12/go.mod h1:kcfd+eTdEi/40FIbLq4Hif3XMXnl5b/+t/KTfLt9xIk=
 github.com/aws/smithy-go v1.20.2 h1:tbp628ireGtzcHDDmLT/6ADHidqnwgF57XOXZe6tp4Q=
 github.com/aws/smithy-go v1.20.2/go.mod h1:krry+ya/rV9RDcV/Q16kpu6ypI4K2czasz0NC3qS14E=
+github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
+github.com/benbjohnson/clock v1.3.5/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/bool64/dev v0.2.34 h1:P9n315P8LdpxusnYQ0X7MP1CZXwBK5ae5RZrd+GdSZE=
 github.com/bool64/dev v0.2.34/go.mod h1:iJbh1y/HkunEPhgebWRNcs8wfGq7sjvJ6W5iabL8ACg=
 github.com/bool64/shared v0.1.5 h1:fp3eUhBsrSjNCQPcSdQqZxxh9bBwrYiZ+zOKFkM0/2E=


### PR DESCRIPTION
closes #1782
ASM changes:
- `ASM` uses `leader` package to coordinate between leader and followers
- The leader syncs secrets from ASM
    - Only requests secrets that have been updated since last sync
- Followers always uses admin service to get the secrets from the leader
- Both leader and follower cache secrets using `secretsCache`

Other changes:
- Remove additional db connection pools created at start up. Now a single db pool is created along with a dal at start up, which is then passed into the controller service and anything else that needs it