### PR TITLE
fix: increase timeout for controller, log timings

### DIFF
--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -142,9 +142,11 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 	}
 
 	// Wait for controller to start, then run startup commands.
-	if err := waitForControllerOnline(ctx, time.Second*10, client); err != nil {
+	start := time.Now()
+	if err := waitForControllerOnline(ctx, time.Second*30, client); err != nil {
 		return fmt.Errorf("controller failed to start: %w", err)
 	}
+	logger.Infof("Controller started in %s", time.Since(start))
 
 	if len(projConfig.Commands.Startup) > 0 {
 		for _, cmd := range projConfig.Commands.Startup {
@@ -344,6 +346,7 @@ func (s *serveCmd) setupDB(ctx context.Context) (string, error) {
 // waitForControllerOnline polls the controller service until it is online.
 func waitForControllerOnline(ctx context.Context, startupTimeout time.Duration, client ftlv1connect.ControllerServiceClient) error {
 	logger := log.FromContext(ctx)
+	logger.Debugf("Waiting %s for controller to be online", startupTimeout)
 
 	ctx, cancel := context.WithTimeout(ctx, startupTimeout)
 	defer cancel()

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -143,7 +143,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 
 	// Wait for controller to start, then run startup commands.
 	start := time.Now()
-	if err := waitForControllerOnline(ctx, time.Second*30, client); err != nil {
+	if err := waitForControllerOnline(ctx, s.StartupTimeout, client); err != nil {
 		return fmt.Errorf("controller failed to start: %w", err)
 	}
 	logger.Infof("Controller started in %s", time.Since(start))


### PR DESCRIPTION
Maybe #1942

* Use `--startup-timeout` flag for controller timeout when in foreground