### PR TITLE
fix: retryable streaming server errors to be logged as debug

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -240,6 +240,9 @@ func RetryStreamingServerStream[Req, Resp any](
 				} else {
 					// Stream terminated; check if this was caused by an error
 					err = stream.Err()
+					if !useDebugErrorLevel(err) {
+						logLevel = log.Warn
+					}
 					break
 				}
 			}
@@ -266,4 +269,10 @@ func RetryStreamingServerStream[Req, Resp any](
 		}
 
 	}
+}
+
+// useDebugErrorLevel indicates whether the specified error should be reported as a debug
+// level log.
+func useDebugErrorLevel(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connect: connection refused")
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -240,9 +240,7 @@ func RetryStreamingServerStream[Req, Resp any](
 				} else {
 					// Stream terminated; check if this was caused by an error
 					err = stream.Err()
-					if !useDebugErrorLevel(err) {
-						logLevel = log.Warn
-					}
+					logLevel = logLevelForError(err)
 					break
 				}
 			}
@@ -273,6 +271,9 @@ func RetryStreamingServerStream[Req, Resp any](
 
 // useDebugErrorLevel indicates whether the specified error should be reported as a debug
 // level log.
-func useDebugErrorLevel(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "connect: connection refused")
+func logLevelForError(err error) log.Level {
+	if err != nil && strings.Contains(err.Error(), "connect: connection refused") {
+		return log.Debug
+	}
+	return log.Warn
 }

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -240,7 +240,6 @@ func RetryStreamingServerStream[Req, Resp any](
 				} else {
 					// Stream terminated; check if this was caused by an error
 					err = stream.Err()
-					logLevel = log.Warn
 					break
 				}
 			}


### PR DESCRIPTION
fixes #2002

unexpected warnings caused by retryable errors - retryable errors will continue to be reported as debug.