### PR TITLE
chore: add `just otel-ui` to view traces through browser

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -189,6 +189,12 @@ grpcPort := `cat docker-compose.yml | grep "OTLP gRPC" | sed 's/:.*//' | sed -r 
 # metrics and logs, but it is not available to be installed yet. Refer to issue:
 #     https://github.com/CtrlSpice/otel-desktop-viewer/issues/146
 otel-ui:
+  #!/bin/bash
+
+  if ! test -f $(git rev-parse --show-toplevel)/.hermit/go/bin/otel-desktop-viewer ; then
+    echo "Installing otel-desktop-viewer..."
+    go install github.com/CtrlSpice/otel-desktop-viewer@latest
+  fi
   otel-desktop-viewer --grpc {{grpcPort}}
 
 # Run otel collector in a docker container to stream local (i.e. from ftl dev) signals to

--- a/Justfile
+++ b/Justfile
@@ -175,9 +175,8 @@ debug *args:
   dlv_pid=$!
   wait "$dlv_pid"
 
-# grpcPort is used for observing the system via otel.
 # otel is short for OpenTelemetry.
-grpcPort := `cat docker-compose.yml | grep "OTLP gRPC" | sed 's/:.*//' | sed -r 's/ +- //'`
+otelGrpcPort := `cat docker-compose.yml | grep "OTLP gRPC" | sed 's/:.*//' | sed -r 's/ +- //'`
 
 # Run otel collector behind a webapp to stream local (i.e. from ftl dev) signals to your
 # browser. Ctrl+C to stop. To start FTL, open another terminal tab and run `just otel-dev`
@@ -195,7 +194,7 @@ otel-ui:
     echo "Installing otel-desktop-viewer..."
     go install github.com/CtrlSpice/otel-desktop-viewer@latest
   fi
-  otel-desktop-viewer --grpc {{grpcPort}}
+  otel-desktop-viewer --grpc {{otelGrpcPort}}
 
 # Run otel collector in a docker container to stream local (i.e. from ftl dev) signals to
 # the terminal tab where this is running. To start FTL, opepn another terminal tab and run
@@ -203,7 +202,7 @@ otel-ui:
 # `just otel-stop` in a third terminal tab.
 otel-stream:
   docker run \
-    -p {{grpcPort}}:{{grpcPort}} \
+    -p {{otelGrpcPort}}:{{otelGrpcPort}} \
     -p 55679:55679 \
     otel/opentelemetry-collector:0.104.0
 

--- a/Justfile
+++ b/Justfile
@@ -175,11 +175,26 @@ debug *args:
   dlv_pid=$!
   wait "$dlv_pid"
 
+# grpcPort is used for observing the system via otel.
+# otel is short for OpenTelemetry.
+grpcPort := `cat docker-compose.yml | grep "OTLP gRPC" | sed 's/:.*//' | sed -r 's/ +- //'`
+
+# Run otel collector behind a webapp to stream local (i.e. from ftl dev) signals to your
+# browser. Ctrl+C to stop. To start FTL, open another terminal tab and run `just otel-dev`
+# with any args you would pass to `ftl dev`.
+#
+# CAUTION: The version of otel-desktop-viewer we are running with only has support for
+# traces, NOT metrics or logs. If you want to view metrics or logs, you will need to use
+# `just otel-stream` below. The latest version of otel-desktop-viewer has support for
+# metrics and logs, but it is not available to be installed yet. Refer to issue:
+#     https://github.com/CtrlSpice/otel-desktop-viewer/issues/146
+otel-ui:
+  otel-desktop-viewer --grpc {{grpcPort}}
+
 # Run otel collector in a docker container to stream local (i.e. from ftl dev) signals to
 # the terminal tab where this is running. To start FTL, opepn another terminal tab and run
 # `just otel-dev` with any args you would pass to `ftl dev`. To stop the otel stream, run
 # `just otel-stop` in a third terminal tab.
-grpcPort := `cat docker-compose.yml | grep "OTLP gRPC" | sed 's/:.*//' | sed -r 's/ +- //'`
 otel-stream:
   docker run \
     -p {{grpcPort}}:{{grpcPort}} \


### PR DESCRIPTION
Part 2 of https://github.com/TBD54566975/ftl/issues/2020

This PR adds `just otel-ui`, which wraps the otel collector so you can view signals generated in `ftl dev` through a webapp without separately needing to start the collector.

Unfortunately, the latest version of `otel-desktop-viewer` that we can install only supports traces, not metrics or logs. The latest version on their github repo does have metrics/logs support, but can't be installed without cloning the whole repo and building from source code. Instead of doing that, I filed this issue: https://github.com/CtrlSpice/otel-desktop-viewer/issues/146

For now, when we're only debugging/developing traces, we can use this desktop viewer, which is quite nice. When working with metrics/logs, we'll still need to use the collector itself: `just otel-stream`. After the upgrade is complete for `otel-desktop-viewer`, we hopefully won't need the `otel-stream` command anymore.

Its terminal output looks like this:

```
$ just otel-ui
Installing otel-desktop-viewer...
otel-desktop-viewer --grpc 4317
2024-07-15T14:05:07.769-0400	info	service/telemetry.go:113	Setting up own telemetry...
2024-07-15T14:05:07.769-0400	info	service/telemetry.go:136	Serving Prometheus metrics	{"address": ":8888", "level": "Basic"}
2024-07-15T14:05:07.769-0400	info	exporter@v0.77.0/exporter.go:286	Development component. May change in the future.	{"kind": "exporter", "data_type": "traces", "name": "desktop"}
2024-07-15T14:05:07.769-0400	info	exporter@v0.77.0/exporter.go:286	Development component. May change in the future.	{"kind": "exporter", "data_type": "logs", "name": "desktop"}
2024-07-15T14:05:07.769-0400	info	exporter@v0.77.0/exporter.go:286	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "desktop"}
2024-07-15T14:05:07.769-0400	info	service/service.go:141	Starting otel-desktop-viewer...	{"Version": "0.1.1", "NumCPU": 12}
2024-07-15T14:05:07.769-0400	info	extensions/extensions.go:41	Starting extensions...
2024-07-15T14:05:07.769-0400	info	otlpreceiver@v0.77.0/otlp.go:94	Starting GRPC server	{"kind": "receiver", "name": "otlp", "data_type": "logs", "endpoint": "localhost:4317"}
2024-07-15T14:05:07.771-0400	info	otlpreceiver@v0.77.0/otlp.go:112	Starting HTTP server	{"kind": "receiver", "name": "otlp", "data_type": "logs", "endpoint": "localhost:4318"}
2024-07-15T14:05:07.771-0400	info	service/service.go:158	Everything is ready. Begin running and processing data.
^C2024-07-15T14:06:40.238-0400	info	otelcol/collector.go:238	Received signal from OS	{"signal": "interrupt"}
2024-07-15T14:06:40.238-0400	info	service/service.go:167	Starting shutdown...
2024-07-15T14:06:40.238-0400	info	extensions/extensions.go:55	Stopping extensions...
2024-07-15T14:06:40.238-0400	info	service/service.go:181	Shutdown complete.
```

Screenshot of traces after starting `ftl dev` and calling `echo.echo` via the console: 

<img width="1333" alt="Screenshot 2024-07-15 at 2 06 31 PM" src="https://github.com/user-attachments/assets/f049caa9-0a64-4286-9648-8429aee466eb">


For posterity, an alternative to using the desktop viewer is the following command to start a terminal ui. However, that doesn't include nearly as much viewable data as the desktop alternative.
```
otel-cli server tui --verbose --protocol grpc --endpoint http://localhost:4317
```