### PR TITLE
feat: pass a `testing.TB` to `ftltest.Context()`

### DIFF
--- a/backend/controller/dal/testdata/go/fsm/fsm_test.go
+++ b/backend/controller/dal/testdata/go/fsm/fsm_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFSM(t *testing.T) {
-	ctx := ftltest.Context()
+	ctx := ftltest.Context(t)
 
 	err := fsm.Send(ctx, "one", Two{Instance: "one"}) // No start transition on Two
 	assert.Error(t, err)

--- a/backend/controller/leases/testdata/go/leases/leases_test.go
+++ b/backend/controller/leases/testdata/go/leases/leases_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLease(t *testing.T) {
-	ctx := ftltest.Context()
+	ctx := ftltest.Context(t)
 	// test that we can acquire a lease in a test environment
 	wg := errgroup.Group{}
 	wg.Go(func() error {

--- a/backend/controller/sql/testdata/go/database/database_test.go
+++ b/backend/controller/sql/testdata/go/database/database_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestDatabase(t *testing.T) {
 	ctx := ftltest.Context(
+		t,
 		ftltest.WithProjectFile("ftl-project.toml"),
 		ftltest.WithDatabase(db),
 	)
@@ -22,6 +23,7 @@ func TestDatabase(t *testing.T) {
 	assert.Equal(t, "unit test 1", list[0])
 
 	ctx = ftltest.Context(
+		t,
 		ftltest.WithProjectFile("ftl-project.toml"),
 		ftltest.WithDatabase(db),
 	)

--- a/go-runtime/ftl/ftltest/ftltest_test.go
+++ b/go-runtime/ftl/ftltest/ftltest_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/alecthomas/assert/v2"
+
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	"github.com/TBD54566975/ftl/go-runtime/internal"
 	"github.com/TBD54566975/ftl/internal/log"
-	"github.com/alecthomas/assert/v2"
 )
 
 func PanicsWithErr(t testing.TB, substr string, fn func()) {
@@ -27,7 +28,7 @@ func PanicsWithErr(t testing.TB, substr string, fn func()) {
 
 func TestFtlTestProjectNotLoadedInContext(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	ctx = internal.WithContext(ctx, newFakeFTL(ctx))
+	ctx = internal.WithContext(ctx, newFakeFTL(ctx, t))
 
 	// This should panic suggesting to use ftltest.WithDefaultProjectFile()
 	PanicsWithErr(t, "ftltest.WithDefaultProjectFile()", func() {

--- a/go-runtime/ftl/ftltest/testdata/go/subscriber/subscriber_test.go
+++ b/go-runtime/ftl/ftltest/testdata/go/subscriber/subscriber_test.go
@@ -4,12 +4,13 @@ import (
 	"ftl/pubsub"
 	"testing"
 
-	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
 )
 
 func TestPublishToExternalModule(t *testing.T) {
-	ctx := ftltest.Context()
+	ctx := ftltest.Context(t)
 	assert.NoError(t, pubsub.Topic.Publish(ctx, pubsub.Event{Value: "external"}))
 	assert.Equal(t, 1, len(ftltest.EventsForTopic(ctx, pubsub.Topic)))
 

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/wrapped_test.go
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/wrapped_test.go
@@ -76,7 +76,7 @@ func TestWrapped(t *testing.T) {
 			},
 			configValue:   "helloworld",
 			secretValue:   "shhhhh",
-			expectedError: ftl.Some("wrapped.inner: no mock found: provide a mock with ftltest.WhenVerb(Inner, ...) or enable all calls within the module with ftltest.WithCallsAllowedWithinModule()"),
+			expectedError: ftl.Some("wrapped.inner: no fake found: provide a mock with ftltest.WhenVerb(Inner, ...) or enable all calls within the module with ftltest.WithCallsAllowedWithinModule()"),
 		},
 		{
 			name: "AllowCallsWithinModule",
@@ -87,7 +87,7 @@ func TestWrapped(t *testing.T) {
 			},
 			configValue:   "helloworld",
 			secretValue:   "shhhhh",
-			expectedError: ftl.Some("wrapped.inner: time.time: no mock found: provide a mock with ftltest.WhenVerb(time.Time, ...)"),
+			expectedError: ftl.Some("wrapped.inner: time.time: no fake found: provide a mock with ftltest.WhenVerb(time.Time, ...)"),
 		},
 		{
 			name: "WithExternalVerbMock",

--- a/go-runtime/ftl/testdata/go/mapper/mapper_test.go
+++ b/go-runtime/ftl/testdata/go/mapper/mapper_test.go
@@ -4,18 +4,19 @@ import (
 	"context"
 	"testing"
 
-	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
 	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
 )
 
 func TestGet(t *testing.T) {
-	ctx := ftltest.Context(ftltest.WithMapsAllowed())
+	ctx := ftltest.Context(t, ftltest.WithMapsAllowed())
 	got := m.Get(ctx)
 	assert.Equal(t, got, 9)
 }
 
 func TestPanicsWithoutExplicitlyAllowingMaps(t *testing.T) {
-	ctx := ftltest.Context()
+	ctx := ftltest.Context(t)
 	assert.Panics(t, func() {
 		m.Get(ctx)
 	})
@@ -23,7 +24,7 @@ func TestPanicsWithoutExplicitlyAllowingMaps(t *testing.T) {
 
 func TestMockGet(t *testing.T) {
 	mockOut := 123
-	ctx := ftltest.Context(ftltest.WhenMap(m, func(ctx context.Context) (int, error) {
+	ctx := ftltest.Context(t, ftltest.WhenMap(m, func(ctx context.Context) (int, error) {
 		return mockOut, nil
 	}))
 	got := m.Get(ctx)

--- a/go-runtime/ftl/testdata/go/typeregistry/typeregistry_test.go
+++ b/go-runtime/ftl/testdata/go/typeregistry/typeregistry_test.go
@@ -4,10 +4,11 @@ import (
 	"ftl/builtin"
 	"testing"
 
+	"github.com/alecthomas/assert/v2"
+
 	"github.com/TBD54566975/ftl/go-runtime/encoding"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/ftltest"
-	"github.com/alecthomas/assert/v2"
 )
 
 func TestIngress(t *testing.T) {
@@ -29,7 +30,7 @@ func TestIngress(t *testing.T) {
 		},
 	}
 
-	ctx := ftltest.Context(ftltest.WithCallsAllowedWithinModule())
+	ctx := ftltest.Context(t, ftltest.WithCallsAllowedWithinModule())
 
 	for _, test := range testCases {
 		t.Run(test.Name, func(t *testing.T) {

--- a/internal/modulecontext/module_context.go
+++ b/internal/modulecontext/module_context.go
@@ -1,7 +1,6 @@
 package modulecontext
 
 import (
-	"connectrpc.com/connect"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"connectrpc.com/connect"
 
 	"github.com/alecthomas/atomic"
 	"github.com/jpillora/backoff"
@@ -174,9 +175,9 @@ func (m ModuleContext) BehaviorForVerb(ref schema.Ref) (optional.Option[VerbBeha
 		return optional.Some(VerbBehavior(DirectBehavior{})), nil
 	} else if m.isTesting {
 		if ref.Module == m.module {
-			return optional.None[VerbBehavior](), fmt.Errorf("no mock found: provide a mock with ftltest.WhenVerb(%s, ...) or enable all calls within the module with ftltest.WithCallsAllowedWithinModule()", strings.ToUpper(ref.Name[:1])+ref.Name[1:])
+			return optional.None[VerbBehavior](), fmt.Errorf("no fake found: provide a fake with ftltest.WhenVerb(%s, ...) or enable all calls within the module with ftltest.WithCallsAllowedWithinModule()", strings.ToUpper(ref.Name[:1])+ref.Name[1:])
 		}
-		return optional.None[VerbBehavior](), fmt.Errorf("no mock found: provide a mock with ftltest.WhenVerb(%s.%s, ...)", ref.Module, strings.ToUpper(ref.Name[:1])+ref.Name[1:])
+		return optional.None[VerbBehavior](), fmt.Errorf("no fake found: provide a fake with ftltest.WhenVerb(%s.%s, ...)", ref.Module, strings.ToUpper(ref.Name[:1])+ref.Name[1:])
 	}
 	return optional.None[VerbBehavior](), nil
 }


### PR DESCRIPTION
This allows us to fail using the test framework's `Fatalf()` calls, rather than using `panic()`.

> [!NOTE]
> This isn't quite as useful as I would hope because a bunch of FTL constructs, such as `SecretHandle.Get()`, panic anyway. We could solve this by injecting some kind of panic proxy function that panics in release mode, and calls `t.Fatalf()` in test mode, but that is a lot more work.