### PR TITLE
fix: don't fail `ftl new` if there's no git repo

### DIFF
--- a/cmd/ftl/cmd_new.go
+++ b/cmd/ftl/cmd_new.go
@@ -67,8 +67,9 @@ func (i newGoCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	logger.Debugf("Adding files to git")
-	if !config.NoGit {
+	_, ok := internal.GitRoot(i.Dir).Get()
+	if !config.NoGit && ok {
+		logger.Debugf("Adding files to git")
 		if config.Hermit {
 			if err := maybeGitAdd(ctx, i.Dir, "bin/*"); err != nil {
 				return err


### PR DESCRIPTION
Fixes #1848