### PR TITLE
feat: ftl migrate command

### DIFF
--- a/backend/controller/sql/database_integration_test.go
+++ b/backend/controller/sql/database_integration_test.go
@@ -3,6 +3,7 @@
 package sql_test
 
 import (
+	"os"
 	"testing"
 
 	in "github.com/TBD54566975/ftl/integration"
@@ -21,5 +22,19 @@ func TestDatabase(t *testing.T) {
 		in.CreateDBAction("database", "testdb", true),
 		in.ExecModuleTest("database"),
 		in.QueryRow("testdb", "SELECT data FROM requests", "hello"),
+	)
+}
+
+func TestMigrate(t *testing.T) {
+	os.Setenv("DATABASE_URL", "postgres://postgres:secret@localhost:15432/ftl_test?sslmode=disable")
+
+	q := func() in.Action {
+		return in.QueryRow("ftl_test", "SELECT version FROM schema_migrations WHERE version = '20240704103403'", "20240704103403")
+	}
+
+	in.RunWithoutController(t, "",
+		in.Fail(q(), "Should fail because the table does not exist."),
+		in.Exec("ftl", "migrate"),
+		q(),
 	)
 }

--- a/backend/controller/sql/databasetesting/devel.go
+++ b/backend/controller/sql/databasetesting/devel.go
@@ -62,7 +62,7 @@ func CreateForDevel(ctx context.Context, dsn string, recreate bool) (*pgxpool.Po
 
 	_, _ = conn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %q", config.Database)) //nolint:errcheck // PG doesn't support "IF NOT EXISTS" so instead we just ignore any error.
 
-	err = sql.Migrate(ctx, dsn)
+	err = sql.Migrate(ctx, dsn, log.Debug)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/controller/sql/migrate.go
+++ b/backend/controller/sql/migrate.go
@@ -18,7 +18,7 @@ import (
 var migrationSchema embed.FS
 
 // Migrate the database.
-func Migrate(ctx context.Context, dsn string) error {
+func Migrate(ctx context.Context, dsn string, logLevel log.Level) error {
 	u, err := url.Parse(dsn)
 	if err != nil {
 		return fmt.Errorf("invalid DSN: %w", err)
@@ -31,7 +31,7 @@ func Migrate(ctx context.Context, dsn string) error {
 
 	db := dbmate.New(u)
 	db.FS = migrationSchema
-	db.Log = log.FromContext(ctx).Scope("migrate").WriterAt(log.Debug)
+	db.Log = log.FromContext(ctx).Scope("migrate").WriterAt(logLevel)
 	db.MigrationsDir = []string{"schema"}
 	err = db.CreateAndMigrate()
 	if err != nil {

--- a/cmd/ftl/cmd_migrate.go
+++ b/cmd/ftl/cmd_migrate.go
@@ -15,7 +15,7 @@ type migrateCmd struct {
 func (c *migrateCmd) Run(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 	logger.Infof("Migrating database")
-	err := sql.Migrate(ctx, c.DSN)
+	err := sql.Migrate(ctx, c.DSN, log.Info)
 	if err != nil {
 		return fmt.Errorf("failed to migrate database: %w", err)
 	}

--- a/cmd/ftl/cmd_migrate.go
+++ b/cmd/ftl/cmd_migrate.go
@@ -3,9 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/TBD54566975/ftl/internal/log"
 
 	"github.com/TBD54566975/ftl/backend/controller/sql"
+	"github.com/TBD54566975/ftl/internal/log"
 )
 
 type migrateCmd struct {

--- a/cmd/ftl/cmd_migrate.go
+++ b/cmd/ftl/cmd_migrate.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"github.com/TBD54566975/ftl/internal/log"
 
 	"github.com/TBD54566975/ftl/backend/controller/sql"
@@ -14,5 +15,6 @@ type migrateCmd struct {
 func (c *migrateCmd) Run(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 	logger.Infof("Migrating database")
-	return sql.Migrate(ctx, c.DSN)
+	err := sql.Migrate(ctx, c.DSN)
+	return fmt.Errorf("failed to migrate database: %w", err)
 }

--- a/cmd/ftl/cmd_migrate.go
+++ b/cmd/ftl/cmd_migrate.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"github.com/TBD54566975/ftl/internal/log"
+
+	"github.com/TBD54566975/ftl/backend/controller/sql"
+)
+
+type migrateCmd struct {
+	DSN string `help:"DSN for the database." default:"postgres://localhost:15432/ftl?sslmode=disable&user=postgres&password=secret" env:"DATABASE_URL"`
+}
+
+func (c *migrateCmd) Run(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	logger.Infof("Migrating database")
+	return sql.Migrate(ctx, c.DSN)
+}

--- a/cmd/ftl/cmd_migrate.go
+++ b/cmd/ftl/cmd_migrate.go
@@ -16,5 +16,8 @@ func (c *migrateCmd) Run(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 	logger.Infof("Migrating database")
 	err := sql.Migrate(ctx, c.DSN)
-	return fmt.Errorf("failed to migrate database: %w", err)
+	if err != nil {
+		return fmt.Errorf("failed to migrate database: %w", err)
+	}
+	return nil
 }

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -47,6 +47,7 @@ type CLI struct {
 	Box      boxCmd      `cmd:"" help:"Build a self-contained Docker container for running a set of module."`
 	BoxRun   boxRunCmd   `cmd:"" hidden:"" help:"Run FTL inside an ftl-in-a-box container"`
 	Deploy   deployCmd   `cmd:"" help:"Build and deploy all modules found in the specified directories."`
+	Migrate  migrateCmd  `cmd:"" help:"Run a database migration, if required based on the migration table"`
 	Download downloadCmd `cmd:"" help:"Download a deployment."`
 	Secret   secretCmd   `cmd:"" help:"Manage secrets."`
 	Config   configCmd   `cmd:"" help:"Manage configuration."`

--- a/cmd/ftl/main.go
+++ b/cmd/ftl/main.go
@@ -47,7 +47,7 @@ type CLI struct {
 	Box      boxCmd      `cmd:"" help:"Build a self-contained Docker container for running a set of module."`
 	BoxRun   boxRunCmd   `cmd:"" hidden:"" help:"Run FTL inside an ftl-in-a-box container"`
 	Deploy   deployCmd   `cmd:"" help:"Build and deploy all modules found in the specified directories."`
-	Migrate  migrateCmd  `cmd:"" help:"Run a database migration, if required based on the migration table"`
+	Migrate  migrateCmd  `cmd:"" help:"Run a database migration, if required, based on the migration table."`
 	Download downloadCmd `cmd:"" help:"Download a deployment."`
 	Secret   secretCmd   `cmd:"" help:"Manage secrets."`
 	Config   configCmd   `cmd:"" help:"Manage configuration."`


### PR DESCRIPTION
Fixes #1839

- Migration files are embedded in the binary, so the binary version matches the schema.
- Uses `DATABASE_URL` (same as dbmate) or `--dsn` to specify the connection.

<img width="909" alt="image" src="https://github.com/TBD54566975/ftl/assets/31338/81b6fc6c-ede4-42c4-a5d5-1ed2d7b02342">
