### PR TITLE
fix: controller startup failure visibility

### DIFF
--- a/buildengine/engine.go
+++ b/buildengine/engine.go
@@ -132,7 +132,7 @@ func New(ctx context.Context, client ftlv1connect.ControllerServiceClient, modul
 		return e, nil
 	}
 	schemaSync := e.startSchemaSync(ctx)
-	go rpc.RetryStreamingServerStream(ctx, backoff.Backoff{Max: time.Second}, &ftlv1.PullSchemaRequest{}, client.PullSchema, schemaSync)
+	go rpc.RetryStreamingServerStream(ctx, backoff.Backoff{Max: time.Second}, &ftlv1.PullSchemaRequest{}, client.PullSchema, schemaSync, rpc.AlwaysRetry())
 	return e, nil
 }
 

--- a/internal/modulecontext/module_context_test.go
+++ b/internal/modulecontext/module_context_test.go
@@ -36,7 +36,7 @@ func TestDynamicContextUpdate(t *testing.T) {
 	assert.Equal(t, mc2, dynamic.CurrentContext())
 }
 
-func (mcs *manualContextSupplier) Subscribe(ctx context.Context, _ string, sink func(ctx context.Context, mCtx ModuleContext)) {
+func (mcs *manualContextSupplier) Subscribe(ctx context.Context, _ string, sink func(ctx context.Context, mCtx ModuleContext), _ func(error) bool) {
 	sink(ctx, mcs.initialCtx)
 	mcs.sink = sink
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -195,6 +195,12 @@ func RetryStreamingClientStream[Req, Resp any](
 	}
 }
 
+// AlwaysRetry instructs RetryStreamingServerStream to always retry the errors it encounters when
+// supplied as the errorRetryCallback argument
+func AlwaysRetry() func(error) bool {
+	return func(err error) bool { return true }
+}
+
 // RetryStreamingServerStream will repeatedly call handler with responses from
 // the stream returned by "rpc" until handler returns an error or the context is
 // cancelled.
@@ -204,6 +210,7 @@ func RetryStreamingServerStream[Req, Resp any](
 	req *Req,
 	rpc func(context.Context, *connect.Request[Req]) (*connect.ServerStreamForClient[Resp], error),
 	handler func(ctx context.Context, resp *Resp) error,
+	errorRetryCallback func(err error) bool,
 ) {
 	logLevel := log.Debug
 	errored := false
@@ -211,36 +218,47 @@ func RetryStreamingServerStream[Req, Resp any](
 	for {
 		stream, err := rpc(ctx, connect.NewRequest(req))
 		if err == nil {
-			for stream.Receive() {
-				req := stream.Msg()
-				err = handler(ctx, req)
-				if err != nil {
+			for {
+				if stream.Receive() {
+					resp := stream.Msg()
+					err = handler(ctx, resp)
+
+					if err != nil {
+						break
+					}
+					if errored {
+						logger.Debugf("Server stream recovered")
+						errored = false
+					}
+					select {
+					case <-ctx.Done():
+						return
+					default:
+					}
+					retry.Reset()
+					logLevel = log.Warn
+				} else {
+					// Stream terminated; check if this was caused by an error
+					err = stream.Err()
+					logLevel = log.Warn
 					break
 				}
-				if errored {
-					logger.Debugf("Server stream recovered")
-					errored = false
-				}
-				select {
-				case <-ctx.Done():
-					return
-				default:
-				}
-				retry.Reset()
-				logLevel = log.Warn
 			}
 		}
 
-		if err != nil {
-			err = stream.Err()
-		}
 		errored = true
 		delay := retry.Duration()
 		if err != nil && !errors.Is(err, context.Canceled) {
+			if errorRetryCallback != nil && !errorRetryCallback(err) {
+				logger.Errorf(err, "Stream handler encountered a non-retryable error")
+				return
+			}
+
 			logger.Logf(logLevel, "Stream handler failed, retrying in %s: %s", delay, err)
 		} else if err == nil {
 			logger.Debugf("Stream finished, retrying in %s", delay)
 		}
+
 		select {
 		case <-ctx.Done():
 			return

--- a/testutils/modulecontext/module_context_utils.go
+++ b/testutils/modulecontext/module_context_utils.go
@@ -22,6 +22,6 @@ func MakeDynamic(ctx context.Context, m modulecontext.ModuleContext) *modulecont
 	return result
 }
 
-func (smc SingleContextSupplier) Subscribe(ctx context.Context, _ string, sink func(ctx context.Context, mCtx modulecontext.ModuleContext)) {
+func (smc SingleContextSupplier) Subscribe(ctx context.Context, _ string, sink func(ctx context.Context, mCtx modulecontext.ModuleContext), _ func(error) bool) {
 	sink(ctx, smc.moduleCtx)
 }


### PR DESCRIPTION
fixes #1959

controller startup failure troubleshooting was complicated by a failure to surface error messages from the `GetModuleContext` streaming end-point.

errors encountered from that end-point are now made visible and if those errors are deemed fatal the runner will terminate.