### PR TITLE
feat: Add ca-certificates package to ftl-runner image

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -34,6 +34,8 @@ RUN just build ftl
 
 # Finally create the runtime image.
 FROM ubuntu:24.04
+RUN apt-get update
+RUN apt-get install -y ca-certificates
 
 WORKDIR /root/
 


### PR DESCRIPTION
Runner applications egress to internet applications today, requiring basic CA bundles to be present.