### PR TITLE
fix(vscode): show full command executing ftl

### DIFF
--- a/extensions/vscode/src/client.ts
+++ b/extensions/vscode/src/client.ts
@@ -42,7 +42,6 @@ export class FTLClient {
       },
     }
 
-
     const clientOptions: LanguageClientOptions = {
       documentSelector: [
         { scheme: 'file', language: 'kotlin' },
@@ -58,7 +57,7 @@ export class FTLClient {
       clientOptions
     )
 
-    let options = (this.client.isInDebugMode) ? serverOptions.debug : serverOptions.run
+    const options = (this.client.isInDebugMode) ? serverOptions.debug : serverOptions.run
     this.outputChannel.appendLine(`Running ${ftlPath} ${options.args?.join(' ')}`)
     console.log(options)
 

--- a/extensions/vscode/src/client.ts
+++ b/extensions/vscode/src/client.ts
@@ -42,8 +42,6 @@ export class FTLClient {
       },
     }
 
-    this.outputChannel.appendLine(`Running ${ftlPath} with flags: ${flags.join(' ')}`)
-    console.log(serverOptions.debug.args)
 
     const clientOptions: LanguageClientOptions = {
       documentSelector: [
@@ -59,6 +57,11 @@ export class FTLClient {
       serverOptions,
       clientOptions
     )
+
+    let options = (this.client.isInDebugMode) ? serverOptions.debug : serverOptions.run
+    this.outputChannel.appendLine(`Running ${ftlPath} ${options.args?.join(' ')}`)
+    console.log(options)
+
     context.subscriptions.push(this.client)
 
     const buildStatus = this.client.onNotification('ftl/buildState', (message) => {


### PR DESCRIPTION
Previously it wasn't including "dev" when showing the command.

Also changed it so you can copy paste the command without text between the command and args.