### PR TITLE
fix: return expected leases.ErrConflict from dal

### DIFF
--- a/backend/controller/dal/lease_test.go
+++ b/backend/controller/dal/lease_test.go
@@ -50,7 +50,7 @@ func TestLease(t *testing.T) {
 
 	// Try to acquire the same lease again, which should fail.
 	_, _, err = dal.AcquireLease(ctx, leases.SystemKey("test"), time.Second*5, optional.None[any]())
-	assert.IsError(t, err, dalerrs.ErrConflict)
+	assert.IsError(t, err, leases.ErrConflict)
 
 	time.Sleep(time.Second * 6)
 

--- a/backend/controller/leader/leader.go
+++ b/backend/controller/leader/leader.go
@@ -132,7 +132,7 @@ func (c *Coordinator[P]) Get() (leaderOrFollower P, err error) {
 		logger.Tracef("new leader for %s: %s", c.key, c.advertise)
 		return l, nil
 	}
-	if !errors.Is(leaseErr, dalerrs.ErrConflict) {
+	if !errors.Is(leaseErr, leases.ErrConflict) {
 		return leaderOrFollower, fmt.Errorf("could not acquire lease for %s: %w", c.key, leaseErr)
 	}
 	// lease already held

--- a/backend/controller/leases/lease_integration_test.go
+++ b/backend/controller/leases/lease_integration_test.go
@@ -49,7 +49,7 @@ func TestLease(t *testing.T) {
 				Body: []byte("{}"),
 			}))
 			assert.NoError(t, err)
-			if resp.Msg.GetError() == nil || !strings.Contains(resp.Msg.GetError().Message, "could not acquire lease") {
+			if resp.Msg.GetError() == nil || !strings.Contains(resp.Msg.GetError().Message, "lease already held") {
 				t.Fatalf("expected error but got: %#v", resp.Msg.GetError())
 			}
 			err = wg.Wait()


### PR DESCRIPTION
fixes #1678
leases interface documents that `leases.ErrConflict` is the expected error if lease acquisition fails, but dal was returning `dal.ErrConflict`