### PR TITLE
fix: improve lease log level and include key

### DIFF
--- a/go-runtime/ftl/leases.go
+++ b/go-runtime/ftl/leases.go
@@ -46,7 +46,7 @@ func (l LeaseHandle) Err() error {
 	l.state.mutex.Lock()
 	defer l.state.mutex.Unlock()
 	if err, ok := l.state.err.Get(); ok {
-		return err
+		return err //nolint:wrapcheck
 	}
 	return nil
 }


### PR DESCRIPTION
fixes #2159
fixes #2160

- When module lease heartbeats stopped, it always logged a warning, even if the lease was released properly.
- All module lease logs now include the lease key for easy log lookups with controller lease logs
- Previously, `lease.err` was not set properly because the struct was not referenced via a pointer so the state was not shared.
    - I added `state: *leaseState` to get around this (rather than making the lease handle a pointer) because it also made clear what the mutex is protecting. Not a strong opinion though, happy to do the other approach if people feel that it's cleaner.