### PR TITLE
fix: dont expand vscode console on startup

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -66,8 +66,6 @@ export const activate = async (context: ExtensionContext) => {
     showCommands,
     showLogsCommand
   )
-
-  outputChannel.show()
 }
 
 export const deactivate = async () => client.stop()


### PR DESCRIPTION
Fixes #1826
