### PR TITLE
fix: avoid insertion key dupls in `module_secrets` table by upserting on conflict

### DIFF
--- a/common/configuration/dal/dal_test.go
+++ b/common/configuration/dal/dal_test.go
@@ -101,3 +101,16 @@ func TestModuleConfiguration(t *testing.T) {
 		}
 	})
 }
+
+func TestModuleSecrets(t *testing.T) {
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	conn := sqltest.OpenForTesting(ctx, t)
+	dal, err := New(ctx, conn)
+	assert.NoError(t, err)
+	assert.NotZero(t, dal)
+
+	err = dal.SetModuleSecretURL(ctx, optional.Some("echo"), "my_secret", "asm://echo.my_secret")
+	assert.NoError(t, err)
+	err = dal.SetModuleSecretURL(ctx, optional.Some("echo"), "my_secret", "asm://echo.my_secret")
+	assert.NoError(t, err)
+}

--- a/common/configuration/sql/queries.sql
+++ b/common/configuration/sql/queries.sql
@@ -36,7 +36,8 @@ ORDER BY module, name;
 
 -- name: SetModuleSecretURL :exec
 INSERT INTO module_secrets (module, name, url)
-VALUES ($1, $2, $3);
+VALUES ($1, $2, $3)
+ON CONFLICT (module, name) DO UPDATE SET url = $3;
 
 -- name: UnsetModuleSecret :exec
 DELETE FROM module_secrets

--- a/common/configuration/sql/queries.sql.go
+++ b/common/configuration/sql/queries.sql.go
@@ -122,6 +122,7 @@ func (q *Queries) SetModuleConfiguration(ctx context.Context, module optional.Op
 const setModuleSecretURL = `-- name: SetModuleSecretURL :exec
 INSERT INTO module_secrets (module, name, url)
 VALUES ($1, $2, $3)
+ON CONFLICT (module, name) DO UPDATE SET url = $3
 `
 
 func (q *Queries) SetModuleSecretURL(ctx context.Context, module optional.Option[string], name string, url string) error {


### PR DESCRIPTION
Addresses part of https://github.com/TBD54566975/ftl/issues/2084

Postgresql way to handle upserts: https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-upsert/

This PR fixes the issue for secrets since that's causing issues for the client team, but not for config, which has the same issue. I confirmed the test fails before this change but passes with it.