### PR TITLE
chore: fix integration success to always report status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,13 @@ jobs:
     name: Integration Success
     needs: [integration-run]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
-      - name: Ok
-        run: echo "Integration tests passed"
+      - name: Check integration tests result
+        run: |
+          if [[ "${{ needs.integration-run.result }}" == "failure" ]]; then
+            echo "Integration tests failed"
+            exit 1
+          else
+            echo "Integration tests passed"
+          fi


### PR DESCRIPTION
It seems like based on the docs [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks), that a "When a job fails, any jobs that depend on the failed job are skipped and do not report a failure.".

This could be causing the issue where if an integration test fails, the status is reported as `Skipped` vs. `Failed`. The solution described there is "To use a required check on a job that depends on other jobs, use the always() conditional expression in addition to needs, see "[Using jobs in a workflow](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs).""

Here's the original offending CI run that shows the skipped check: https://github.com/TBD54566975/ftl/actions/runs/9901843688/job/27354958500?pr=2055

Tested with a failing integration test:
<img width="533" alt="Screenshot 2024-07-23 at 9 27 46 AM" src="https://github.com/user-attachments/assets/4cf8e35b-17d2-47d8-abc9-c276cb95e2d1">
