### PR TITLE
feat: add /debug/pprof handlers

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -149,6 +149,7 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 			rpc.GRPC(ftlv1connect.NewAdminServiceHandler, admin),
 			rpc.GRPC(pbconsoleconnect.NewConsoleServiceHandler, console),
 			rpc.HTTP("/", consoleHandler),
+			rpc.PProf(),
 		)
 	})
 

--- a/common/plugin/serve.go
+++ b/common/plugin/serve.go
@@ -21,6 +21,7 @@ import (
 	"golang.org/x/net/http2/h2c"
 
 	_ "github.com/TBD54566975/ftl/internal/automaxprocs" // Set GOMAXPROCS to match Linux container CPU quota.
+	ftlhttp "github.com/TBD54566975/ftl/internal/http"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/rpc"
 )
@@ -154,6 +155,7 @@ func Start[Impl any, Iface any, Config any](
 	reflector := grpcreflect.NewStaticReflector(servicePaths...)
 	mux.Handle(grpcreflect.NewHandlerV1(reflector))
 	mux.Handle(grpcreflect.NewHandlerV1Alpha(reflector))
+	ftlhttp.RegisterPprof(mux)
 
 	// Start the server.
 	http1Server := &http.Server{

--- a/internal/http/pprof.go
+++ b/internal/http/pprof.go
@@ -1,0 +1,24 @@
+package http
+
+import (
+	"net/http"
+	"net/http/pprof"
+)
+
+// RegisterPprof registers all pprof handlers and the index on the provided ServeMux.
+func RegisterPprof(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/debug/pprof/", http.StatusFound)
+	})
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	mux.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
+	mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+	mux.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
+}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	gaphttp "github.com/TBD54566975/ftl/internal/http"
+
 	"connectrpc.com/connect"
 	"connectrpc.com/grpcreflect"
 	"github.com/alecthomas/concurrency"
@@ -37,6 +39,13 @@ func GRPC[Iface, Impl Pingable](constructor GRPCServerConstructor[Iface], impl I
 		path, handler := constructor(any(impl).(Iface), options...)
 		o.reflectionPaths = append(o.reflectionPaths, strings.Trim(path, "/"))
 		o.mux.Handle(path, handler)
+	}
+}
+
+// PProf adds /debug/pprof routes to the server.
+func PProf() Option {
+	return func(so *serverOptions) {
+		gaphttp.RegisterPprof(so.mux)
 	}
 }
 


### PR DESCRIPTION
This adds debugging pprof HTTP handlers.

The controller serves this directly, while the runner forwards to the user verb server's handlers, allowing verb servers to be debugged directly.

Here's an example of CPU profiling the echo module:

```
🐚 ~/dev/ftl $ go tool pprof http://localhost:8894/debug/pprof/profile
Fetching profile over HTTP from http://localhost:8894/debug/pprof/profile
Saved profile in /Users/alec/pprof/pprof.main.samples.cpu.001.pb.gz
File: main
Type: cpu
Time: Jul 5, 2024 at 5:33am (AEST)
Duration: 30.18s, Total samples = 600ms ( 1.99%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 600ms, 100% of 600ms total
Showing top 10 nodes out of 73
      flat  flat%   sum%        cum   cum%
     210ms 35.00% 35.00%      210ms 35.00%  runtime.pthread_cond_signal
     190ms 31.67% 66.67%      190ms 31.67%  runtime.kevent
     110ms 18.33% 85.00%      110ms 18.33%  runtime.pthread_cond_wait
      50ms  8.33% 93.33%       50ms  8.33%  syscall.syscall
      10ms  1.67% 95.00%       10ms  1.67%  connectrpc.com/connect.grpcErrorToTrailer
      10ms  1.67% 96.67%       10ms  1.67%  runtime.scanobject
      10ms  1.67% 98.33%       10ms  1.67%  runtime.usleep
      10ms  1.67%   100%       10ms  1.67%  runtime.write1
         0     0%   100%       30ms  5.00%  bufio.(*Writer).Flush
         0     0%   100%       10ms  1.67%  connectrpc.com/connect.(*Handler).ServeHTTP
```

pprof index looks like this:

<img width="967" alt="image" src="https://github.com/TBD54566975/ftl/assets/41767/90675d6e-edd7-495e-8b6c-2ee1e299f743">

