### PR TITLE
fix: improve errors when unmarshalling config/secrets

### DIFF
--- a/backend/controller/admin/admin.go
+++ b/backend/controller/admin/admin.go
@@ -54,7 +54,7 @@ func (s *AdminService) ConfigList(ctx context.Context, req *connect.Request[ftlv
 			var value any
 			err := s.cm.Get(ctx, config.Ref, &value)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to get value for %v: %w", ref, err)
 			}
 			cv, err = json.Marshal(value)
 			if err != nil {
@@ -140,7 +140,7 @@ func (s *AdminService) SecretsList(ctx context.Context, req *connect.Request[ftl
 			var value any
 			err := s.sm.Get(ctx, secret.Ref, &value)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("failed to get value for %v: %w", ref, err)
 			}
 			sv, err = json.Marshal(value)
 			if err != nil {

--- a/common/configuration/manager.go
+++ b/common/configuration/manager.go
@@ -98,7 +98,11 @@ func (m *Manager[R]) Get(ctx context.Context, ref Ref, value any) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, value)
+	err = json.Unmarshal(data, value)
+	if err != nil {
+		return fmt.Errorf("could not unmarshal: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager[R]) availableProviderKeys() []string {


### PR DESCRIPTION
previously we would see errors like this when getting the secrets list with values if a secret was not properly json encoded:
> unknown: invalid character 'c' looking for beginning of value

now we will get errors like this:
> unknown: failed to get value for [module].[name]: could not unmarshal: invalid character 'c' looking for beginning of value