### PR TITLE
fix: remove all the crazy bundled files

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "@uiw/codemirror-theme-atomone": "^4.22.0",
         "@uiw/codemirror-theme-github": "^4.22.0",
         "@vitejs/plugin-react": "^4.0.4",
-        "codemirror-json-schema": "^0.7.1",
+        "codemirror-json-schema": "0.7.0",
         "codemirror-json5": "^1.0.3",
         "fnv1a": "^1.1.1",
         "highlight.js": "^11.8.0",
@@ -489,7 +489,6 @@
       "version": "6.16.2",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.16.2.tgz",
       "integrity": "sha512-MjfDrHy0gHKlPWsvSsikhO1+BOh+eBHNgfH1OXs1+DAf30IonQldgMM3kxLDTG9ktE7kDLaA1j/l7KMPA4KNfw==",
-      "optional": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -528,7 +527,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-yaml/-/lang-yaml-6.1.1.tgz",
       "integrity": "sha512-HV2NzbK9bbVnjWxwObuZh5FuPCowx51mEfoFT9y3y+M37fA3+pbxx4I7uePuygFzDsAmCTwQSc/kXh/flab4uw==",
-      "optional": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
@@ -1402,7 +1400,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@lezer/yaml/-/yaml-1.0.3.tgz",
       "integrity": "sha512-GuBLekbw9jDBDhGur82nuwkxKQ+a3W5H0GfaAthDXcAu+XdpS43VlnxA9E9hllkpSP5ellRDKjLLj7Lu9Wr6xA==",
-      "optional": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1650,29 +1647,6 @@
       "dependencies": {
         "@sagold/json-pointer": "^5.1.2",
         "ebnf": "^1.9.1"
-      }
-    },
-    "node_modules/@shikijs/core": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.6.4.tgz",
-      "integrity": "sha512-WTU9rzZae1p2v6LOxMf6LhtmZOkIHYYW160IuahUyJy7YXPPjyWZLR1ag+SgD22ZMxZtz1gfU6Tccc8t0Il/XA=="
-    },
-    "node_modules/@shikijs/markdown-it": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/markdown-it/-/markdown-it-1.6.4.tgz",
-      "integrity": "sha512-mlAJmjbmKnuMBraMpWALcZiHWUizNSZjr6/FSspB1soViKK5LJHS7N1RckJ6x7AewkihEvZHUauc5EgihBgrTA==",
-      "dependencies": {
-        "@shikijs/transformers": "1.6.4",
-        "markdown-it": "^14.1.0",
-        "shiki": "1.6.4"
-      }
-    },
-    "node_modules/@shikijs/transformers": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.6.4.tgz",
-      "integrity": "sha512-NqDt7gUg3ayVBnsipT/KoL1pqsVbsvT/2cB0pb5SG2q72qjAv9Lb5OP99pL//BMmI+sMTo+TeARntklyBu4mZQ==",
-      "dependencies": {
-        "shiki": "1.6.4"
       }
     },
     "node_modules/@swc/helpers": {
@@ -2922,34 +2896,31 @@
       }
     },
     "node_modules/codemirror-json-schema": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/codemirror-json-schema/-/codemirror-json-schema-0.7.8.tgz",
-      "integrity": "sha512-tfHRirCWbkGGdTY/Y9t/fNu4OHCOWULoATycQmV3lgGzS+OKPB41clji9nNDtF1vnSYH2pD/BVzzD7B0sXgEdQ==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/codemirror-json-schema/-/codemirror-json-schema-0.7.0.tgz",
+      "integrity": "sha512-N51/TMZjjcNuCyVVGniA88DRVY7V7LKOO0xpfUYwdzQ3OWM8xcg/JoWeEc7E1T9kpd+7+gSP7I9WAFqbuTZMHA==",
       "dependencies": {
         "@changesets/changelog-github": "^0.4.8",
+        "@codemirror/lang-yaml": "^6.0.0",
         "@sagold/json-pointer": "^5.1.1",
-        "@shikijs/markdown-it": "^1.1.7",
         "@types/json-schema": "^7.0.12",
         "@types/node": "^20.4.2",
         "json-schema": "^0.4.0",
-        "json-schema-library": "^9.3.5",
+        "json-schema-library": "^9.1.2",
         "markdown-it": "^14.0.0",
-        "vite-tsconfig-paths": "^4.3.1",
         "yaml": "^2.3.4"
       },
       "optionalDependencies": {
-        "@codemirror/autocomplete": "^6.16.2",
         "@codemirror/lang-json": "^6.0.1",
-        "@codemirror/lang-yaml": "^6.1.1",
         "codemirror-json5": "^1.0.3",
         "json5": "^2.2.3"
       },
       "peerDependencies": {
-        "@codemirror/language": "^6.10.2",
-        "@codemirror/lint": "^6.8.0",
-        "@codemirror/state": "^6.4.1",
-        "@codemirror/view": "^6.27.0",
-        "@lezer/common": "^1.2.1"
+        "@codemirror/language": "^6.8.0",
+        "@codemirror/lint": "^6.4.0",
+        "@codemirror/state": "^6.2.1",
+        "@codemirror/view": "^6.14.1",
+        "@lezer/common": "^1.0.3"
       }
     },
     "node_modules/codemirror-json5": {
@@ -4373,11 +4344,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
     },
     "node_modules/gopd": {
       "version": "1.0.1",
@@ -6799,14 +6765,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shiki": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.6.4.tgz",
-      "integrity": "sha512-X88chM7w8jnadoZtjPTi5ahCJx9pc9f8GfEkZAEYUTlcUZIEw2D/RY86HI/LkkE7Nj8TQWkiBfaFTJ3VJT6ESg==",
-      "dependencies": {
-        "@shikijs/core": "1.6.4"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -7390,25 +7348,6 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.0.tgz",
-      "integrity": "sha512-CMjc5zMnyAjcS9sPLytrbFmj89st2g+JYtY/c02ug4Q+CZaAtCgbyviI0n1YvjZE/pzoc6FbNsINS13DOL1B9w==",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -7774,24 +7713,6 @@
           "optional": true
         },
         "terser": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.3.2.tgz",
-      "integrity": "sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "@uiw/codemirror-theme-atomone": "^4.22.0",
     "@uiw/codemirror-theme-github": "^4.22.0",
     "@vitejs/plugin-react": "^4.0.4",
-    "codemirror-json-schema": "^0.7.1",
+    "codemirror-json-schema": "0.7.0",
     "codemirror-json5": "^1.0.3",
     "fnv1a": "^1.1.1",
     "highlight.js": "^11.8.0",


### PR DESCRIPTION
Downgrade `codemirror-json-schema` to fix the massive bundle size based on the comments [here](https://github.com/jsonnext/codemirror-json-schema/issues/125). After downgrading this is the new bundled output:

```sh
> tsc && vite build

vite v4.5.3 building for production...
✓ 1481 modules transformed.
dist/index.html                       0.65 kB │ gzip:   0.41 kB
dist/assets/favicon-2732bf7e.ico     15.41 kB
dist/assets/index-1905dbdc.css       52.20 kB │ gzip:   9.56 kB
dist/assets/index-5b44d2c3.js     1,662.44 kB │ gzip: 526.12 kB
```

Thanks @mistermoe for searching github issues with me! :) 