### PR TITLE
revert: "fix: call `op` serially to avoid multiple authorization prompts

### DIFF
--- a/common/configuration/defaults.go
+++ b/common/configuration/defaults.go
@@ -18,6 +18,6 @@ func NewSecretsManager(ctx context.Context, router Router[Secrets], opVault stri
 		InlineProvider[Secrets]{},
 		EnvarProvider[Secrets]{},
 		KeychainProvider{},
-		&OnePasswordProvider{Vault: opVault},
+		OnePasswordProvider{Vault: opVault},
 	})
 }


### PR DESCRIPTION
Loading passwords this way took so long that deploys started failing.
This reverts commit b5fbf19765d91b42e198fb8bdf0e8712fa7b5edf.