### PR TITLE
ci: ensure frozen migrations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
         uses: cashapp/activate-hermit@v1
       - name: Freeze Migrations
         run: just ensure-frozen-migrations
-
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,17 @@ jobs:
         run: just init-db
       - name: Vet SQL
         run: sqlc vet
+  ensure-frozen-migrations:
+    name: Ensure Frozen Migrations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Init Hermit
+        uses: cashapp/activate-hermit@v1
+      - name: Freeze Migrations
+        run: just ensure-frozen-migrations
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
       - name: Freeze Migrations

--- a/Justfile
+++ b/Justfile
@@ -133,6 +133,10 @@ test-readme *args:
 tidy:
   find . -name go.mod -execdir go mod tidy \;
 
+# Check for changes in existing SQL migrations compared to main
+ensure-frozen-migrations:
+  scripts/ensure-frozen-migrations
+
 # Run backend tests
 test-backend:
   @gotestsum --hide-summary skipped --format-hide-empty-pkg -- -short -fullpath ./...

--- a/backend/controller/sql/schema/file with space.sql
+++ b/backend/controller/sql/schema/file with space.sql
@@ -1,3 +1,0 @@
-
-arstarsta
-

--- a/backend/controller/sql/schema/file with space.sql
+++ b/backend/controller/sql/schema/file with space.sql
@@ -1,0 +1,3 @@
+
+arstarsta
+

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,3 +14,5 @@ pre-push:
     lint-frontend:
       root: frontend/
       run: just lint-frontend
+    ensure-frozen-migrations:
+      run: just ensure-frozen-migrations

--- a/scripts/ensure-frozen-migrations
+++ b/scripts/ensure-frozen-migrations
@@ -5,7 +5,7 @@ set -euo pipefail
 # It ignores comments when comparing the files.
 
 remove_comments() {
-    sed 's/--.*$//g; s/\/\*.*\*\///g' "$1"
+    sed 's/--.*$//g' "$1"
 }
 
 compare_sql_files() {

--- a/scripts/ensure-frozen-migrations
+++ b/scripts/ensure-frozen-migrations
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script checks if the SQL migration have been modified compared to the main branch.
+# It ignores comments when comparing the files.
+
+remove_comments() {
+    sed 's/--.*$//g; s/\/\*.*\*\///g' "$1"
+}
+
+compare_sql_files() {
+    local file1="$1"
+    local file2="$2"
+    diff -q <(remove_comments "$file1" | sed '/^\s*$/d' | sort) \
+            <(remove_comments "$file2" | sed '/^\s*$/d' | sort) > /dev/null
+}
+
+show_diff() {
+    local file1="$1"
+    local file2="$2"
+    diff -u <(remove_comments "$file1") <(remove_comments "$file2")
+}
+
+main() {
+    local sql_dir="backend/controller/sql/schema"
+    local changed_files
+
+    # Get list of changed SQL files compared to main branch
+    changed_files=$(git diff --name-only main -- "$sql_dir"/*.sql)
+
+    if [ -z "$changed_files" ]; then
+        echo "👍 No SQL files changed in $sql_dir compared to main branch"
+        exit 0
+    fi
+
+    while IFS= read -r file; do
+        if [ ! -f "$file" ]; then
+            echo "$file no longer exists!"
+            exit 1
+        fi
+        if compare_sql_files "$file" <(git show "main:$file"); then
+            : # Do nothing if files are the same
+        else
+            echo "Migration files changes detected"
+            show_diff "$file" <(git show "main:$file")
+            exit 1
+        fi
+    done <<< "$changed_files"
+
+    echo "👍SQL files changed in $sql_dir but comments only:"
+    git diff --color=always main -- "$sql_dir"/*.sql | cat
+}
+
+# Run the main function
+main

--- a/scripts/ensure-frozen-migrations
+++ b/scripts/ensure-frozen-migrations
@@ -33,7 +33,7 @@ main() {
     merge_base=$(git merge-base HEAD origin/main)
 
     # Get list of changed SQL files compared to the merge base
-    changed_files=$(git diff --name-only $merge_base -- "$sql_dir"/*.sql)
+    changed_files=$(git diff --name-only "$merge_base" -- "$sql_dir"/*.sql)
 
     if [ -z "$changed_files" ]; then
         echo "👍 No SQL files changed in $sql_dir compared to the common ancestor with main branch"
@@ -54,7 +54,7 @@ main() {
         fi
     done <<< "$changed_files"
 
-    git diff --color=always $merge_base -- "$sql_dir"/*.sql | cat
+    git diff --color=always "$merge_base" -- "$sql_dir"/*.sql | cat
     echo "👍 Only comments/new lines changed in SQL files"
 }
 

--- a/scripts/ensure-frozen-migrations
+++ b/scripts/ensure-frozen-migrations
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+# echo
+set -x
+
 # This script checks if the SQL migration have been modified compared to the common ancestor with the main branch.
 # It ignores comments when comparing the files.
 

--- a/scripts/ensure-frozen-migrations
+++ b/scripts/ensure-frozen-migrations
@@ -5,7 +5,7 @@ set -euo pipefail
 # It ignores comments when comparing the files.
 
 remove_comments() {
-    sed 's/--.*$//g' "$1"
+    sed 's/[[:space:]]*--.*$//g' "$1"
 }
 
 compare_sql_files() {
@@ -41,14 +41,14 @@ main() {
         if compare_sql_files "$file" <(git show "main:$file"); then
             : # Do nothing if files are the same
         else
-            echo "Migration files changes detected"
+            echo "❌ Migration files changes detected"
             show_diff "$file" <(git show "main:$file")
             exit 1
         fi
     done <<< "$changed_files"
 
-    echo "👍SQL files changed in $sql_dir but comments only:"
     git diff --color=always main -- "$sql_dir"/*.sql | cat
+    echo "👍 Only comments/new lines changed in SQL files"
 }
 
 # Run the main function

--- a/scripts/ensure-frozen-migrations
+++ b/scripts/ensure-frozen-migrations
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# This script checks if the SQL migration have been modified compared to the main branch.
+# This script checks if the SQL migration have been modified compared to the common ancestor with the main branch.
 # It ignores comments when comparing the files.
 
 remove_comments() {
@@ -24,12 +24,16 @@ show_diff() {
 main() {
     local sql_dir="backend/controller/sql/schema"
     local changed_files
+    local merge_base
 
-    # Get list of changed SQL files compared to main branch
-    changed_files=$(git diff --name-only origin/main -- "$sql_dir"/*.sql)
+    # Find the merge base commit
+    merge_base=$(git merge-base HEAD origin/main)
+
+    # Get list of changed SQL files compared to the merge base
+    changed_files=$(git diff --name-only $merge_base -- "$sql_dir"/*.sql)
 
     if [ -z "$changed_files" ]; then
-        echo "👍 No SQL files changed in $sql_dir compared to main branch"
+        echo "👍 No SQL files changed in $sql_dir compared to the common ancestor with main branch"
         exit 0
     fi
 
@@ -38,16 +42,16 @@ main() {
             echo "$file no longer exists!"
             exit 1
         fi
-        if compare_sql_files "$file" <(git show "origin/main:$file"); then
+        if compare_sql_files "$file" <(git show "$merge_base:$file"); then
             : # Do nothing if files are the same
         else
             echo "❌ Migration files changes detected"
-            show_diff "$file" <(git show "origin/main:$file")
+            show_diff "$file" <(git show "$merge_base:$file")
             exit 1
         fi
     done <<< "$changed_files"
 
-    git diff --color=always origin/main -- "$sql_dir"/*.sql | cat
+    git diff --color=always $merge_base -- "$sql_dir"/*.sql | cat
     echo "👍 Only comments/new lines changed in SQL files"
 }
 

--- a/scripts/ensure-frozen-migrations
+++ b/scripts/ensure-frozen-migrations
@@ -26,7 +26,7 @@ main() {
     local changed_files
 
     # Get list of changed SQL files compared to main branch
-    changed_files=$(git diff --name-only main -- "$sql_dir"/*.sql)
+    changed_files=$(git diff --name-only origin/main -- "$sql_dir"/*.sql)
 
     if [ -z "$changed_files" ]; then
         echo "👍 No SQL files changed in $sql_dir compared to main branch"
@@ -38,16 +38,16 @@ main() {
             echo "$file no longer exists!"
             exit 1
         fi
-        if compare_sql_files "$file" <(git show "main:$file"); then
+        if compare_sql_files "$file" <(git show "origin/main:$file"); then
             : # Do nothing if files are the same
         else
             echo "❌ Migration files changes detected"
-            show_diff "$file" <(git show "main:$file")
+            show_diff "$file" <(git show "origin/main:$file")
             exit 1
         fi
     done <<< "$changed_files"
 
-    git diff --color=always main -- "$sql_dir"/*.sql | cat
+    git diff --color=always origin/main -- "$sql_dir"/*.sql | cat
     echo "👍 Only comments/new lines changed in SQL files"
 }
 


### PR DESCRIPTION
Fixes #1962

- Checks for changes to existing migration files against `main, ignoring new lines and single line comments.
- Adds a `just ensure-frozen-migrations`.
- Adds a CI check.