### PR TITLE
fix: allow subpackage's verbs to be called

### DIFF
--- a/go-runtime/ftl/leases.go
+++ b/go-runtime/ftl/leases.go
@@ -46,7 +46,7 @@ func (l LeaseHandle) Err() error {
 	l.state.mutex.Lock()
 	defer l.state.mutex.Unlock()
 	if err, ok := l.state.err.Get(); ok {
-		return err
+		return err //nolint:wrapcheck
 	}
 	return nil
 }

--- a/go-runtime/ftl/reflection/reflection_test.go
+++ b/go-runtime/ftl/reflection/reflection_test.go
@@ -74,3 +74,53 @@ func TestReflectTypeFromValue(t *testing.T) {
 		})
 	})
 }
+
+func TestGoRefToFTLRef(t *testing.T) {
+	tests := []struct {
+		input        string
+		expected     Ref
+		expectsError bool
+	}{
+		{
+			input:    "ftl/echo/inner.Verb",
+			expected: Ref{Module: "echo", Name: "verb"},
+		},
+		{
+			input:    "ftl/echo/inner/subpackage.TestName",
+			expected: Ref{Module: "echo", Name: "testName"},
+		},
+		{
+			input:    "ftl/echo/inner/subpackage1/subpackage2.A_Name",
+			expected: Ref{Module: "echo", Name: "a_Name"},
+		},
+		{
+			input:    "ftl/echo/inner/subpackage1/subpackage2.Verb",
+			expected: Ref{Module: "echo", Name: "verb"},
+		},
+		{
+			input:        "echo/inner.Verb",
+			expectsError: true,
+		},
+		{
+			input:        "echo/inner.Verb",
+			expectsError: true,
+		},
+		{
+			input:        "inner.Verb",
+			expectsError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if tt.expectsError {
+				assert.Panics(t, func() {
+					goRefToFTLRef(tt.input)
+				})
+				return
+			}
+			output := goRefToFTLRef(tt.input)
+			assert.Equal(t, tt.expected, output)
+		})
+	}
+
+}

--- a/go-runtime/server/server.go
+++ b/go-runtime/server/server.go
@@ -143,7 +143,7 @@ func (m *moduleServer) Call(ctx context.Context, req *connect.Request[ftlv1.Call
 	}()
 	handler, ok := m.handlers[reflection.RefFromProto(req.Msg.Verb)]
 	if !ok {
-		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("verb %q not found", req.Msg.Verb))
+		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("verb %s.%s not found", req.Msg.Verb.Module, req.Msg.Verb.Name))
 	}
 
 	respdata, err := handler.fn(ctx, req.Msg.Body)


### PR DESCRIPTION
In `.ftl/go/main/main.go` when registering verb handlers, we were calculating the refs for each verb as `Ref{module:subpackage, name:verb}`.
This fixes the conversion from go function to FTL ref by handling subpackages correctly.