### PR TITLE
chore: enable wrapcheck for new code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,12 +58,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
       - name: Build Cache
         uses: ./.github/actions/build-cache
       - name: golangci-lint
-        run: golangci-lint run --out-format github-actions ./...
+        run: golangci-lint run --new-from-rev="$(git merge-base origin/main HEAD)" --out-format github-actions ./...
       - name: go-check-sumtype
         shell: bash
         run: go-check-sumtype ./... 2>&1 | to-annotation

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,6 @@ linters:
     - interfacebloat
     - tagalign
     - nolintlint
-    - wrapcheck # We might want to re-enable this if we manually wrap all the existing errors with fmt.Errorf
     - protogetter
 
 linters-settings:

--- a/Justfile
+++ b/Justfile
@@ -139,7 +139,7 @@ lint-frontend: build-frontend
 
 # Lint the backend
 lint-backend:
-  @golangci-lint run ./...
+  @golangci-lint run --new-from-rev=$(git merge-base origin/main HEAD) ./...
 
 # Run live docs server
 docs:


### PR DESCRIPTION
This has been disabled because manually wrapping all errors is very tedious when iterating quickly, but it's come to the point where we need to do this in order to provide useful errors. Recent examples of this are https://github.com/TBD54566975/ftl/pull/1885 and https://github.com/TBD54566975/ftl/pull/1879.