### PR TITLE
feat: extract verb call metadata

### DIFF
--- a/go-runtime/compile/schema_test.go
+++ b/go-runtime/compile/schema_test.go
@@ -248,7 +248,12 @@ func TestExtractModuleSchemaTwo(t *testing.T) {
 			export verb callsTwo(two.Payload<String>) two.Payload<String>
 				+calls two.two
 
+			export verb callsTwoAndThree(two.Payload<String>) two.Payload<String>
+				+calls two.three, two.two
+
 			export verb returnsUser(Unit) two.UserResponse
+
+			export verb three(two.Payload<String>) two.Payload<String>
 
 			export verb two(two.Payload<String>) two.Payload<String>
 		  }
@@ -547,10 +552,10 @@ func TestErrorReporting(t *testing.T) {
 		`31:3-3: unexpected directive "ftl:export" attached for verb, did you mean to use '//ftl:verb export' instead?`,
 		`37:40-40: unsupported request type "ftl/failing.Request"`,
 		`37:50-50: unsupported response type "ftl/failing.Response"`,
-		`38:16-29: call first argument must be a function but is an unresolved reference to lib.OtherFunc`,
-		`38:16-29: call first argument must be a function in an ftl module`,
+		`38:16-29: call first argument must be a function but is an unresolved reference to lib.OtherFunc, does it need to be exported?`,
+		`38:16-29: call first argument must be a function in an ftl module, does it need to be exported?`,
 		`39:2-46: call must have exactly three arguments`,
-		`40:16-25: call first argument must be a function in an ftl module`,
+		`40:16-25: call first argument must be a function in an ftl module, does it need to be exported?`,
 		`45:1-2: must have at most two parameters (context.Context, struct)`,
 		`45:69-69: unsupported response type "ftl/failing.Response"`,
 		`50:22-27: first parameter must be of type context.Context but is ftl/failing.Request`,

--- a/go-runtime/compile/testdata/go/two/two.go
+++ b/go-runtime/compile/testdata/go/two/two.go
@@ -55,8 +55,19 @@ func Two(ctx context.Context, req Payload[string]) (Payload[string], error) {
 }
 
 //ftl:verb export
+func Three(ctx context.Context, req Payload[string]) (Payload[string], error) {
+	return Payload[string]{}, nil
+}
+
+//ftl:verb export
 func CallsTwo(ctx context.Context, req Payload[string]) (Payload[string], error) {
 	return ftl.Call(ctx, Two, req)
+}
+
+//ftl:verb export
+func CallsTwoAndThree(ctx context.Context, req Payload[string]) (Payload[string], error) {
+	err := transitiveVerbCall(ctx, req)
+	return Payload[string]{}, err
 }
 
 //ftl:verb export
@@ -87,3 +98,19 @@ type ExplicitAliasAlias = lib.NonFTLType
 type TransitiveAliasType lib.NonFTLType
 
 type TransitiveAliasAlias = lib.NonFTLType
+
+type TransitiveAlias lib.NonFTLType
+
+func transitiveVerbCall(ctx context.Context, req Payload[string]) error {
+	_, err := ftl.Call(ctx, Two, req)
+	if err != nil {
+		return err
+	}
+	err = superTransitiveVerbCall(ctx, req)
+	return err
+}
+
+func superTransitiveVerbCall(ctx context.Context, req Payload[string]) error {
+	_, err := ftl.Call(ctx, Three, req)
+	return err
+}

--- a/go-runtime/schema/call/analyzer.go
+++ b/go-runtime/schema/call/analyzer.go
@@ -5,6 +5,8 @@ import (
 	"go/types"
 	"strings"
 
+	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/TBD54566975/ftl/backend/schema/strcase"
 	"github.com/TBD54566975/ftl/go-runtime/schema/common"
 	"github.com/TBD54566975/golang-tools/go/analysis"
 	"github.com/TBD54566975/golang-tools/go/analysis/passes/inspect"
@@ -12,6 +14,7 @@ import (
 )
 
 const (
+	ftlCallFuncPath        = "github.com/TBD54566975/ftl/go-runtime/ftl.Call"
 	ftlPkgPath             = "github.com/TBD54566975/ftl/go-runtime/ftl"
 	ftlTopicHandleTypeName = "TopicHandle"
 )
@@ -23,17 +26,71 @@ type Tag struct{} // Tag uniquely identifies the fact type for this extractor.
 type Fact = common.DefaultFact[Tag]
 
 func Extract(pass *analysis.Pass) (interface{}, error) {
-	//TODO: implement call metadata extraction (for now this just validates all calls)
-
 	in := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector) //nolint:forcetypeassert
 	nodeFilter := []ast.Node{
+		(*ast.FuncDecl)(nil),
 		(*ast.CallExpr)(nil),
 	}
+	var currentFunc *ast.FuncDecl
 	in.Preorder(nodeFilter, func(n ast.Node) {
-		node := n.(*ast.CallExpr) //nolint:forcetypeassert
-		validateCallExpr(pass, node)
+		switch node := n.(type) {
+		case *ast.FuncDecl:
+			currentFunc = node
+		case *ast.CallExpr:
+			validateCallExpr(pass, node)
+			if currentFunc == nil {
+				return
+			}
+			parentFuncObj, ok := common.GetObjectForNode(pass.TypesInfo, currentFunc).Get()
+			if !ok {
+				return
+			}
+			_, fn := common.Deref[*types.Func](pass, node.Fun)
+			if fn == nil {
+				return
+			}
+			if fn.FullName() == ftlCallFuncPath {
+				extractVerbCall(pass, parentFuncObj, node)
+				return
+			}
+			common.MarkFunctionCall(pass, parentFuncObj, fn)
+		}
 	})
 	return common.NewExtractorResult(pass), nil
+}
+
+func extractVerbCall(pass *analysis.Pass, parentFuncObj types.Object, node *ast.CallExpr) {
+	if len(node.Args) != 3 {
+		common.Errorf(pass, node, "call must have exactly three arguments")
+		return
+	}
+	ref := parseVerbRef(pass, node.Args[1])
+	if ref == nil {
+		if sel, ok := node.Args[1].(*ast.SelectorExpr); ok {
+			common.Errorf(pass, node.Args[1], "call first argument must be a function but is an unresolved "+
+				"reference to %s.%s, does it need to be exported?", sel.X, sel.Sel)
+		}
+		common.Errorf(pass, node.Args[1], "call first argument must be a function in an ftl module, does "+
+			"it need to be exported?")
+		return
+	}
+	common.MarkVerbCall(pass, parentFuncObj, ref)
+}
+
+func parseVerbRef(pass *analysis.Pass, node ast.Expr) *schema.Ref {
+	_, verbFn := common.Deref[*types.Func](pass, node)
+	if verbFn == nil {
+		return nil
+	}
+	moduleName, err := common.FtlModuleFromGoPackage(verbFn.Pkg().Path())
+	if err != nil {
+		return nil
+	}
+	return &schema.Ref{
+		Pos:    common.GoPosToSchemaPos(pass.Fset, node.Pos()),
+		Module: moduleName,
+		Name:   strcase.ToLowerCamel(verbFn.Name()),
+	}
 }
 
 // validateCallExpr validates all function calls

--- a/go-runtime/schema/enum/analyzer.go
+++ b/go-runtime/schema/enum/analyzer.go
@@ -67,7 +67,7 @@ func Extract(pass *analysis.Pass, node *ast.TypeSpec, obj types.Object) optional
 
 func findValueEnumVariants(pass *analysis.Pass, obj types.Object) []*schema.EnumVariant {
 	var variants []*schema.EnumVariant
-	for o, fact := range common.GetAllFacts[*common.MaybeValueEnumVariant](pass) {
+	for o, fact := range common.GetAllFactsOfType[*common.MaybeValueEnumVariant](pass) {
 		if o.Type() == obj.Type() && validateVariant(pass, o, fact.Variant) {
 			variants = append(variants, fact.Variant)
 		}
@@ -79,7 +79,7 @@ func findValueEnumVariants(pass *analysis.Pass, obj types.Object) []*schema.Enum
 }
 
 func validateVariant(pass *analysis.Pass, obj types.Object, variant *schema.EnumVariant) bool {
-	for _, fact := range common.GetAllFacts[*common.ExtractedDecl](pass) {
+	for _, fact := range common.GetAllFactsOfType[*common.ExtractedDecl](pass) {
 		if fact.Decl == nil {
 			continue
 		}
@@ -100,7 +100,7 @@ func validateVariant(pass *analysis.Pass, obj types.Object, variant *schema.Enum
 
 func findTypeValueVariants(pass *analysis.Pass, obj types.Object) []*schema.EnumVariant {
 	var variants []*schema.EnumVariant
-	for vObj, fact := range common.GetAllFacts[*common.MaybeTypeEnumVariant](pass) {
+	for vObj, fact := range common.GetAllFactsOfType[*common.MaybeTypeEnumVariant](pass) {
 		if fact.Parent != obj {
 			continue
 		}

--- a/go-runtime/schema/metadata/analyzer.go
+++ b/go-runtime/schema/metadata/analyzer.go
@@ -206,7 +206,7 @@ func canRepeatDirective(dir common.Directive) bool {
 // TODO: fix - this doesn't work for member functions.
 //
 // func getDuplicate(pass *analysis.Pass, name string, newMd *common.ExtractedMetadata) optional.Option[types.Object] {
-// 	for obj, md := range common.GetAllFacts[*common.ExtractedMetadata](pass) {
+// 	for obj, md := range common.GetAllFactsOfType[*common.ExtractedMetadata](pass) {
 // 		if reflect.TypeOf(md.Type) == reflect.TypeOf(newMd.Type) && obj.Ref() == name {
 // 			return optional.Some(obj)
 // 		}

--- a/go-runtime/schema/transitive/analyzer.go
+++ b/go-runtime/schema/transitive/analyzer.go
@@ -116,7 +116,7 @@ func inferDeclType(pass *analysis.Pass, node ast.Node, obj types.Object) optiona
 	}
 	if !common.IsSelfReference(pass, obj, t) {
 		// if this is a type alias and it has enum variants, infer to be a value enum
-		for o := range common.GetAllFacts[*common.MaybeValueEnumVariant](pass) {
+		for o := range common.GetAllFactsOfType[*common.MaybeValueEnumVariant](pass) {
 			if o.Type() == obj.Type() {
 				return optional.Some[schema.Decl](&schema.Enum{})
 			}

--- a/go-runtime/schema/typeenumvariant/analyzer.go
+++ b/go-runtime/schema/typeenumvariant/analyzer.go
@@ -48,7 +48,7 @@ func extractEnumVariant(pass *analysis.Pass, node *ast.TypeSpec, obj types.Objec
 	if md, ok := common.GetFactForObject[*common.ExtractedMetadata](pass, obj).Get(); ok {
 		variant.Comments = md.Comments
 	}
-	for o := range common.GetAllFacts[*common.MaybeTypeEnum](pass) {
+	for o := range common.GetAllFactsOfType[*common.MaybeTypeEnum](pass) {
 		named, ok := pass.TypesInfo.TypeOf(node.Name).(*types.Named)
 		if !ok {
 			continue


### PR DESCRIPTION
migrates verb call extraction out of the legacy extractor. also supports transitive calls now