### PR TITLE
fix: console was crashing quietly, relative paths

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -113,7 +113,7 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 	} else {
 		consoleHandler, err = frontend.Server(ctx, config.ContentTime, config.Bind, config.ConsoleURL)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not start console: %w", err)
 		}
 		logger.Infof("Web console available at: %s", config.Bind)
 	}

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -142,7 +142,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 
 	// Wait for controller to start, then run startup commands.
 	if err := waitForControllerOnline(ctx, time.Second*10, client); err != nil {
-		return fmt.Errorf("controller failed to start: %w", err)
+		return fmt.Errorf("controller failed to start: %w: %w", err, wg.Wait())
 	}
 
 	if len(projConfig.Commands.Startup) > 0 {

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -134,6 +134,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 
 		wg.Go(func() error {
 			if err := controller.Start(controllerCtx, config, runnerScaling, dal); err != nil {
+				logger.Errorf(err, "controller%d failed: %v", i, err)
 				return fmt.Errorf("controller%d failed: %w", i, err)
 			}
 			return nil
@@ -142,7 +143,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 
 	// Wait for controller to start, then run startup commands.
 	if err := waitForControllerOnline(ctx, time.Second*10, client); err != nil {
-		return fmt.Errorf("controller failed to start: %w: %w", err, wg.Wait())
+		return fmt.Errorf("controller failed to start: %w", err)
 	}
 
 	if len(projConfig.Commands.Startup) > 0 {

--- a/frontend/local.go
+++ b/frontend/local.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
 	"time"
 
 	"github.com/TBD54566975/ftl/internal"
@@ -33,7 +34,7 @@ func Server(ctx context.Context, timestamp time.Time, publicURL *url.URL, allowO
 		return nil, err
 	}
 
-	err = exec.Command(ctx, log.Debug, "frontend", "npm", "run", "dev").Start()
+	err = exec.Command(ctx, log.Debug, path.Join(gitRoot, "frontend"), "npm", "run", "dev").Start()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Now log why console crashed
- Use gitRoot based path for running console