### PR TITLE
fix: module context errors should not cause a negative wait group

### DIFF
--- a/internal/modulecontext/module_context.go
+++ b/internal/modulecontext/module_context.go
@@ -1,7 +1,6 @@
 package modulecontext
 
 import (
-	"connectrpc.com/connect"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -10,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"connectrpc.com/connect"
 
 	"github.com/alecthomas/atomic"
 	"github.com/jpillora/backoff"
@@ -239,7 +240,9 @@ func NewDynamicContext(ctx context.Context, supplier ModuleContextSupplier, modu
 
 			if errors.As(err, &connectErr) && connectErr.Code() == connect.CodeInternal {
 				cancel(err)
-				await.Done()
+				releaseOnce.Do(func() {
+					await.Done()
+				})
 				return false
 			}
 


### PR DESCRIPTION
We were catching multiple calls for `wg.Done()` in the success case, but when an error was hit