### PR TITLE
fix: reduce ASM batch size to stay within filter limit of 10

### DIFF
--- a/common/configuration/asm_leader.go
+++ b/common/configuration/asm_leader.go
@@ -95,7 +95,9 @@ func (l *asmLeader) sync(ctx context.Context, secrets *xsync.MapOf[Ref, cachedSe
 
 	// get values for new and updated secrets
 	for len(refsToLoad) > 0 {
-		batchSize := 20
+		// ASM returns an error when there are more than 10 filters
+		// A batch size of 9 + 1 tag filter keeps us within this limit
+		batchSize := 9
 		secretIDs := []string{}
 		for ref := range refsToLoad {
 			secretIDs = append(secretIDs, ref.String())


### PR DESCRIPTION
fixes #1937
Not able to reproduce the issue in local stack. A tag filter + 20 secret names worked fine there.