### PR TITLE
fix: proactively coordinate leader/followers

### DIFF
--- a/backend/controller/leader/leader.go
+++ b/backend/controller/leader/leader.go
@@ -112,7 +112,7 @@ func (c *Coordinator[P]) sync(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		}
-		next = time.Now().Add(c.leaseTTL / 2)
+		next = time.Now().Add(max(time.Second*5, c.leaseTTL/2))
 	}
 }
 

--- a/backend/controller/leader/leader.go
+++ b/backend/controller/leader/leader.go
@@ -95,10 +95,10 @@ func NewCoordinator[P any](ctx context.Context,
 	return coordinator
 }
 
-// sync proactively tries and coordinate
+// sync proactively tries to coordinate between leader and followers
 //
 // This allows the coordinator to maintain a leader or follower even when Get() is not called.
-// Otherwise we can have stale followers attempting to communicate with a leader that no longer exists, until an external component called Get()
+// Otherwise we can have stale followers attempting to communicate with a leader that no longer exists, until a call to Get() comes in
 func (c *Coordinator[P]) sync(ctx context.Context) {
 	logger := log.FromContext(ctx)
 	next := time.Now()


### PR DESCRIPTION
fixes #2011

Cause: 
- Coordinator only does it coordination logic when something calls `Get()`
- If leader/follower coordinator's `Get()` function was not called then an expired leader/follower would not change
- ASM follower syncs with what it expects to be the leader even if that leader is not alive. Even if we get a new leader, the follower would not be swapped out for a valid one until `Get()` was called. So it would churn away failing to sync.

Fix:
- Proactively call `Get()` periodically so that coordination occurs even if no calls to Get() would otherwise happen.