### PR TITLE
fix: building withing lower parallelism than dependency group size

### DIFF
--- a/buildengine/engine.go
+++ b/buildengine/engine.go
@@ -690,11 +690,7 @@ func (e *Engine) build(ctx context.Context, moduleName string, builtModules map[
 		return fmt.Errorf("module %q not found", moduleName)
 	}
 
-	combined := map[string]*schema.Module{}
-	if err := e.gatherSchemas(builtModules, combined); err != nil {
-		return err
-	}
-	sch := &schema.Schema{Modules: maps.Values(combined)}
+	sch := &schema.Schema{Modules: maps.Values(builtModules)}
 
 	if e.listener != nil {
 		e.listener.OnBuildStarted(meta.module)


### PR DESCRIPTION
Fixes #2042

Before this change, we would get build errors because the `go.work` file for a given module would include all the built modules including modules that were in the same build `group` layer as a given module.

For example, if we had 4 modules all in the same group `[a, b, c, d]` and we build with a `-j2` option (2 parallel builds), we would run into an issue where `a` and `b` would build first, in parallel. `a` would finish and we would start to build `c`. But, when we looked up the `schema` to get shared modules for the `go.work` file for `c`, that list would now include `a` even though they are in the same build group and should never depend on each other.

This fix changes the build func to not re-lookup built modules and instead just use the set of `builtModules` that were available at the start of the build group.

With this change we should be able to safely support any `-j` option higher or lower than the number of modules. This probably would have eventually happened either way once we had a system with more modules than the number of cpus on a given machine.
