### PR TITLE
fix(vscode): handle lsp crashes

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "lookpath": "^1.2.2",
         "semver": "^7.6.0",
-        "vscode-languageclient": "^9.0.1"
+        "vscode-languageclient": "^10.0.0-next.8"
       },
       "devDependencies": {
         "@types/mocha": "^10.0.6",
@@ -28,7 +28,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "vscode": "^1.87.0"
+        "vscode": "^1.90.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2646,7 +2646,6 @@
       "version": "9.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
       "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -4075,50 +4074,39 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "version": "9.0.0-next.4",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-9.0.0-next.4.tgz",
+      "integrity": "sha512-zSVIr58lJSMYKIsZ5P7GtBbv1eEx25eNyOf0NmEzxmn1GhUNJAVAb5hkA1poKUwj1FRMwN6CeyWxZypmr8SsQQ==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
-      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
+      "version": "10.0.0-next.8",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-10.0.0-next.8.tgz",
+      "integrity": "sha512-D9inIHgqKayO9Tv0MeLb3XIL76yTuWmKdHqcGZKzjtQrMGJgASJDYWTapu+yAjEpDp0gmVOaCYyIlLB86ncDoQ==",
       "dependencies": {
-        "minimatch": "^5.1.0",
-        "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.5"
+        "minimatch": "^9.0.3",
+        "semver": "^7.6.0",
+        "vscode-languageserver-protocol": "3.17.6-next.6"
       },
       "engines": {
-        "vscode": "^1.82.0"
-      }
-    },
-    "node_modules/vscode-languageclient/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
+        "vscode": "^1.89.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "version": "3.17.6-next.6",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.6-next.6.tgz",
+      "integrity": "sha512-naxM9kc/phpl0kAFNVPejMUWUtzFXdPYY/BtQTYtfbBbHf8sceHOrKkmf6yynZRu1A4oFtRZNqV3wyFRTWqUHw==",
       "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
+        "vscode-jsonrpc": "9.0.0-next.4",
+        "vscode-languageserver-types": "3.17.6-next.4"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
-      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+      "version": "3.17.6-next.4",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.6-next.4.tgz",
+      "integrity": "sha512-SeJTpH/S14EbxOAVaOUoGVqPToqpRTld5QO5Ghig3AlbFJTFF9Wu7srHMfa85L0SX1RYAuuCSFKJVVCxDIk1/Q=="
     },
     "node_modules/watchpack": {
       "version": "2.4.1",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/TBD54566975/ftl-vscode"
   },
   "engines": {
-    "vscode": "^1.87.0"
+    "vscode": "^1.90.2"
   },
   "categories": [
     "Other"
@@ -99,6 +99,6 @@
   "dependencies": {
     "lookpath": "^1.2.2",
     "semver": "^7.6.0",
-    "vscode-languageclient": "^9.0.1"
+    "vscode-languageclient": "^10.0.0-next.8"
   }
 }

--- a/extensions/vscode/src/client.ts
+++ b/extensions/vscode/src/client.ts
@@ -3,6 +3,7 @@ import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
+  State,
 } from 'vscode-languageclient/node'
 import { FTLStatus } from './status'
 
@@ -14,6 +15,7 @@ export class FTLClient {
   private outputChannel: vscode.OutputChannel
   private client: LanguageClient | undefined
   private isClientStarting = false
+  private isExpectingStop = false
 
   constructor(statusBar: vscode.StatusBarItem, output: vscode.OutputChannel) {
     this.statusBarItem = statusBar
@@ -81,14 +83,41 @@ export class FTLClient {
     this.outputChannel.appendLine('Starting lsp client')
     try {
       await this.client.start()
-      this.outputChannel.appendLine('Client started')
       console.log(`${this.clientName} started`)
-      FTLStatus.buildOK(this.statusBarItem)
     } catch (error) {
       console.error(`Error starting ${this.clientName}: ${error}`)
       FTLStatus.ftlError(this.statusBarItem, `Error starting ${this.clientName}: ${error}`)
-      this.outputChannel.appendLine(`Error starting ${this.clientName}: ${error}`)
     }
+
+    this.client.onDidChangeState((event) => {
+      switch (event.newState) {
+        case State.Starting:
+          FTLStatus.ftlStarting(this.statusBarItem)
+          this.isClientStarting = true
+          break
+        case State.Running:
+          FTLStatus.buildRunning(this.statusBarItem)
+          this.isClientStarting = false
+          break
+        case State.Stopped:
+          if (this.isExpectingStop) {
+            FTLStatus.ftlStopped(this.statusBarItem)
+          } else {
+            FTLStatus.ftlError(this.statusBarItem, 'Client stopped unexpectedly')
+            this.client = undefined
+          }
+          this.isExpectingStop = false
+          this.isClientStarting = false
+          break
+        case State.StartFailed:
+          // TODO: This is new in vscode-languageclient v10.0.0 but is not being set for some reason.
+          // https://github.com/microsoft/vscode-languageserver-node/blob/539330136d84891d005e2d0d539932a05644ba54/client/src/common/client.ts#L1618
+          FTLStatus.ftlError(this.statusBarItem, 'Client start failed')
+          this.client = undefined
+          this.isClientStarting = false
+          break
+      }
+    })
 
     this.isClientStarting = false
   }
@@ -113,6 +142,7 @@ export class FTLClient {
 
     console.log('Stopping client')
     const serverProcess = this.client!['_serverProcess']
+    this.isExpectingStop = true
 
     try {
       await this.client!.stop()
@@ -148,7 +178,5 @@ export class FTLClient {
     } else if (serverProcess && serverProcess.killed) {
       console.log('Server process was already killed')
     }
-
-    FTLStatus.ftlStopped(this.statusBarItem)
   }
 }


### PR DESCRIPTION
Fixes #1890 

- Detect when FTL stops via crash and shows an error on the status bar.
- When restarting, start spinning again.
- Tested manually with both examples in #1890 and also killing the process directly.