### PR TITLE
fix: diagnostic errors were being discarded

### DIFF
--- a/lsp/lsp.go
+++ b/lsp/lsp.go
@@ -103,23 +103,20 @@ func (s *Server) post(err error) {
 
 	// Deduplicate and associate by filename.
 	for _, e := range ftlErrors.DeduplicateErrors(ftlErrors.UnwrapAll(err)) {
-		// CompilerBuildErrors are not innermost errors, so we need to check for them first.
-		var cbe buildengine.CompilerBuildError
-		if errors.As(e, &cbe) {
-			// CompilerBuildErrors should have emitted errors beforehand so don't alert the user again.
-			return
-		}
-
 		if !ftlErrors.Innermost(e) {
 			continue
 		}
+
 		var ce *schema.Error
+		var cbe buildengine.CompilerBuildError
 		if errors.As(e, &ce) {
 			filename := ce.Pos.Filename
 			if _, exists := errByFilename[filename]; !exists {
 				errByFilename[filename] = errSet{}
 			}
 			errByFilename[filename] = append(errByFilename[filename], ce)
+		} else if errors.As(e, &cbe) {
+			continue
 		} else {
 			errUnspecified = append(errUnspecified, err)
 		}


### PR DESCRIPTION
Fixes #1849 

Error detection was far too aggressive, discarding legit schema.Errors.
