### PR TITLE
chore: make using ModuleConfig paths more consistent

### DIFF
--- a/buildengine/build.go
+++ b/buildengine/build.go
@@ -36,7 +36,7 @@ func buildModule(ctx context.Context, sch *schema.Schema, module Module, filesTr
 	ctx = log.ContextWithLogger(ctx, logger)
 
 	// clear the deploy directory before extracting schema
-	if err := os.RemoveAll(module.Config.AbsDeployDir()); err != nil {
+	if err := os.RemoveAll(module.Config.Abs().DeployDir); err != nil {
 		return fmt.Errorf("failed to clear errors: %w", err)
 	}
 
@@ -55,7 +55,7 @@ func buildModule(ctx context.Context, sch *schema.Schema, module Module, filesTr
 		errs = append(errs, err)
 	}
 	// read runtime-specific build errors from the build directory
-	errorList, err := loadProtoErrors(module.Config)
+	errorList, err := loadProtoErrors(module.Config.Abs())
 	if err != nil {
 		return fmt.Errorf("failed to read build errors for module: %w", err)
 	}
@@ -71,13 +71,12 @@ func buildModule(ctx context.Context, sch *schema.Schema, module Module, filesTr
 	return nil
 }
 
-func loadProtoErrors(config moduleconfig.ModuleConfig) (*schema.ErrorList, error) {
-	f := filepath.Join(config.AbsDeployDir(), config.Errors)
-	if _, err := os.Stat(f); errors.Is(err, os.ErrNotExist) {
+func loadProtoErrors(config moduleconfig.AbsModuleConfig) (*schema.ErrorList, error) {
+	if _, err := os.Stat(config.Errors); errors.Is(err, os.ErrNotExist) {
 		return &schema.ErrorList{Errors: make([]*schema.Error, 0)}, nil
 	}
 
-	content, err := os.ReadFile(f)
+	content, err := os.ReadFile(config.Errors)
 	if err != nil {
 		return nil, err
 	}

--- a/buildengine/build_kotlin.go
+++ b/buildengine/build_kotlin.go
@@ -94,7 +94,7 @@ func SetPOMProperties(ctx context.Context, baseDir string) error {
 }
 
 func prepareFTLRoot(module Module) error {
-	buildDir := module.Config.AbsDeployDir()
+	buildDir := module.Config.Abs().DeployDir
 	if err := os.MkdirAll(buildDir, 0700); err != nil {
 		return err
 	}

--- a/buildengine/build_test.go
+++ b/buildengine/build_test.go
@@ -122,7 +122,7 @@ func assertBuildProtoErrors(msgs ...string) assertion {
 		t.Helper()
 		config, err := moduleconfig.LoadModuleConfig(bctx.moduleDir)
 		assert.NoError(t, err, "Error loading module config")
-		errorList, err := loadProtoErrors(config)
+		errorList, err := loadProtoErrors(config.Abs())
 		assert.NoError(t, err, "Error loading proto errors")
 
 		expected := make([]*schema.Error, 0, len(msgs))

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -539,7 +539,7 @@ func writeSchema(config moduleconfig.ModuleConfig, module *schema.Module) error 
 	if err != nil {
 		return fmt.Errorf("failed to marshal schema: %w", err)
 	}
-	return os.WriteFile(filepath.Join(config.AbsDeployDir(), "schema.pb"), schemaBytes, 0600)
+	return os.WriteFile(config.Abs().Schema, schemaBytes, 0600)
 }
 
 func writeSchemaErrors(config moduleconfig.ModuleConfig, errors []*schema.Error) error {
@@ -550,7 +550,7 @@ func writeSchemaErrors(config moduleconfig.ModuleConfig, errors []*schema.Error)
 	if err != nil {
 		return fmt.Errorf("failed to marshal errors: %w", err)
 	}
-	return os.WriteFile(filepath.Join(config.AbsDeployDir(), config.Errors), elBytes, 0600)
+	return os.WriteFile(config.Abs().Errors, elBytes, 0600)
 }
 
 func getSumTypes(module *schema.Module, sch *schema.Schema, nativeNames NativeNames) []goSumType {


### PR DESCRIPTION
`.Abs()` will return a clone with all paths made absolute. This avoids a bunch of manual and error prone joining.