### PR TITLE
fix: only create config managers if needed to avoid syncing on every cmd

### DIFF
--- a/backend/controller/admin/local_client.go
+++ b/backend/controller/admin/local_client.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/buildengine"
-	"github.com/TBD54566975/ftl/common/configuration"
+	cf "github.com/TBD54566975/ftl/common/configuration"
 	"github.com/TBD54566975/ftl/common/projectconfig"
 	"github.com/alecthomas/types/optional"
 )
@@ -24,9 +24,8 @@ type diskSchemaRetriever struct {
 	deployRoot optional.Option[string]
 }
 
-func newLocalClient(ctx context.Context) *localClient {
-	cm := configuration.ConfigFromContext(ctx)
-	sm := configuration.SecretsFromContext(ctx)
+// NewLocalClient creates a admin client that reads and writes from the provided config and secret managers
+func NewLocalClient(cm *cf.Manager[cf.Configuration], sm *cf.Manager[cf.Secrets]) *localClient {
 	return &localClient{NewAdminService(cm, sm, &diskSchemaRetriever{})}
 }
 

--- a/backend/controller/admin/local_client.go
+++ b/backend/controller/admin/local_client.go
@@ -25,7 +25,7 @@ type diskSchemaRetriever struct {
 }
 
 // NewLocalClient creates a admin client that reads and writes from the provided config and secret managers
-func NewLocalClient(cm *cf.Manager[cf.Configuration], sm *cf.Manager[cf.Secrets]) *localClient {
+func NewLocalClient(cm *cf.Manager[cf.Configuration], sm *cf.Manager[cf.Secrets]) Client {
 	return &localClient{NewAdminService(cm, sm, &diskSchemaRetriever{})}
 }
 

--- a/cmd/ftl/cmd_config.go
+++ b/cmd/ftl/cmd_config.go
@@ -75,14 +75,14 @@ func setUpAdminClient(ctx context.Context, config projectconfig.Config) (ctxOut 
 		cr := cf.ProjectConfigResolver[cf.Configuration]{Config: config.Path}
 		cm, err := cf.NewConfigurationManager(ctx, cr)
 		if err != nil {
-			return client, err
+			return ctx, client, err
 		}
 		ctx = cf.ContextWithConfig(ctx, cm)
 
 		sr := cf.ProjectConfigResolver[cf.Secrets]{Config: config.Path}
 		sm, err := cf.NewSecretsManager(ctx, sr, cli.Vault, config.Path)
 		if err != nil {
-			return client, err
+			return ctx, client, err
 		}
 		ctx = cf.ContextWithSecrets(ctx, sm)
 

--- a/cmd/ftl/cmd_config.go
+++ b/cmd/ftl/cmd_config.go
@@ -75,14 +75,14 @@ func setUpAdminClient(ctx context.Context, config projectconfig.Config) (ctxOut 
 		cr := cf.ProjectConfigResolver[cf.Configuration]{Config: config.Path}
 		cm, err := cf.NewConfigurationManager(ctx, cr)
 		if err != nil {
-			return ctx, client, err
+			return ctx, client, fmt.Errorf("could not create config manager: %w", err)
 		}
 		ctx = cf.ContextWithConfig(ctx, cm)
 
 		sr := cf.ProjectConfigResolver[cf.Secrets]{Config: config.Path}
 		sm, err := cf.NewSecretsManager(ctx, sr, cli.Vault, config.Path)
 		if err != nil {
-			return ctx, client, err
+			return ctx, client, fmt.Errorf("could not create secrets manager: %w", err)
 		}
 		ctx = cf.ContextWithSecrets(ctx, sm)
 

--- a/cmd/ftl/cmd_config.go
+++ b/cmd/ftl/cmd_config.go
@@ -13,7 +13,11 @@ import (
 
 	"github.com/TBD54566975/ftl/backend/controller/admin"
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	cf "github.com/TBD54566975/ftl/common/configuration"
+	"github.com/TBD54566975/ftl/common/projectconfig"
+	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/rpc"
 )
 
 type configCmd struct {
@@ -60,7 +64,38 @@ type configListCmd struct {
 	Module string `optional:"" arg:"" placeholder:"MODULE" help:"List configuration only in this module."`
 }
 
-func (s *configListCmd) Run(ctx context.Context, adminClient admin.Client) error {
+func setUpAdminClient(ctx context.Context, config projectconfig.Config) (ctxOut context.Context, client admin.Client, err error) {
+	adminServiceClient := rpc.Dial(ftlv1connect.NewAdminServiceClient, cli.Endpoint.String(), log.Error)
+	shouldUseLocalClient, err := admin.ShouldUseLocalClient(ctx, adminServiceClient, cli.Endpoint)
+	if err != nil {
+		return ctx, client, fmt.Errorf("could not create admin client: %w", err)
+	}
+	if shouldUseLocalClient {
+		// create config and secret managers
+		cr := cf.ProjectConfigResolver[cf.Configuration]{Config: config.Path}
+		cm, err := cf.NewConfigurationManager(ctx, cr)
+		if err != nil {
+			return client, err
+		}
+		ctx = cf.ContextWithConfig(ctx, cm)
+
+		sr := cf.ProjectConfigResolver[cf.Secrets]{Config: config.Path}
+		sm, err := cf.NewSecretsManager(ctx, sr, cli.Vault, config.Path)
+		if err != nil {
+			return client, err
+		}
+		ctx = cf.ContextWithSecrets(ctx, sm)
+
+		return ctx, admin.NewLocalClient(cm, sm), nil
+	}
+	return ctx, adminServiceClient, nil
+}
+
+func (s *configListCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
+	ctx, adminClient, err := setUpAdminClient(ctx, projConfig)
+	if err != nil {
+		return err
+	}
 	resp, err := adminClient.ConfigList(ctx, connect.NewRequest(&ftlv1.ListConfigRequest{
 		Module:        &s.Module,
 		IncludeValues: &s.Values,
@@ -90,7 +125,11 @@ Returns a JSON-encoded configuration value.
 `
 }
 
-func (s *configGetCmd) Run(ctx context.Context, adminClient admin.Client) error {
+func (s *configGetCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
+	ctx, adminClient, err := setUpAdminClient(ctx, projConfig)
+	if err != nil {
+		return err
+	}
 	resp, err := adminClient.ConfigGet(ctx, connect.NewRequest(&ftlv1.GetConfigRequest{
 		Ref: configRefFromRef(s.Ref),
 	}))
@@ -107,8 +146,11 @@ type configSetCmd struct {
 	Value *string `arg:"" placeholder:"VALUE" help:"Configuration value (read from stdin if omitted)." optional:""`
 }
 
-func (s *configSetCmd) Run(ctx context.Context, scmd *configCmd, adminClient admin.Client) error {
-	var err error
+func (s *configSetCmd) Run(ctx context.Context, scmd *configCmd, projConfig projectconfig.Config) error {
+	ctx, adminClient, err := setUpAdminClient(ctx, projConfig)
+	if err != nil {
+		return err
+	}
 	var config []byte
 	if s.Value != nil {
 		config = []byte(*s.Value)
@@ -151,14 +193,18 @@ type configUnsetCmd struct {
 	Ref cf.Ref `arg:"" help:"Configuration reference in the form [<module>.]<name>."`
 }
 
-func (s *configUnsetCmd) Run(ctx context.Context, scmd *configCmd, adminClient admin.Client) error {
+func (s *configUnsetCmd) Run(ctx context.Context, scmd *configCmd, projConfig projectconfig.Config) error {
+	ctx, adminClient, err := setUpAdminClient(ctx, projConfig)
+	if err != nil {
+		return err
+	}
 	req := &ftlv1.UnsetConfigRequest{
 		Ref: configRefFromRef(s.Ref),
 	}
 	if provider, ok := scmd.provider().Get(); ok {
 		req.Provider = &provider
 	}
-	_, err := adminClient.ConfigUnset(ctx, connect.NewRequest(req))
+	_, err = adminClient.ConfigUnset(ctx, connect.NewRequest(req))
 	if err != nil {
 		return err
 	}
@@ -175,7 +221,11 @@ Imports configuration values from a JSON object.
 `
 }
 
-func (s *configImportCmd) Run(ctx context.Context, cmd *configCmd, adminClient admin.Client) error {
+func (s *configImportCmd) Run(ctx context.Context, cmd *configCmd, projConfig projectconfig.Config) error {
+	ctx, adminClient, err := setUpAdminClient(ctx, projConfig)
+	if err != nil {
+		return err
+	}
 	input, err := io.ReadAll(s.Input)
 	if err != nil {
 		return fmt.Errorf("failed to read input: %w", err)
@@ -218,7 +268,11 @@ Outputs configuration values in a JSON object. A provider can be used to filter 
 `
 }
 
-func (s *configExportCmd) Run(ctx context.Context, cmd *configCmd, adminClient admin.Client) error {
+func (s *configExportCmd) Run(ctx context.Context, cmd *configCmd, projConfig projectconfig.Config) error {
+	ctx, adminClient, err := setUpAdminClient(ctx, projConfig)
+	if err != nil {
+		return err
+	}
 	req := &ftlv1.ListConfigRequest{
 		IncludeValues: optional.Some(true).Ptr(),
 	}

--- a/cmd/ftl/cmd_serve.go
+++ b/cmd/ftl/cmd_serve.go
@@ -127,7 +127,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 		cr := cf.ProjectConfigResolver[cf.Configuration]{Config: projConfig.Path}
 		cm, err := cf.NewConfigurationManager(controllerCtx, cr)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not create config manager: %w", err)
 		}
 		controllerCtx = cf.ContextWithConfig(controllerCtx, cm)
 
@@ -135,7 +135,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 		sr := cf.ProjectConfigResolver[cf.Secrets]{Config: projConfig.Path}
 		sm, err := cf.NewSecretsManager(controllerCtx, sr, cli.Vault, projConfig.Path)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not create secrets manager: %w", err)
 		}
 		controllerCtx = cf.ContextWithSecrets(controllerCtx, sm)
 

--- a/cmd/ftl/testdata/secrets1.json
+++ b/cmd/ftl/testdata/secrets1.json
@@ -1,0 +1,3 @@
+{
+    "test.one": "hello world"
+}

--- a/cmd/ftl/testdata/secrets2.json
+++ b/cmd/ftl/testdata/secrets2.json
@@ -1,0 +1,3 @@
+{
+    "test.one": "hello world 2"
+}


### PR DESCRIPTION
fixes #2086
- Recently we added a feature for cf.Manager to sync providers (1Password & ASM)
- We should not create these managers if they are not used, otherwise we will prompt the user for 1Password access unnecessarily
- Previously we were creating config + secret managers in `main.go` for every command, even though it is only needed for these commands:
    - `ftl serve`
    - `ftl dev`
    - `ftl config ...` if there is no controller running
    - `ftl secret ...` if there is no controller running