### PR TITLE
feat: instrument otel metrics for pubsub failures

### DIFF
--- a/backend/controller/observability/pubsub.go
+++ b/backend/controller/observability/pubsub.go
@@ -26,10 +26,10 @@ const (
 )
 
 type PubSubMetrics struct {
-	meter              metric.Meter
-	published          metric.Int64Counter
-	propagationFailure metric.Int64Counter
-	subscriberCalled   metric.Int64Counter
+	meter             metric.Meter
+	published         metric.Int64Counter
+	propagationFailed metric.Int64Counter
+	subscriberCalled  metric.Int64Counter
 }
 
 func initPubSubMetrics() (*PubSubMetrics, error) {
@@ -48,13 +48,13 @@ func initPubSubMetrics() (*PubSubMetrics, error) {
 		result.published = noop.Int64Counter{}
 	}
 
-	counterName = fmt.Sprintf("%s.propagation.failure", pubsubMeterName)
-	if result.propagationFailure, err = result.meter.Int64Counter(
+	counterName = fmt.Sprintf("%s.propagation.failed", pubsubMeterName)
+	if result.propagationFailed, err = result.meter.Int64Counter(
 		counterName,
 		metric.WithUnit("1"),
 		metric.WithDescription("the number of times that subscriptions fail to progress")); err != nil {
 		errs = handleInitCounterError(errs, err, counterName)
-		result.propagationFailure = noop.Int64Counter{}
+		result.propagationFailed = noop.Int64Counter{}
 	}
 
 	counterName = fmt.Sprintf("%s.subscriber.called", pubsubMeterName)
@@ -94,7 +94,7 @@ func (m *PubSubMetrics) PropagationFailed(ctx context.Context, failedOp, topic s
 		attrs = append(attrs, attribute.String(pubsubSubscriberModuleAttr, sinkRef.Module))
 	}
 
-	m.propagationFailure.Add(ctx, 1, metric.WithAttributes(attrs...))
+	m.propagationFailed.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 func (m *PubSubMetrics) SubscriberCalled(ctx context.Context, topic string, subscription, sink schema.RefKey) {

--- a/internal/observability/attributes.go
+++ b/internal/observability/attributes.go
@@ -1,5 +1,6 @@
 package observability
 
 const (
-	ModuleNameAttribute = "ftl.module.name"
+	ModuleNameAttribute      = "ftl.module.name"
+	StatusSucceededAttribute = "ftl.status.succeeded"
 )


### PR DESCRIPTION
- Adds `ftl.status.succeeded` attr to `ftl.pubsub.published` metric
- Adds separate subscription and subscriber `module.name` attrs to all metrics except `.published`
- Adds `ftl.pubsub.propagation.failed` metric

Success case:
```
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope ftl.pubsub 

Metric #0
Descriptor:
     -> Name: ftl.pubsub.published
     -> Description: the number of times that an event is published to a topic
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.module.name: Str(echo)
     -> ftl.pubsub.topic.name: Str(echotopic)
     -> ftl.status.succeeded: Bool(true)
StartTimestamp: 2024-07-30 18:52:54.389353 +0000 UTC
Timestamp: 2024-07-30 18:53:09.390058 +0000 UTC
Value: 1

Metric #1
Descriptor:
     -> Name: ftl.pubsub.subscriber.called
     -> Description: the number of times that a pubsub event has been enqueued to asynchronously send to a subscriber
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.pubsub.subscriber.sink.module.name: Str(echo)
     -> ftl.pubsub.subscriber.sink.ref: Str(echo.echoSinkOne)
     -> ftl.pubsub.subscription.module.name: Str(echo)
     -> ftl.pubsub.subscription.ref: Str(echo.sub)
     -> ftl.pubsub.topic.name: Str(echotopic)
StartTimestamp: 2024-07-30 18:52:54.38936 +0000 UTC
Timestamp: 2024-07-30 18:53:09.390076 +0000 UTC
Value: 1
```

Error case with subscriber defined:
```
Metric #1
Descriptor:
     -> Name: ftl.pubsub.propagation.failed
     -> Description: the number of times that subscriptions fail to progress
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.pubsub.propagation.failed_operation: Str(CreateAsyncCall)
     -> ftl.pubsub.subscriber.sink.module.name: Str(echo)
     -> ftl.pubsub.subscriber.sink.ref: Str(echo.echoSinkOne)
     -> ftl.pubsub.subscription.module.name: Str(echo)
     -> ftl.pubsub.subscription.ref: Str(echo.sub)
     -> ftl.pubsub.topic.name: Str(echotopic)
StartTimestamp: 2024-07-30 19:03:52.231516 +0000 UTC
Timestamp: 2024-07-30 19:05:52.231796 +0000 UTC
Value: 1
```

Error case without subscriber:
```
Metric #1
Descriptor:
     -> Name: ftl.pubsub.propagation.failed
     -> Description: the number of times that subscriptions fail to progress
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.pubsub.propagation.failed_operation: Str(GetNextEventForSubscription)
     -> ftl.pubsub.subscription.module.name: Str(echo)
     -> ftl.pubsub.subscription.ref: Str(echo.sub)
     -> ftl.pubsub.topic.name: Str(echotopic)
StartTimestamp: 2024-07-30 19:09:10.084914 +0000 UTC
Timestamp: 2024-07-30 19:09:25.086338 +0000 UTC
Value: 4
```

Issue: https://github.com/TBD54566975/ftl/issues/2194