### PR TITLE
fix: `GetModuleContext()` was busy looping

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -122,6 +122,7 @@ func (s *serveCmd) Run(ctx context.Context, projConfig projectconfig.Config) err
 		if err := kong.ApplyDefaults(&config); err != nil {
 			return err
 		}
+		config.ModuleUpdateFrequency = time.Second * 1
 
 		scope := fmt.Sprintf("controller%d", i)
 		controllerCtx := log.ContextWithLogger(ctx, logger.Scope(scope))


### PR DESCRIPTION
By design, `RetryStreamingServerStream()` repeatedly retries the RPC when it exits, and `GetModuleContext()` was exiting immediately after sending its first response, resulting in a busy loop.