### PR TITLE
feat: add leader coordinator

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -720,7 +720,7 @@ func (s *Service) AcquireLease(ctx context.Context, stream *connect.BidiStream[f
 			return connect.NewError(connect.CodeInternal, fmt.Errorf("could not receive lease request: %w", err))
 		}
 		if lease == nil {
-			lease, err = s.dal.AcquireLease(ctx, leases.ModuleKey(msg.Module, msg.Key...), msg.Ttl.AsDuration())
+			lease, _, err = s.dal.AcquireLease(ctx, leases.ModuleKey(msg.Module, msg.Key...), msg.Ttl.AsDuration(), optional.None[any]())
 			if err != nil {
 				if errors.Is(err, leases.ErrConflict) {
 					return connect.NewError(connect.CodeResourceExhausted, fmt.Errorf("lease is held: %w", err))

--- a/backend/controller/dal/async_calls.go
+++ b/backend/controller/dal/async_calls.go
@@ -105,12 +105,13 @@ func (d *DAL) AcquireAsyncCall(ctx context.Context) (call *AsyncCall, err error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse origin key %q: %w", row.Origin, err)
 	}
+	lease, _ := d.newLease(ctx, row.LeaseKey, row.LeaseIdempotencyKey, ttl)
 	return &AsyncCall{
 		ID:                row.AsyncCallID,
 		Verb:              row.Verb,
 		Origin:            origin,
 		Request:           row.Request,
-		Lease:             d.newLease(ctx, row.LeaseKey, row.LeaseIdempotencyKey, ttl),
+		Lease:             lease,
 		ScheduledAt:       row.ScheduledAt,
 		RemainingAttempts: row.RemainingAttempts,
 		Backoff:           row.Backoff,

--- a/backend/controller/dal/fsm.go
+++ b/backend/controller/dal/fsm.go
@@ -97,7 +97,7 @@ type FSMInstance struct {
 //
 // The lease must be released by the caller.
 func (d *DAL) AcquireFSMInstance(ctx context.Context, fsm schema.RefKey, instanceKey string) (*FSMInstance, error) {
-	lease, err := d.AcquireLease(ctx, leases.SystemKey("fsm_instance", fsm.String(), instanceKey), time.Second*5)
+	lease, _, err := d.AcquireLease(ctx, leases.SystemKey("fsm_instance", fsm.String(), instanceKey), time.Second*5, optional.None[any]())
 	if err != nil {
 		return nil, fmt.Errorf("failed to acquire FSM lease: %w", err)
 	}

--- a/backend/controller/dal/lease.go
+++ b/backend/controller/dal/lease.go
@@ -100,7 +100,7 @@ func (d *DAL) AcquireLease(ctx context.Context, key leases.Key, ttl time.Duratio
 }
 
 func (d *DAL) newLease(ctx context.Context, key leases.Key, idempotencyKey uuid.UUID, ttl time.Duration) (*Lease, context.Context) {
-	leaseCtx, cancelCtx := context.WithCancel(ctx)
+	ctx, cancelCtx := context.WithCancel(ctx)
 	lease := &Lease{
 		idempotencyKey: idempotencyKey,
 		key:            key,
@@ -110,7 +110,7 @@ func (d *DAL) newLease(ctx context.Context, key leases.Key, idempotencyKey uuid.
 		errch:          make(chan error, 1),
 	}
 	go lease.renew(ctx, cancelCtx)
-	return lease, leaseCtx
+	return lease, ctx
 }
 
 // GetLeaseInfo returns the metadata and expiry time for the lease with the given key.

--- a/backend/controller/dal/lease.go
+++ b/backend/controller/dal/lease.go
@@ -25,7 +25,7 @@ type Lease struct {
 	ttl            time.Duration
 	errch          chan error
 	release        chan bool
-	cancelCtx      context.CancelFunc // cancels context created for lease owner
+	cancelCtx      context.CancelFunc // Cancels context created for lease owner.
 	leak           bool               // For testing.
 }
 

--- a/backend/controller/dal/lease.go
+++ b/backend/controller/dal/lease.go
@@ -79,6 +79,8 @@ func (l *Lease) Release() error {
 // AcquireLease acquires a lease for the given key.
 //
 // Will return ErrConflict if the lease is already held by another controller.
+//
+// The returned context will be cancelled when the lease fails to renew.
 func (d *DAL) AcquireLease(ctx context.Context, key leases.Key, ttl time.Duration, metadata optional.Option[any]) (leases.Lease, context.Context, error) {
 	if ttl < time.Second*5 {
 		return nil, nil, fmt.Errorf("lease TTL must be at least 5 seconds")

--- a/backend/controller/leader/coordinator.go
+++ b/backend/controller/leader/coordinator.go
@@ -102,7 +102,10 @@ func (c *Coordinator[P]) Get() (leaderOrFollower P, err error) {
 		// became leader
 		l, err := c.leaderFactory(leaderCtx)
 		if err != nil {
-			lease.Release()
+			err := lease.Release()
+			if err != nil {
+				logger.Warnf("could not release lease after failing to create leader for %s: %s", c.key, err)
+			}
 			return leaderOrFollower, fmt.Errorf("could not create leader for %s: %w", c.key, err)
 		}
 		c.leader = optional.Some(leader[P]{

--- a/backend/controller/leader/coordinator.go
+++ b/backend/controller/leader/coordinator.go
@@ -1,0 +1,170 @@
+package leader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/TBD54566975/ftl/backend/controller/dal"
+	"github.com/TBD54566975/ftl/backend/controller/leases"
+	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/alecthomas/types/optional"
+)
+
+// LeaderFactory is a function that is called whenever a new leader is acquired.
+//
+// The context provided is tied to the lease and will be cancelled when the leader is no longer leading.
+type LeaderFactory[P any] func(ctx context.Context) (P, error)
+
+// FollowerFactory is a function that is called whenever we follow a new leader.
+//
+// If the new leader has the same url as the previous leader, the existing follower will be used.
+type FollowerFactory[P any] func(ctx context.Context, url *url.URL) (P, error)
+
+type leader[P any] struct {
+	value P
+	lease leases.Lease
+}
+
+type follower[P any] struct {
+	value    P
+	deadline time.Time
+	url      *url.URL
+}
+
+// Coordinator assigns a single leader for the rest to follow.
+// It uses a lease to ensure that only one leader is active at a time.
+type Coordinator[P any] struct {
+	// ctx is passed into the follower factory and is the parent context of leader's lease context
+	// it is captured at the time of Coordinator creation as the context when getting may be short lived
+	ctx context.Context
+
+	advertise *url.URL
+	key       leases.Key
+	leaser    leases.Leaser
+	leaseTTL  time.Duration
+
+	// leader is active leader value is set
+	leaderFactory LeaderFactory[P]
+	leader        optional.Option[leader[P]]
+
+	followerFactory FollowerFactory[P]
+	follower        optional.Option[*follower[P]]
+
+	// mutex protects leader and follower coordination
+	mutex sync.Mutex
+}
+
+func NewCoordinator[P any](ctx context.Context,
+	advertise *url.URL,
+	key leases.Key,
+	leaser leases.Leaser,
+	leaseTTL time.Duration,
+	leaderFactory LeaderFactory[P],
+	followerFactory FollowerFactory[P]) *Coordinator[P] {
+	coordinator := &Coordinator[P]{
+		ctx:             ctx,
+		leaser:          leaser,
+		leaseTTL:        leaseTTL,
+		key:             key,
+		advertise:       advertise,
+		leaderFactory:   leaderFactory,
+		followerFactory: followerFactory,
+	}
+	// Attempt to coordinate proactively without blocking
+	go func() {
+		_, _ = coordinator.Get() //nolint:errcheck
+	}()
+	return coordinator
+}
+
+// Get returns either a leader or follower
+func (c *Coordinator[P]) Get() (leaderOrFollower P, err error) {
+	// Can not have multiple Get() calls in parallel as they may conflict with each other.
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	logger := log.FromContext(c.ctx)
+	if l, ok := c.leader.Get(); ok {
+		// currently leading
+		return l.value, nil
+	}
+	if f, ok := c.follower.Get(); ok && time.Now().Before(f.deadline) {
+		// currently following
+		return f.value, nil
+	}
+
+	lease, leaderCtx, leaseErr := c.leaser.AcquireLease(c.ctx, c.key, c.leaseTTL, optional.Some[any](c.advertise.String()))
+	if leaseErr == nil {
+		// became leader
+		l, err := c.leaderFactory(leaderCtx)
+		if err != nil {
+			lease.Release()
+			return leaderOrFollower, fmt.Errorf("could not create leader for %s: %w", c.key, err)
+		}
+		c.leader = optional.Some(leader[P]{
+			lease: lease,
+			value: l,
+		})
+		go func() {
+			c.watchForLeaderExpiration(leaderCtx)
+		}()
+		logger.Tracef("new leader for %s: %s", c.key, c.advertise)
+		return l, nil
+	}
+	if !errors.Is(leaseErr, dal.ErrConflict) {
+		return leaderOrFollower, fmt.Errorf("could not acquire lease for %s: %w", c.key, leaseErr)
+	}
+	// lease already held
+	return c.createFollower()
+}
+
+// watchForLeaderExpiration will remove the leader when the lease's context is cancelled due to failure to heartbeat the lease
+func (c *Coordinator[P]) watchForLeaderExpiration(ctx context.Context) {
+	<-ctx.Done()
+
+	logger := log.FromContext(c.ctx)
+	logger.Warnf("removing leader for %s", c.key)
+
+	c.mutex.Lock()
+	c.leader = optional.None[leader[P]]()
+	c.mutex.Unlock()
+}
+
+func (c *Coordinator[P]) createFollower() (out P, err error) {
+	var urlString string
+	expiry, err := c.leaser.GetLeaseInfo(c.ctx, c.key, &urlString)
+	if err != nil {
+		if errors.Is(err, dal.ErrNotFound) {
+			return out, fmt.Errorf("could not acquire or find lease for %s", c.key)
+		}
+		return out, fmt.Errorf("could not get lease for %s: %w", c.key, err)
+	}
+	if urlString == c.advertise.String() {
+		// This prevents endless loops after a lease breaks.
+		// If we create a follower pointing locally, the receiver will likely try to then call the leader, which starts the loop again.
+		return out, fmt.Errorf("could not follow %s leader at own url: %s", c.key, urlString)
+	}
+	// check if url matches existing follower's url, just with newer deadline
+	if f, ok := c.follower.Get(); ok && f.url.String() == urlString {
+		f.deadline = expiry
+		return f.value, nil
+	}
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return out, fmt.Errorf("could not parse leader url for %s: %w", c.key, err)
+	}
+	f, err := c.followerFactory(c.ctx, url)
+	if err != nil {
+		return out, fmt.Errorf("could not generate follower for %s: %w", c.key, err)
+	}
+	c.follower = optional.Some(&follower[P]{
+		value:    f,
+		deadline: expiry,
+		url:      url,
+	})
+	return f, nil
+}

--- a/backend/controller/leader/leader.go
+++ b/backend/controller/leader/leader.go
@@ -1,7 +1,7 @@
 // Package leader provides a way to coordinate a single leader and multiple followers.
 //
 // Coordinator uses factory functions for leaders and followers, creating each as needed.
-// Leader and followers conform to the same protocol so other components can interact with them in the same way.
+// Leader and followers conform to the same protocol, abstracting away the difference to callers.
 // Each coordinator has a url to advertise the leader to other coordinators if it generates one.
 //
 // A leader is created when a lease can be acquired in the database.

--- a/backend/controller/leader/leader.go
+++ b/backend/controller/leader/leader.go
@@ -1,3 +1,15 @@
+// Package leader provides a way to coordinate a single leader and multiple followers.
+//
+// Coordinator uses factory functions for leaders and followers, creating each as needed.
+// Leader and followers conform to the same protocol so other components can interact with them in the same way.
+// Each coordinator has a url to advertise the leader to other coordinators if it generates one.
+//
+// A leader is created when a lease can be acquired in the database.
+// Leaders last as long as the lease can be successfully renewed. Leaders should react to the context being cancelled to know
+// when they are no longer leading.
+//
+// A follower is created with with the url of the leader. Followers last as long as the url for the leader has not changed.
+
 package leader
 
 import (
@@ -36,7 +48,9 @@ type follower[P any] struct {
 }
 
 // Coordinator assigns a single leader for the rest to follow.
-// It uses a lease to ensure that only one leader is active at a time.
+//
+// P is the protocol that the leader and followers must implement. Callers of Get() will receive a P,
+// abstracting away whether they are interacting with a leader or a follower.
 type Coordinator[P any] struct {
 	// ctx is passed into the follower factory and is the parent context of leader's lease context
 	// it is captured at the time of Coordinator creation as the context when getting may be short lived

--- a/backend/controller/leases/fake_lease_test.go
+++ b/backend/controller/leases/fake_lease_test.go
@@ -6,22 +6,27 @@ import (
 	"time"
 
 	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/types/optional"
 )
 
 func TestFakeLease(t *testing.T) {
 	leaser := NewFakeLeaser()
 
-	lease1, err := leaser.AcquireLease(context.Background(), SystemKey("test"), time.Second)
+	lease1, lease1Ctx, err := leaser.AcquireLease(context.Background(), SystemKey("test"), time.Second, optional.None[any]())
 	assert.NoError(t, err)
 
-	_, err = leaser.AcquireLease(context.Background(), SystemKey("test"), time.Second)
+	_, _, err = leaser.AcquireLease(context.Background(), SystemKey("test"), time.Second, optional.None[any]())
 	assert.IsError(t, err, ErrConflict)
 
 	err = lease1.Release()
 	assert.NoError(t, err)
 
-	lease2, err := leaser.AcquireLease(context.Background(), SystemKey("test"), time.Second)
+	lease2, lease2Ctx, err := leaser.AcquireLease(context.Background(), SystemKey("test"), time.Second, optional.None[any]())
 	assert.NoError(t, err)
 	err = lease2.Release()
 	assert.NoError(t, err)
+
+	time.Sleep(time.Second)
+	assert.Error(t, lease1Ctx.Err(), "context should be cancelled after lease1 was released")
+	assert.Error(t, lease2Ctx.Err(), "context should be cancelled after lease2 was released")
 }

--- a/backend/controller/leases/leases.go
+++ b/backend/controller/leases/leases.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	"github.com/alecthomas/types/optional"
 )
 
 // ErrConflict is returned when a lease is already held.
@@ -23,7 +25,14 @@ type Leaser interface {
 	//
 	// This function will return [ErrConflict] if a lease is already held. The [ttl]
 	// must be at _least_ 5 seconds.
-	AcquireLease(ctx context.Context, key Key, ttl time.Duration) (Lease, error)
+	//
+	// The returned context will be cancelled when the lease fails to renew.
+	AcquireLease(ctx context.Context, key Key, ttl time.Duration, metadata optional.Option[any]) (Lease, context.Context, error)
+
+	// GetLeaseInfo returns the metadata and expiry time for a key.
+	//
+	// metadata should be a pointer to the type that metadata should be unmarshaled into.
+	GetLeaseInfo(ctx context.Context, key Key, metadata any) (expiry time.Time, err error)
 }
 
 // Lease represents a lease that is held by a controller.

--- a/backend/controller/scheduledtask/scheduledtask.go
+++ b/backend/controller/scheduledtask/scheduledtask.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alecthomas/types/optional"
 	clock "github.com/benbjohnson/clock"
 	"github.com/jpillora/backoff"
 
@@ -128,7 +129,7 @@ func (s *Scheduler) run(ctx context.Context) {
 				}
 				// If the job is singly homed, see if we can acquire the lease.
 				if job.singlyHomed && job.lease == nil {
-					lease, err := s.leaser.AcquireLease(ctx, leases.SystemKey("scheduledtask", job.name), time.Second*10)
+					lease, _, err := s.leaser.AcquireLease(ctx, leases.SystemKey("scheduledtask", job.name), time.Second*10, optional.None[any]())
 					if err != nil {
 						if errors.Is(err, leases.ErrConflict) {
 							logger.Scope(job.name).Tracef("Lease is held by another controller, will try again shortly.")

--- a/backend/controller/sql/models.go
+++ b/backend/controller/sql/models.go
@@ -461,6 +461,7 @@ type Lease struct {
 	Key            leases.Key
 	CreatedAt      time.Time
 	ExpiresAt      time.Time
+	Metadata       []byte
 }
 
 type Module struct {

--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -63,6 +63,7 @@ type Querier interface {
 	GetIdleRunners(ctx context.Context, labels []byte, limit int64) ([]Runner, error)
 	// Get the runner endpoints corresponding to the given ingress route.
 	GetIngressRoutes(ctx context.Context, method string) ([]GetIngressRoutesRow, error)
+	GetLeaseInfo(ctx context.Context, key leases.Key) (GetLeaseInfoRow, error)
 	GetModuleConfiguration(ctx context.Context, module optional.Option[string], name string) ([]byte, error)
 	GetModulesByID(ctx context.Context, ids []int64) ([]Module, error)
 	GetNextEventForSubscription(ctx context.Context, consumptionDelay time.Duration, topic model.TopicKey, cursor optional.Option[model.TopicEventKey]) (GetNextEventForSubscriptionRow, error)
@@ -91,7 +92,7 @@ type Querier interface {
 	KillStaleRunners(ctx context.Context, timeout time.Duration) (int64, error)
 	ListModuleConfiguration(ctx context.Context) ([]ModuleConfiguration, error)
 	LoadAsyncCall(ctx context.Context, id int64) (AsyncCall, error)
-	NewLease(ctx context.Context, key leases.Key, ttl time.Duration) (uuid.UUID, error)
+	NewLease(ctx context.Context, key leases.Key, ttl time.Duration, metadata []byte) (uuid.UUID, error)
 	PublishEventForTopic(ctx context.Context, arg PublishEventForTopicParams) error
 	ReleaseLease(ctx context.Context, idempotencyKey uuid.UUID, key leases.Key) (bool, error)
 	RenewLease(ctx context.Context, ttl time.Duration, idempotencyKey uuid.UUID, key leases.Key) (bool, error)

--- a/backend/controller/sql/schema/001_init.sql
+++ b/backend/controller/sql/schema/001_init.sql
@@ -442,7 +442,8 @@ CREATE TABLE leases (
     idempotency_key UUID UNIQUE NOT NULL,
     key lease_key UNIQUE NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
-    expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc')
+    expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() AT TIME ZONE 'utc'),
+    metadata JSONB
 );
 
 CREATE INDEX leases_expires_at_idx ON leases (expires_at);


### PR DESCRIPTION
- add `leader` package which coordinates between leaders and followers
    - leader and followers conform to the same interface
    - call `Get()` on the coordinator get get either a leader or a follower
    - built on top of leases
    - handles case when leader loses connection to the db and loses leader role
- leases now return a context which will be cancelled when the lease fails to heartbeat
    - no other lease-based features make use of this yet