### PR TITLE
fix: make 1Password serial access less strict

### DIFF
--- a/common/configuration/manager.go
+++ b/common/configuration/manager.go
@@ -105,6 +105,11 @@ func (m *Manager[R]) Get(ctx context.Context, ref Ref, value any) error {
 	return nil
 }
 
+func (m *Manager[R]) HasProviderForKey(key string) bool {
+	_, ok := m.providers[key]
+	return ok
+}
+
 func (m *Manager[R]) availableProviderKeys() []string {
 	keys := make([]string, 0, len(m.providers))
 	for k := range m.providers {


### PR DESCRIPTION
Fixes this issue:
- Try deploying modules with a decent amount of secrets
- Initial deploys would work, and then those deployments would saturate 1password access while checking for updates every 1s
    - It takes about 1s for a call to `op` to return a result
- Subsequent deploys would struggle to succeed as secrets need to be gathered within 5s.

Also of note: always calling `op` serially would mean modules with ~5 secrets could never be deployed

Changes:
- `OnePasswordProvider` is less strict. If a call to `op` succeeded within a second ago then concurrent calls to `op` is allowed
- Controller only processes updates to secrets serially. This avoids the biggest cause of multiple 1Password prompts
    - This is skipped if 1Password is not a provider (ie: production)

Multiple 1Password prompts are possible, but hopefully minimized.
- In idle state, controllers will only be making 1 `op` call at a time (module update checks)
- In short bursts, more `op` calls can happen at a time
- Previously, after the computer was locked, we would prompt as many times as there were deployed modules with 1Password secrets