### PR TITLE
fix: no need to specify —opvault to access secrets

### DIFF
--- a/common/configuration/api.go
+++ b/common/configuration/api.go
@@ -117,9 +117,9 @@ type AsynchronousProvider[R Role] interface {
 	// SyncInterval() provides the expected time between syncs.
 	// If Sync() returns an error, sync will be retried with an exponential backoff.
 	//
-	// Sync is only called if the Router has keys referring to this provider.
-	// If the Router did have keys for this provider but removed them, one more round of sync is executed until Sync() will stop being called
-	Sync(ctx context.Context, values *xsync.MapOf[Ref, SyncedValue]) error
+	// Values should be updated by Sync().
+	// An array of known entries from the router is provided in case it is helpful, but the provider can store any values it wants.
+	Sync(ctx context.Context, entries []Entry, values *xsync.MapOf[Ref, SyncedValue]) error
 }
 
 type VersionToken any

--- a/common/configuration/asm.go
+++ b/common/configuration/asm.go
@@ -92,7 +92,7 @@ func (a *ASM) SyncInterval() time.Duration {
 	return client.syncInterval()
 }
 
-func (a *ASM) Sync(ctx context.Context, values *xsync.MapOf[Ref, SyncedValue]) error {
+func (a *ASM) Sync(ctx context.Context, entries []Entry, values *xsync.MapOf[Ref, SyncedValue]) error {
 	client, err := a.coordinator.Get()
 	if err != nil {
 		return fmt.Errorf("could not coordinate ASM: %w", err)

--- a/common/configuration/asm_test.go
+++ b/common/configuration/asm_test.go
@@ -174,9 +174,9 @@ func TestLeaderSync(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
 	sm, _, _, externalClient, clock, _ := setUp(ctx, t, None[Router[Secrets]]())
 	testClientSync(ctx, t, sm, externalClient, true, func(percentage float64) {
-		clock.Add(time.Duration(percentage) * asmLeaderSyncInterval)
+		clock.Add(time.Second * (time.Duration(asmLeaderSyncInterval.Seconds()*percentage) + 1.0))
 		if percentage == 1.0 {
-			time.Sleep(time.Second * 2)
+			time.Sleep(time.Second * 4)
 		}
 	})
 }
@@ -202,15 +202,15 @@ func TestFollowerSync(t *testing.T) {
 
 	testClientSync(ctx, t, sm, externalClient, false, func(percentage float64) {
 		// sync leader
-		leaderClock.Add(time.Duration(percentage) * asmLeaderSyncInterval)
+		leaderClock.Add(time.Second * (time.Duration(asmLeaderSyncInterval.Seconds()*percentage) + 1.0))
 		if percentage == 1.0 {
-			time.Sleep(time.Second * 2)
+			time.Sleep(time.Second * 4)
 		}
 
 		// then sync follower
-		followerClock.Add(time.Duration(percentage) * asmFollowerSyncInterval)
+		followerClock.Add(time.Second * (time.Duration(asmFollowerSyncInterval.Seconds()*percentage) + 1.0))
 		if percentage == 1.0 {
-			time.Sleep(time.Second * 2)
+			time.Sleep(time.Second * 4)
 		}
 	})
 }

--- a/common/configuration/cache.go
+++ b/common/configuration/cache.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/slices"
 	"github.com/alecthomas/types/optional"
 	"github.com/alecthomas/types/pubsub"
 	"github.com/benbjohnson/clock"
@@ -162,13 +163,9 @@ func (c *cache[R]) sync(ctx context.Context, clock clock.Clock) {
 				continue
 			}
 			for _, cp := range providersToSync {
-				entriesForProvider := []Entry{}
-				for _, e := range entries {
-					if ProviderKeyForAccessor(e.Accessor) != cp.provider.Key() {
-						continue
-					}
-					entriesForProvider = append(entriesForProvider, e)
-				}
+				entriesForProvider := slices.Filter(entries, func(e Entry) bool {
+					return ProviderKeyForAccessor(e.Accessor) == cp.provider.Key()
+				})
 				wg.Add(1)
 				go func(cp *cacheProvider[R]) {
 					cp.sync(ctx, entriesForProvider, clock)


### PR DESCRIPTION
Changes:
- Asynchronous providers are given a list of known entries when syncing
- 1Password provider uses these entries to know which vaults to sync
- Removed logic for whether an asynchronous provider was active. This was there to make sure we didnt attempt syncing with 1Password for projects that weren't using 1Password. This is now solved by 1PasswordProvider only syncing known vaults.