### PR TITLE
fix: wrap errors in ReplaceDeployment, don’t hide errconflicts

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -526,7 +526,7 @@ func (s *Service) ReplaceDeploy(ctx context.Context, c *connect.Request[ftlv1.Re
 		if errors.Is(err, dalerrs.ErrNotFound) {
 			logger.Errorf(err, "Deployment not found: %s", newDeploymentKey)
 			return nil, connect.NewError(connect.CodeNotFound, errors.New("deployment not found"))
-		} else if errors.Is(err, dalerrs.ErrConflict) {
+		} else if errors.Is(err, dal.ErrReplaceDeploymentAlreadyActive) {
 			logger.Infof("Reusing deployment: %s", newDeploymentKey)
 		} else {
 			logger.Errorf(err, "Could not replace deployment: %s", newDeploymentKey)

--- a/backend/controller/dal/dal.go
+++ b/backend/controller/dal/dal.go
@@ -754,7 +754,7 @@ func (d *DAL) ReplaceDeployment(ctx context.Context, newDeploymentKey model.Depl
 	if err == nil {
 		count, err := tx.ReplaceDeployment(ctx, oldDeployment.Key, newDeploymentKey, int32(minReplicas))
 		if err != nil {
-			return fmt.Errorf("replace deployment failed replace min replicas from %v to %v: %w", oldDeployment.Key, newDeploymentKey, dalerrs.TranslatePGError(err))
+			return fmt.Errorf("replace deployment failed to replace min replicas from %v to %v: %w", oldDeployment.Key, newDeploymentKey, dalerrs.TranslatePGError(err))
 		}
 		if count == 1 {
 			return fmt.Errorf("replace deployment failed: deployment already exists from %v to %v: %w", oldDeployment.Key, newDeploymentKey, ErrReplaceDeploymentAlreadyActive)

--- a/buildengine/deploy.go
+++ b/buildengine/deploy.go
@@ -100,6 +100,7 @@ func Deploy(ctx context.Context, module Module, replicas int32, waitForDeployOnl
 		if err != nil {
 			return err
 		}
+		logger.Debugf("Deployment %s became ready", resp.Msg.DeploymentKey)
 	}
 
 	return nil


### PR DESCRIPTION
also logs now include old and new deployment keys