### PR TITLE
fix: flaky asm tests fixed by wrapping async provider

### DIFF
--- a/common/configuration/asm.go
+++ b/common/configuration/asm.go
@@ -93,6 +93,14 @@ func (a *ASM) SyncInterval() time.Duration {
 }
 
 func (a *ASM) Sync(ctx context.Context, entries []Entry, values *xsync.MapOf[Ref, SyncedValue]) error {
+	refs := []Ref{}
+	values.Range(func(key Ref, value SyncedValue) bool {
+		refs = append(refs, key)
+		return true
+	})
+
+	c, _ := a.coordinator.Get()
+	fmt.Printf("before %T sync: %v\n", c, refs)
 	client, err := a.coordinator.Get()
 	if err != nil {
 		return fmt.Errorf("could not coordinate ASM: %w", err)
@@ -101,6 +109,12 @@ func (a *ASM) Sync(ctx context.Context, entries []Entry, values *xsync.MapOf[Ref
 	if err != nil {
 		return fmt.Errorf("%s: %w", client.name(), err)
 	}
+	refs = []Ref{}
+	values.Range(func(key Ref, value SyncedValue) bool {
+		refs = append(refs, key)
+		return true
+	})
+	fmt.Printf("after %T sync: %v\n", c, refs)
 	return nil
 }
 

--- a/common/configuration/asm.go
+++ b/common/configuration/asm.go
@@ -93,14 +93,6 @@ func (a *ASM) SyncInterval() time.Duration {
 }
 
 func (a *ASM) Sync(ctx context.Context, entries []Entry, values *xsync.MapOf[Ref, SyncedValue]) error {
-	refs := []Ref{}
-	values.Range(func(key Ref, value SyncedValue) bool {
-		refs = append(refs, key)
-		return true
-	})
-
-	c, _ := a.coordinator.Get()
-	fmt.Printf("before %T sync: %v\n", c, refs)
 	client, err := a.coordinator.Get()
 	if err != nil {
 		return fmt.Errorf("could not coordinate ASM: %w", err)
@@ -109,12 +101,6 @@ func (a *ASM) Sync(ctx context.Context, entries []Entry, values *xsync.MapOf[Ref
 	if err != nil {
 		return fmt.Errorf("%s: %w", client.name(), err)
 	}
-	refs = []Ref{}
-	values.Range(func(key Ref, value SyncedValue) bool {
-		refs = append(refs, key)
-		return true
-	})
-	fmt.Printf("after %T sync: %v\n", c, refs)
 	return nil
 }
 

--- a/common/configuration/asm_test.go
+++ b/common/configuration/asm_test.go
@@ -306,9 +306,6 @@ func waitForManualSync[R Role](t *testing.T, providers []*ManualSyncProvider[R])
 
 	for _, provider := range providers {
 		err := provider.SyncAndWait()
-		if err != nil {
-			fmt.Printf("aaa\n")
-		}
 		assert.NoError(t, err)
 	}
 }

--- a/common/configuration/cache.go
+++ b/common/configuration/cache.go
@@ -150,7 +150,6 @@ func (c *cache[R]) sync(ctx context.Context) {
 			providersToSync := []*cacheProvider[R]{}
 			for _, cp := range c.providers {
 				if cp.needsSync() {
-					fmt.Print("needs sync!\n")
 					providersToSync = append(providersToSync, cp)
 				}
 			}

--- a/common/configuration/cache.go
+++ b/common/configuration/cache.go
@@ -11,7 +11,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/slices"
 	"github.com/alecthomas/types/optional"
 	"github.com/alecthomas/types/pubsub"
-	"github.com/benbjohnson/clock"
 	"github.com/puzpuzpuz/xsync/v3"
 )
 
@@ -48,7 +47,7 @@ type cache[R Role] struct {
 	topicWaitGroup *sync.WaitGroup
 }
 
-func newCache[R Role](ctx context.Context, providers []AsynchronousProvider[R], listProvider listProvider, clock clock.Clock) *cache[R] {
+func newCache[R Role](ctx context.Context, providers []AsynchronousProvider[R], listProvider listProvider) *cache[R] {
 	cacheProviders := make(map[string]*cacheProvider[R], len(providers))
 	for _, provider := range providers {
 		cacheProviders[provider.Key()] = &cacheProvider[R]{
@@ -64,7 +63,7 @@ func newCache[R Role](ctx context.Context, providers []AsynchronousProvider[R], 
 		topic:          pubsub.New[updateCacheEvent](),
 		topicWaitGroup: &sync.WaitGroup{},
 	}
-	go cache.sync(ctx, clock)
+	go cache.sync(ctx)
 
 	return cache
 }
@@ -121,7 +120,7 @@ func (c *cache[R]) deletedValue(ref Ref, pkey string) {
 // Errors returned by a provider cause retries with exponential backoff.
 //
 // Events are processed when all providers are not being synced
-func (c *cache[R]) sync(ctx context.Context, clock clock.Clock) {
+func (c *cache[R]) sync(ctx context.Context) {
 	if len(c.providers) == 0 {
 		// nothing to sync
 		return
@@ -134,7 +133,7 @@ func (c *cache[R]) sync(ctx context.Context, clock clock.Clock) {
 	defer c.topic.Unsubscribe(events)
 
 	// start syncing immediately
-	next := clock.Now()
+	next := time.Now()
 
 	for {
 		select {
@@ -145,12 +144,13 @@ func (c *cache[R]) sync(ctx context.Context, clock clock.Clock) {
 			c.processEvent(e)
 
 		// Can not calculate next sync date for each provider as sync intervals can change (eg when follower becomes leader)
-		case <-clock.After(next.Sub(clock.Now())):
+		case <-time.After(time.Until(next)):
 			wg := &sync.WaitGroup{}
 
 			providersToSync := []*cacheProvider[R]{}
 			for _, cp := range c.providers {
-				if cp.needsSync(clock) {
+				if cp.needsSync() {
+					fmt.Print("needs sync!\n")
 					providersToSync = append(providersToSync, cp)
 				}
 			}
@@ -168,12 +168,12 @@ func (c *cache[R]) sync(ctx context.Context, clock clock.Clock) {
 				})
 				wg.Add(1)
 				go func(cp *cacheProvider[R]) {
-					cp.sync(ctx, entriesForProvider, clock)
+					cp.sync(ctx, entriesForProvider)
 					wg.Done()
 				}(cp)
 			}
 			wg.Wait()
-			next = clock.Now().Add(time.Second)
+			next = time.Now().Add(time.Second)
 		}
 	}
 }
@@ -211,22 +211,22 @@ func (c *cacheProvider[R]) waitForInitialSync() error {
 }
 
 // needsSync returns true if the provider needs to be synced.
-func (c *cacheProvider[R]) needsSync(clock clock.Clock) bool {
+func (c *cacheProvider[R]) needsSync() bool {
 	lastSyncAttempt, ok := c.lastSyncAttempt.Get()
 	if !ok {
 		return true
 	}
 	if currentBackoff, ok := c.currentBackoff.Get(); ok {
-		return clock.Now().After(lastSyncAttempt.Add(currentBackoff))
+		return time.Now().After(lastSyncAttempt.Add(currentBackoff))
 	}
-	return clock.Now().After(lastSyncAttempt.Add(c.provider.SyncInterval()))
+	return time.Now().After(lastSyncAttempt.Add(c.provider.SyncInterval()))
 }
 
 // sync executes sync on the provider and updates the cacheProvider sync state
-func (c *cacheProvider[R]) sync(ctx context.Context, entries []Entry, clock clock.Clock) {
+func (c *cacheProvider[R]) sync(ctx context.Context, entries []Entry) {
 	logger := log.FromContext(ctx)
 
-	c.lastSyncAttempt = optional.Some(clock.Now())
+	c.lastSyncAttempt = optional.Some(time.Now())
 	err := c.provider.Sync(ctx, entries, c.values)
 	if err != nil {
 		logger.Errorf(err, "Error syncing %s", c.provider.Key())

--- a/common/configuration/manager.go
+++ b/common/configuration/manager.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/alecthomas/types/optional"
-	"github.com/benbjohnson/clock"
 )
 
 // Role of [Manager], either Secrets or Configuration.
@@ -65,10 +64,6 @@ func NewDefaultConfigurationManagerFromConfig(ctx context.Context, config string
 
 // New configuration manager.
 func New[R Role](ctx context.Context, router Router[R], providers []Provider[R]) (*Manager[R], error) {
-	return newForTesting(ctx, router, providers, clock.New()), nil
-}
-
-func newForTesting[R Role](ctx context.Context, router Router[R], providers []Provider[R], clock clock.Clock) *Manager[R] {
 	m := &Manager[R]{
 		providers: map[string]Provider[R]{},
 	}
@@ -86,9 +81,9 @@ func newForTesting[R Role](ctx context.Context, router Router[R], providers []Pr
 			asyncProviders = append(asyncProviders, sp)
 		}
 	}
-	m.cache = newCache[R](ctx, asyncProviders, m, clock)
+	m.cache = newCache[R](ctx, asyncProviders, m)
 
-	return m
+	return m, nil
 }
 
 func ProviderKeyForAccessor(accessor *url.URL) string {

--- a/common/configuration/manual_sync_utils.go
+++ b/common/configuration/manual_sync_utils.go
@@ -1,0 +1,86 @@
+//go:build !release
+
+package configuration
+
+import (
+	"context"
+	"net/url"
+	"time"
+
+	"github.com/alecthomas/atomic"
+
+	"github.com/alecthomas/types/optional"
+	"github.com/puzpuzpuz/xsync/v3"
+)
+
+type manualSyncBlock struct {
+	sync chan optional.Option[error]
+}
+
+// ManualSyncProvider prevents normal syncs by returning a very high sync interval
+// when syncAndWait() is called, it starts returning a 0 sync interval  and then then blocks until sync completes.
+// See why we didn't use mock clocks to schedule syncs here: https://github.com/TBD54566975/ftl/issues/2092
+type ManualSyncProvider[R Role] struct {
+	syncRequested atomic.Value[optional.Option[manualSyncBlock]]
+
+	provider AsynchronousProvider[R]
+}
+
+var _ AsynchronousProvider[Secrets] = &ManualSyncProvider[Secrets]{}
+
+func NewManualSyncProvider[R Role](provider AsynchronousProvider[R]) *ManualSyncProvider[R] {
+	return &ManualSyncProvider[R]{
+		provider: provider,
+	}
+}
+
+func (a *ManualSyncProvider[R]) SyncAndWait() error {
+	block := manualSyncBlock{
+		sync: make(chan optional.Option[error]),
+	}
+	a.syncRequested.Store(optional.Some(block))
+	err := <-block.sync
+	if err, hasErr := err.Get(); hasErr {
+		return err
+	}
+	return nil
+}
+
+func (a *ManualSyncProvider[R]) Role() R {
+	return a.provider.Role()
+}
+
+func (a *ManualSyncProvider[R]) Key() string {
+	return a.provider.Key()
+}
+
+func (a *ManualSyncProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
+	return a.provider.Store(ctx, ref, value)
+}
+
+func (a *ManualSyncProvider[R]) Delete(ctx context.Context, ref Ref) error {
+	return a.provider.Delete(ctx, ref)
+}
+
+func (a *ManualSyncProvider[R]) SyncInterval() time.Duration {
+	if _, ok := a.syncRequested.Load().Get(); ok {
+		// sync now
+		return 0
+	}
+	// prevent sync
+	return time.Hour * 24 * 365
+}
+
+func (a *ManualSyncProvider[R]) Sync(ctx context.Context, entries []Entry, values *xsync.MapOf[Ref, SyncedValue]) error {
+	err := a.provider.Sync(ctx, entries, values)
+
+	if block, ok := a.syncRequested.Load().Get(); ok {
+		a.syncRequested.Store(optional.None[manualSyncBlock]())
+		if err == nil {
+			block.sync <- optional.None[error]()
+		} else {
+			block.sync <- optional.Some(err)
+		}
+	}
+	return err
+}

--- a/common/configuration/manual_sync_utils.go
+++ b/common/configuration/manual_sync_utils.go
@@ -41,7 +41,7 @@ func (a *ManualSyncProvider[R]) SyncAndWait() error {
 	a.syncRequested.Store(optional.Some(block))
 	err := <-block.sync
 	if err, hasErr := err.Get(); hasErr {
-		return err
+		return err //nolint:wrapcheck
 	}
 	return nil
 }
@@ -55,11 +55,11 @@ func (a *ManualSyncProvider[R]) Key() string {
 }
 
 func (a *ManualSyncProvider[R]) Store(ctx context.Context, ref Ref, value []byte) (*url.URL, error) {
-	return a.provider.Store(ctx, ref, value)
+	return a.provider.Store(ctx, ref, value) //nolint:wrapcheck
 }
 
 func (a *ManualSyncProvider[R]) Delete(ctx context.Context, ref Ref) error {
-	return a.provider.Delete(ctx, ref)
+	return a.provider.Delete(ctx, ref) //nolint:wrapcheck
 }
 
 func (a *ManualSyncProvider[R]) SyncInterval() time.Duration {
@@ -82,5 +82,5 @@ func (a *ManualSyncProvider[R]) Sync(ctx context.Context, entries []Entry, value
 			block.sync <- optional.Some(err)
 		}
 	}
-	return err
+	return err //nolint:wrapcheck
 }


### PR DESCRIPTION
fixes #2092
- mock clock was causing the same race conditions as this issue: https://github.com/TBD54566975/ftl/issues/1368#issuecomment-2087944187
- instead we are now wrapping the ASM provider with a manual sync provider
    - This wrapper allows us to trigger when syncs should happen in tests, and block until sync completes