### PR TITLE
fix: validate project config

### DIFF
--- a/backend/controller/admin/admin_test.go
+++ b/backend/controller/admin/admin_test.go
@@ -62,7 +62,7 @@ func tempConfigPath(t *testing.T, existingPath string, prefix string) string {
 	var existing []byte
 	var err error
 	if existingPath == "" {
-		existing = []byte{}
+		existing = []byte("name = \"generated\"")
 	} else {
 		existing, err = os.ReadFile(existingPath)
 		assert.NoError(t, err)

--- a/backend/controller/admin/admin_test.go
+++ b/backend/controller/admin/admin_test.go
@@ -62,7 +62,7 @@ func tempConfigPath(t *testing.T, existingPath string, prefix string) string {
 	var existing []byte
 	var err error
 	if existingPath == "" {
-		existing = []byte("name = \"generated\"")
+		existing = []byte(`name = "generated"`)
 	} else {
 		existing, err = os.ReadFile(existingPath)
 		assert.NoError(t, err)

--- a/backend/controller/admin/testdata/ftl-project.toml
+++ b/backend/controller/admin/testdata/ftl-project.toml
@@ -1,3 +1,4 @@
+name = "testdata"
 [global]
 [global.secrets]
 bar = "envar://baza"

--- a/backend/controller/sql/testdata/go/database/ftl-project.toml
+++ b/backend/controller/sql/testdata/go/database/ftl-project.toml
@@ -1,3 +1,4 @@
+name = "testdata"
 ftl-min-version = ""
 
 [global]

--- a/common/configuration/manager_test.go
+++ b/common/configuration/manager_test.go
@@ -101,7 +101,7 @@ func tempConfigPath(t *testing.T, existingPath string, prefix string) string {
 	var existing []byte
 	var err error
 	if existingPath == "" {
-		existing = []byte{}
+		existing = []byte("name = \"generated\"")
 	} else {
 		existing, err = os.ReadFile(existingPath)
 		assert.NoError(t, err)

--- a/common/configuration/manager_test.go
+++ b/common/configuration/manager_test.go
@@ -101,7 +101,7 @@ func tempConfigPath(t *testing.T, existingPath string, prefix string) string {
 	var existing []byte
 	var err error
 	if existingPath == "" {
-		existing = []byte("name = \"generated\"")
+		existing = []byte(`name = "generated"`)
 	} else {
 		existing, err = os.ReadFile(existingPath)
 		assert.NoError(t, err)

--- a/common/configuration/projectconfig_resolver.go
+++ b/common/configuration/projectconfig_resolver.go
@@ -70,7 +70,7 @@ func (p ProjectConfigResolver[R]) List(ctx context.Context) ([]Entry, error) {
 }
 
 func (p ProjectConfigResolver[R]) Set(ctx context.Context, ref Ref, key *url.URL) error {
-	config, err := pc.LoadOrCreate(ctx, p.Config)
+	config, err := pc.Load(ctx, p.Config)
 	if err != nil {
 		return err
 	}
@@ -83,7 +83,7 @@ func (p ProjectConfigResolver[R]) Set(ctx context.Context, ref Ref, key *url.URL
 }
 
 func (p ProjectConfigResolver[From]) Unset(ctx context.Context, ref Ref) error {
-	config, err := pc.LoadOrCreate(ctx, p.Config)
+	config, err := pc.Load(ctx, p.Config)
 	if err != nil {
 		return err
 	}

--- a/common/configuration/projectconfig_resolver_test.go
+++ b/common/configuration/projectconfig_resolver_test.go
@@ -26,19 +26,12 @@ func TestSet(t *testing.T) {
 	err = os.WriteFile(config, existing, 0600)
 	assert.NoError(t, err)
 
-	t.Run("ExistingModule", func(t *testing.T) {
-		setAndAssert(t, "echo", config)
-	})
-	t.Run("NewModule", func(t *testing.T) {
-		setAndAssert(t, "echooo", config)
-	})
-	t.Run("MissingTOMLFile", func(t *testing.T) {
-		err := os.Remove(config)
-		assert.NoError(t, err)
-		setAndAssert(t, "echooooo", config)
-		err = os.WriteFile(defaultPath, origConfigBytes, 0600)
-		assert.NoError(t, err)
-	})
+	setAndAssert(t, "echo", config)
+	setAndAssert(t, "echooo", config)
+
+	// Restore the original config file.
+	err = os.WriteFile(defaultPath, origConfigBytes, 0600)
+	assert.NoError(t, err)
 }
 
 func TestGetGlobal(t *testing.T) {

--- a/common/configuration/testdata/ftl-project.toml
+++ b/common/configuration/testdata/ftl-project.toml
@@ -1,3 +1,5 @@
+name = "testdata"
+
 [global]
 [global.secrets]
 baz = "envar://baz"

--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -47,6 +47,26 @@ func (c Config) Root() string {
 	return filepath.Dir(c.Path)
 }
 
+// Validate checks that the configuration is valid.
+func (c Config) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("project name is required: %s", c.Path)
+	}
+	if strings.Contains(c.Name, " ") {
+		return fmt.Errorf("project name %q includes spaces: %s", c.Name, c.Path)
+	}
+	if c.FTLMinVersion != "" && !ftl.IsVersionAtLeastMin(ftl.Version, c.FTLMinVersion) {
+		return fmt.Errorf("FTL version %q predates the minimum version %q", ftl.Version, c.FTLMinVersion)
+	}
+	for _, dir := range c.ModuleDirs {
+		absDir := filepath.Clean(filepath.Join(c.Root(), dir))
+		if !strings.HasPrefix(absDir, c.Root()) {
+			return fmt.Errorf("module-dirs path %q is not within the project root %q", dir, c.Root())
+		}
+	}
+	return nil
+}
+
 // AbsModuleDirs returns the absolute path for the module-dirs field from the ftl-project.toml, unless
 // that is not defined, in which case it defaults to the root directory.
 func (c Config) AbsModuleDirs() []string {
@@ -103,6 +123,9 @@ func DefaultConfigPath() optional.Option[string] {
 
 // Create creates the ftl-project.toml file with the given Config into dir.
 func Create(ctx context.Context, config Config, dir string) error {
+	if err := config.Validate(); err != nil {
+		return err
+	}
 	logger := log.FromContext(ctx)
 	path, err := filepath.Abs(dir)
 	if err != nil {
@@ -159,19 +182,11 @@ func Load(ctx context.Context, path string) (Config, error) {
 		}
 		return Config{}, fmt.Errorf("unknown configuration keys: %s", strings.Join(keys, ", "))
 	}
-
-	if config.FTLMinVersion != "" && !ftl.IsVersionAtLeastMin(ftl.Version, config.FTLMinVersion) {
-		return config, fmt.Errorf("FTL version %q predates the minimum version %q", ftl.Version, config.FTLMinVersion)
-	}
 	config.Path = path
 
-	for _, dir := range config.ModuleDirs {
-		absDir := filepath.Clean(filepath.Join(config.Root(), dir))
-		if !strings.HasPrefix(absDir, config.Root()) {
-			return Config{}, fmt.Errorf("module-dirs path %q is not within the project root %q", dir, config.Root())
-		}
+	if err := config.Validate(); err != nil {
+		return Config{}, err
 	}
-
 	return config, nil
 }
 

--- a/common/projectconfig/projectconfig.go
+++ b/common/projectconfig/projectconfig.go
@@ -144,19 +144,6 @@ func Create(ctx context.Context, config Config, dir string) error {
 	return Save(config)
 }
 
-// LoadOrCreate loads or creates the given configuration file.
-func LoadOrCreate(ctx context.Context, target string) (Config, error) {
-	logger := log.FromContext(ctx)
-	if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
-		logger.Debugf("Creating a new project config file at %q", target)
-		config := Config{Path: target}
-		return config, Save(config)
-	}
-
-	log.FromContext(ctx).Tracef("Loading config from %s", target)
-	return Load(ctx, target)
-}
-
 // Load project config from a file.
 func Load(ctx context.Context, path string) (Config, error) {
 	if path == "" {

--- a/common/projectconfig/projectconfig_test.go
+++ b/common/projectconfig/projectconfig_test.go
@@ -14,6 +14,7 @@ func TestProjectConfig(t *testing.T) {
 	actual, err := Load(context.Background(), "testdata/ftl-project.toml")
 	assert.NoError(t, err)
 	expected := Config{
+		Name: "testdata",
 		Path: actual.Path,
 		Modules: map[string]ConfigAndSecrets{
 			"module": {

--- a/common/projectconfig/testdata/ftl-project.toml
+++ b/common/projectconfig/testdata/ftl-project.toml
@@ -1,3 +1,4 @@
+name = "testdata"
 module-dirs = ["a/b/c", "d"]
 
 [modules.module.configuration]

--- a/common/projectconfig/testdata/go/configs-ftl-project.toml
+++ b/common/projectconfig/testdata/go/configs-ftl-project.toml
@@ -1,3 +1,5 @@
+name = "testdata"
+
 [global]
   [global.configuration]
     key = "inline://InZhbHVlIg"

--- a/common/projectconfig/testdata/go/findconfig/ftl-project.toml
+++ b/common/projectconfig/testdata/go/findconfig/ftl-project.toml
@@ -1,3 +1,5 @@
+name = "testdata"
+
 [global]
   [global.configuration]
     test = "inline://InRlc3Qi"

--- a/common/projectconfig/testdata/go/no-module-dirs-ftl-project.toml
+++ b/common/projectconfig/testdata/go/no-module-dirs-ftl-project.toml
@@ -1,2 +1,4 @@
+name = "testdata"
+
 [commands]
   startup = ["echo 'Executing global pre-build command'"]

--- a/common/projectconfig/testdata/withMinVersion/ftl-project.toml
+++ b/common/projectconfig/testdata/withMinVersion/ftl-project.toml
@@ -1,3 +1,4 @@
+name = "testdata"
 module-dirs = ["a/b/c", "d"]
 ftl-min-version = "0.129.2"
 

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project-test-1.toml
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project-test-1.toml
@@ -1,3 +1,4 @@
+name = "testdata"
 ftl-min-version = ""
 
 [global]

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project.toml
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/ftl-project.toml
@@ -1,3 +1,4 @@
+name = "testdata"
 ftl-min-version = ""
 
 [global]

--- a/integration/harness.go
+++ b/integration/harness.go
@@ -79,7 +79,7 @@ func run(t *testing.T, ftlConfigPath string, startController bool, actions ...Ac
 		// is used by FTL during startup.
 		t.Setenv("FTL_CONFIG", filepath.Join(cwd, "testdata", "go", ftlConfigPath))
 	} else {
-		err = os.WriteFile(filepath.Join(tmpDir, "ftl-project.toml"), []byte{}, 0644)
+		err = os.WriteFile(filepath.Join(tmpDir, "ftl-project.toml"), []byte("name = \"integration\""), 0644)
 		assert.NoError(t, err)
 	}
 

--- a/integration/harness.go
+++ b/integration/harness.go
@@ -79,7 +79,7 @@ func run(t *testing.T, ftlConfigPath string, startController bool, actions ...Ac
 		// is used by FTL during startup.
 		t.Setenv("FTL_CONFIG", filepath.Join(cwd, "testdata", "go", ftlConfigPath))
 	} else {
-		err = os.WriteFile(filepath.Join(tmpDir, "ftl-project.toml"), []byte("name = \"integration\""), 0644)
+		err = os.WriteFile(filepath.Join(tmpDir, "ftl-project.toml"), []byte(`name = "integration"`), 0644)
 		assert.NoError(t, err)
 	}
 


### PR DESCRIPTION
Validates project config files.

This breaks previous cases where `ftl config set` and similar would be able to create the project toml if it wasn't already created. Now that a project's name is required, an invalid project config would have been created.

It is now a requirement to go through `ftl init <name> <dir>`