### PR TITLE
fix(vscode): url for repo update

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -7,7 +7,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/TBD54566975/ftl-vscode"
+    "url": "https://github.com/TBD54566975/ftl"
   },
   "engines": {
     "vscode": "^1.90.2"


### PR DESCRIPTION
Existing url on the extension page is old:

<img width="300" alt="image" src="https://github.com/TBD54566975/ftl/assets/31338/4cddf78e-abab-482f-945f-68401b036ed2">
