### PR TITLE
fix: console erroring with bad jsonschema values

### DIFF
--- a/backend/schema/jsonschema.go
+++ b/backend/schema/jsonschema.go
@@ -49,7 +49,10 @@ func DataToJSONSchema(sch *Schema, ref Ref) (*jsonschema.Schema, error) {
 		case *Enum:
 			root.Definitions[r.String()] = jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(n, refs)}
 
-		case *Config, *Database, *Secret, *Verb, *FSM, *TypeAlias, *Topic, *Subscription:
+		case *TypeAlias:
+			root.Definitions[r.String()] = jsonschema.SchemaOrBool{TypeObject: nodeToJSSchema(n.Type, refs)}
+
+		case *Config, *Database, *Secret, *Verb, *FSM, *Topic, *Subscription:
 			return nil, fmt.Errorf("reference to unsupported node type %T", decl)
 		}
 	}
@@ -183,11 +186,14 @@ func nodeToJSSchema(node Node, refs map[RefKey]*Ref) *jsonschema.Schema {
 	case *TypeParameter:
 		return &jsonschema.Schema{}
 
+	case *TypeAlias:
+		return nodeToJSSchema(node.Type, refs)
+
 	case Decl, *Field, Metadata, *MetadataCalls, *MetadataDatabases, *MetadataIngress,
 		*MetadataAlias, IngressPathComponent, *IngressPathLiteral, *IngressPathParameter, *Module,
 		*Schema, Type, *Database, *Verb, *EnumVariant, *MetadataCronJob, Value,
 		*StringValue, *IntValue, *TypeValue, *Config, *Secret, Symbol, Named,
-		*FSM, *FSMTransition, *TypeAlias, *MetadataRetry, *Topic, *Subscription, *MetadataSubscriber:
+		*FSM, *FSMTransition, *MetadataRetry, *Topic, *Subscription, *MetadataSubscriber:
 		panic(fmt.Sprintf("unsupported node type %T", node))
 
 	default:

--- a/frontend/src/features/verbs/verb.utils.ts
+++ b/frontend/src/features/verbs/verb.utils.ts
@@ -66,12 +66,18 @@ export const defaultRequest = (verb?: Verb): string => {
     requiredOnly: true
   })
 
-  let fake = JSONSchemaFaker.generate(schema)
-  if (fake) {
-    fake = processJsonValue(fake)
+  try {
+    let fake = JSONSchemaFaker.generate(schema)
+    if (fake) {
+      fake = processJsonValue(fake)
+    }
+
+    return JSON.stringify(fake, null, 2) ?? '{}'
+  } catch (error) {
+    console.error(error)
+    return '{}'
   }
 
-  return JSON.stringify(fake, null, 2) ?? '{}'
 }
 
 export const ingress = (verb?: Verb) => {


### PR DESCRIPTION
This doesn't fully fix the issue with jsonschema and `TypeAlias`ed fields, but will keep the console from failing completely when the schema is not valid.

See #2004 
See #1991