### PR TITLE
feat: implement `ftl box run`

### DIFF
--- a/Dockerfile.box
+++ b/Dockerfile.box
@@ -47,4 +47,4 @@ RUN mkdir modules
 EXPOSE 8891
 EXPOSE 8892
 
-CMD ["/root/ftl", "box", "run"]
+CMD ["/root/ftl", "box-run", "/root/deployments"]

--- a/cmd/ftl/cmd_box_run.go
+++ b/cmd/ftl/cmd_box_run.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/jpillora/backoff"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/TBD54566975/ftl/backend/controller"
+	"github.com/TBD54566975/ftl/backend/controller/dal"
+	"github.com/TBD54566975/ftl/backend/controller/scaling/localscaling"
+	"github.com/TBD54566975/ftl/backend/controller/sql/databasetesting"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/buildengine"
+	"github.com/TBD54566975/ftl/internal/bind"
+	"github.com/TBD54566975/ftl/internal/model"
+	"github.com/TBD54566975/ftl/internal/rpc"
+)
+
+type boxRunCmd struct {
+	Recreate          bool          `help:"Recreate the database."`
+	DSN               string        `help:"DSN for the database." default:"postgres://postgres:secret@localhost:5432/ftl?sslmode=disable" env:"FTL_CONTROLLER_DSN"`
+	IngressBind       *url.URL      `help:"Bind address for the ingress server." default:"http://0.0.0.0:8891" env:"FTL_INGRESS_BIND"`
+	Bind              *url.URL      `help:"Bind address for the FTL controller." default:"http://0.0.0.0:8892" env:"FTL_BIND"`
+	RunnerBase        *url.URL      `help:"Base bind address for FTL runners." default:"http://127.0.0.1:8893" env:"FTL_RUNNER_BIND"`
+	Dir               string        `arg:"" help:"Directory to scan for precompiled modules." default:"."`
+	ControllerTimeout time.Duration `help:"Timeout for Controller start." default:"30s"`
+}
+
+func (b *boxRunCmd) Run(ctx context.Context) error {
+	conn, err := databasetesting.CreateForDevel(ctx, b.DSN, b.Recreate)
+	if err != nil {
+		return fmt.Errorf("failed to create database: %w", err)
+	}
+	dal, err := dal.New(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("failed to create DAL: %w", err)
+	}
+	config := controller.Config{
+		Bind:        b.Bind,
+		IngressBind: b.IngressBind,
+		Key:         model.NewLocalControllerKey(0),
+		DSN:         b.DSN,
+	}
+	if err := kong.ApplyDefaults(&config); err != nil {
+		return err
+	}
+
+	// Start the controller.
+	runnerPortAllocator, err := bind.NewBindAllocator(b.RunnerBase)
+	if err != nil {
+		return fmt.Errorf("failed to create runner port allocator: %w", err)
+	}
+	runnerScaling, err := localscaling.NewLocalScaling(runnerPortAllocator, []*url.URL{b.Bind})
+	if err != nil {
+		return fmt.Errorf("failed to create runner autoscaler: %w", err)
+	}
+	wg := errgroup.Group{}
+	wg.Go(func() error {
+		return controller.Start(ctx, config, runnerScaling, dal)
+	})
+
+	// Wait for the controller to come up.
+	client := ftlv1connect.NewControllerServiceClient(rpc.GetHTTPClient(b.Bind.String()), b.Bind.String())
+	waitCtx, cancel := context.WithTimeout(ctx, b.ControllerTimeout)
+	defer cancel()
+	if err := rpc.Wait(waitCtx, backoff.Backoff{}, client); err != nil {
+		return fmt.Errorf("controller failed to start: %w", err)
+	}
+
+	engine, err := buildengine.New(ctx, client, []string{b.Dir})
+	if err != nil {
+		return fmt.Errorf("failed to create build engine: %w", err)
+	}
+
+	if err := engine.Deploy(ctx, 1, true); err != nil {
+		return fmt.Errorf("failed to deploy: %w", err)
+	}
+	return wg.Wait()
+}

--- a/cmd/ftl/cmd_deploy.go
+++ b/cmd/ftl/cmd_deploy.go
@@ -21,5 +21,5 @@ func (d *deployCmd) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return engine.Deploy(ctx, d.Replicas, !d.NoWait)
+	return engine.BuildAndDeploy(ctx, d.Replicas, !d.NoWait)
 }

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -45,6 +45,7 @@ type CLI struct {
 	Schema   schemaCmd   `cmd:"" help:"FTL schema commands."`
 	Build    buildCmd    `cmd:"" help:"Build all modules found in the specified directories."`
 	Box      boxCmd      `cmd:"" help:"Build a self-contained Docker container for running a set of module."`
+	BoxRun   boxRunCmd   `cmd:"" hidden:"" help:"Run FTL inside an ftl-in-a-box container"`
 	Deploy   deployCmd   `cmd:"" help:"Build and deploy all modules found in the specified directories."`
 	Download downloadCmd `cmd:"" help:"Download a deployment."`
 	Secret   secretCmd   `cmd:"" help:"Manage secrets."`

--- a/internal/modulecontext/module_context.go
+++ b/internal/modulecontext/module_context.go
@@ -5,15 +5,17 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
-	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
-	"github.com/TBD54566975/ftl/internal/rpc"
-	"github.com/alecthomas/atomic"
-	"github.com/jpillora/backoff"
-	"golang.org/x/sync/errgroup"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/alecthomas/atomic"
+	"github.com/jpillora/backoff"
+	"golang.org/x/sync/errgroup"
+
+	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/internal/rpc"
 
 	"github.com/alecthomas/types/optional"
 	_ "github.com/jackc/pgx/v5/stdlib" // SQL driver

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -162,7 +162,7 @@ func RetryStreamingClientStream[Req, Resp any](
 				break
 			}
 			if errored {
-				logger.Debugf("Stream recovered")
+				logger.Debugf("Client stream recovered")
 				errored = false
 			}
 			select {
@@ -218,7 +218,7 @@ func RetryStreamingServerStream[Req, Resp any](
 					break
 				}
 				if errored {
-					logger.Debugf("Stream recovered")
+					logger.Debugf("Server stream recovered")
 					errored = false
 				}
 				select {
@@ -238,6 +238,8 @@ func RetryStreamingServerStream[Req, Resp any](
 		delay := retry.Duration()
 		if err != nil && !errors.Is(err, context.Canceled) {
 			logger.Logf(logLevel, "Stream handler failed, retrying in %s: %s", delay, err)
+		} else if err == nil {
+			logger.Debugf("Stream finished, retrying in %s", delay)
 		}
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
This required some changes to how the build engine works, in that build and deploy can now be run separately.

Building the box:

```
🐚 ~/dev/ftl $ ftl box echo examples/go
info:time: Building module
info:echo: Building module
info: Building image echo
```

Running locally:

```
🐚 ~/dev/ftl $ ftl box-run --dsn="postgres://postgres:secret@localhost:15432/ftl?sslmode=disable" examples/go/
info: Web console available at: http://0.0.0.0:8892
info: HTTP ingress server listening on: http://0.0.0.0:8891
info:time: Deploying module
info: Reusing deployment: dpl-time-xpun6vddce07f5s
info: Deployed dpl-echo-1bd1tvnmig06767u
info: Deployed dpl-time-xpun6vddce07f5s
info:echo: Deploying module
info: Reusing deployment: dpl-echo-1bd1tvnmig06767u
info: All modules deployed
```

Running the resulting image works but we need to set up Docker compose with PG:

```
🐚 ~/dev/ftl $ docker run --platform linux/amd64 echo
ftl: error: failed to create database: database not ready after 10 tries: failed to connect to `user=postgres database=`:
             127.0.0.1:5432 (localhost): dial error: dial tcp 127.0.0.1:5432: connect: connection refused
             [::1]:5432 (localhost): dial error: dial tcp [::1]:5432: connect: connection refused
```