### PR TITLE
fix: asm follower obfuscation

### DIFF
--- a/common/configuration/asm_follower.go
+++ b/common/configuration/asm_follower.go
@@ -18,8 +18,11 @@ const asmFollowerSyncInterval = time.Minute * 1
 
 // asmFollower uses AdminService to get/set secrets from the leader
 type asmFollower struct {
+	// client requests/responses use unobfuscated values
 	client ftlv1connect.AdminServiceClient
-	cache  *secretsCache
+
+	// cache stores obfuscated values
+	cache *secretsCache
 }
 
 var _ asmClient = &asmFollower{}
@@ -36,6 +39,7 @@ func newASMFollower(ctx context.Context, rpcClient ftlv1connect.AdminServiceClie
 }
 
 func (f *asmFollower) sync(ctx context.Context, secrets *xsync.MapOf[Ref, cachedSecret]) error {
+	obfuscator := Secrets{}.obfuscator()
 	module := ""
 	includeValues := true
 	resp, err := f.client.SecretsList(ctx, connect.NewRequest(&ftlv1.ListSecretsRequest{
@@ -51,9 +55,13 @@ func (f *asmFollower) sync(ctx context.Context, secrets *xsync.MapOf[Ref, cached
 		if err != nil {
 			return fmt.Errorf("invalid ref %q: %w", s.RefPath, err)
 		}
+		obfuscatedValue, err := obfuscator.Obfuscate(s.Value)
+		if err != nil {
+			return fmt.Errorf("asm follower could not obfuscate value for ref %q: %w", s.RefPath, err)
+		}
 		visited[ref] = true
 		secrets.Store(ref, cachedSecret{
-			value: s.Value,
+			value: obfuscatedValue,
 		})
 	}
 	// delete old values
@@ -85,20 +93,25 @@ func (f *asmFollower) load(ctx context.Context, ref Ref, key *url.URL) ([]byte, 
 	return f.cache.getSecret(ref)
 }
 
-func (f *asmFollower) store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+func (f *asmFollower) store(ctx context.Context, ref Ref, obfuscatedValue []byte) (*url.URL, error) {
+	obfuscator := Secrets{}.obfuscator()
+	unobfuscatedValue, err := obfuscator.Reveal(obfuscatedValue)
+	if err != nil {
+		return nil, fmt.Errorf("asm follower could not unobfuscate: %w", err)
+	}
 	provider := ftlv1.SecretProvider_SECRET_ASM
-	_, err := f.client.SecretSet(ctx, connect.NewRequest(&ftlv1.SetSecretRequest{
+	_, err = f.client.SecretSet(ctx, connect.NewRequest(&ftlv1.SetSecretRequest{
 		Provider: &provider,
 		Ref: &ftlv1.ConfigRef{
 			Module: ref.Module.Ptr(),
 			Name:   ref.Name,
 		},
-		Value: value,
+		Value: unobfuscatedValue,
 	}))
 	if err != nil {
 		return nil, err
 	}
-	f.cache.updatedSecret(ref, value)
+	f.cache.updatedSecret(ref, obfuscatedValue)
 	return asmURLForRef(ref), nil
 }
 

--- a/common/configuration/obfuscator.go
+++ b/common/configuration/obfuscator.go
@@ -49,7 +49,7 @@ func (o Obfuscator) Reveal(input []byte) ([]byte, error) {
 
 	obfuscated, err := base64.StdEncoding.DecodeString(string(input))
 	if err != nil {
-		return nil, fmt.Errorf("expected hexadecimal string: %w", err)
+		return nil, fmt.Errorf("expected base64 string: %w", err)
 	}
 	block, err := aes.NewCipher(o.key)
 	if err != nil {


### PR DESCRIPTION
- Secret providers take in obfuscated bytes to store and should return obfuscated bytes when loading secrets
- ASM follower was not doing this because it stores and retrieves secrets through the admin API
    - When storing secrets it would send obfuscated values to the admin endpoint, which would fail (can not parse json string because its base64)
    - When retrieving secrets it woudl get unobfuscated values from the admin endpoint and return them. The manager would then fail when then unobfuscate this value (resulting in gibberish) which would then fail when trying to parse it as json
    
Solution:
ASM follower now directly accesses `Secrets{}.obfuscator()` to translate into the correct form.