### PR TITLE
fix: otel rpc metrics also as span attributes

### DIFF
--- a/internal/rpc/otel_interceptor.go
+++ b/internal/rpc/otel_interceptor.go
@@ -193,6 +193,8 @@ func (i *otelInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) 
 			attributes:        attributes,
 			receiveSizeMetric: instruments.responseSize,
 			sendSizeMetric:    instruments.requestSize,
+			receiveSizes:      []int64{},
+			sendSizes:         []int64{},
 		}
 
 		return &streamingClientInterceptor{ // nolint:spancheck
@@ -249,6 +251,8 @@ func (i *otelInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc
 			attributes:        attributes,
 			receiveSizeMetric: instruments.requestSize,
 			sendSizeMetric:    instruments.responseSize,
+			receiveSizes:      []int64{},
+			sendSizes:         []int64{},
 		}
 		streamingHandler := &streamingHandlerInterceptor{
 			StreamingHandlerConn: conn,
@@ -299,23 +303,23 @@ type instrumentation struct {
 }
 
 func createInstruments(meter metric.Meter) instrumentation {
-	duration, err := meter.Int64Histogram(otelRPCDurationMetricName, metric.WithUnit("ms"))
+	duration, err := meter.Int64Histogram(otelRPCDurationMetricName, metric.WithUnit("ms"), metric.WithDescription("Duration of the RPC call"))
 	if err != nil {
 		panic(fmt.Errorf("failed to create duration metric: %w", err))
 	}
-	requestSize, err := meter.Int64Histogram(otelRPCRequestSizeMetricName, metric.WithUnit("By"))
+	requestSize, err := meter.Int64Histogram(otelRPCRequestSizeMetricName, metric.WithUnit("By"), metric.WithDescription("Size of the request payload"))
 	if err != nil {
 		panic(fmt.Errorf("failed to create request size metric: %w", err))
 	}
-	responseSize, err := meter.Int64Histogram(otelRPCResponseSizeMetricName, metric.WithUnit("By"))
+	responseSize, err := meter.Int64Histogram(otelRPCResponseSizeMetricName, metric.WithUnit("By"), metric.WithDescription("Size of the response payload"))
 	if err != nil {
 		panic(fmt.Errorf("failed to create response size metric: %w", err))
 	}
-	requestsPerRPC, err := meter.Int64Histogram(otelRPCRequestsPerRPCMetricName, metric.WithUnit("1"))
+	requestsPerRPC, err := meter.Int64Histogram(otelRPCRequestsPerRPCMetricName, metric.WithUnit("1"), metric.WithDescription("Number of requests made in the RPC call"))
 	if err != nil {
 		panic(fmt.Errorf("failed to create requests per rpc metric: %w", err))
 	}
-	responsesPerRPC, err := meter.Int64Histogram(otelRPCResponsesPerRPCMetricName, metric.WithUnit("1"))
+	responsesPerRPC, err := meter.Int64Histogram(otelRPCResponsesPerRPCMetricName, metric.WithUnit("1"), metric.WithDescription("Number of responses received in the RPC call"))
 	if err != nil {
 		panic(fmt.Errorf("failed to create responses per rpc metric: %w", err))
 	}

--- a/internal/rpc/otel_interceptor.go
+++ b/internal/rpc/otel_interceptor.go
@@ -24,20 +24,18 @@ import (
 )
 
 const (
-	otelFtlRequestKeyAttr        = attribute.Key("ftl.request_key")
-	otelFtlVerbRefAttr           = attribute.Key("ftl.verb.ref")
-	otelFtlVerbModuleAttr        = attribute.Key("ftl.verb.module")
-	otelMessageEventName         = "message"
-	otelMessageEventIDAttr       = attribute.Key("message.id")
-	otelMessageEventSizeAttr     = attribute.Key("message.uncompressed_size")
-	otelMessageEventTypeAttr     = attribute.Key("message.type")
-	otelMessageEventTypeSent     = "SENT"
-	otelMessageEventTypeReceived = "RECEIVED"
-	otelMessageSentSizesAttr     = attribute.Key("rpc.message.sent.sizes_bytes")
-	otelMessageReceivedSizesAttr = attribute.Key("rpc.message.received.sizes_bytes")
-)
-
-const (
+	otelFtlRequestKeyAttr            = attribute.Key("ftl.request_key")
+	otelFtlVerbChainAttr             = attribute.Key("ftl.verb_chain")
+	otelFtlVerbRefAttr               = attribute.Key("ftl.verb.ref")
+	otelFtlVerbModuleAttr            = attribute.Key("ftl.verb.module")
+	otelMessageEventName             = "message"
+	otelMessageEventIDAttr           = attribute.Key("message.id")
+	otelMessageEventSizeAttr         = attribute.Key("message.uncompressed_size")
+	otelMessageEventTypeAttr         = attribute.Key("message.type")
+	otelMessageEventTypeSent         = "SENT"
+	otelMessageEventTypeReceived     = "RECEIVED"
+	otelMessageSentSizesAttr         = attribute.Key("rpc.message.sent.sizes_bytes")
+	otelMessageReceivedSizesAttr     = attribute.Key("rpc.message.received.sizes_bytes")
 	otelRPCDurationMetricName        = "rpc.duration_ms"
 	otelRPCRequestSizeMetricName     = "rpc.request.size_bytes"
 	otelRPCRequestsPerRPCMetricName  = "rpc.request.count_per_rpc"
@@ -81,6 +79,13 @@ func getAttributes(ctx context.Context, rpcSystemKey string) []attribute.KeyValu
 	if verb, ok := VerbFromContext(ctx); ok {
 		attributes = append(attributes, otelFtlVerbRefAttr.String(verb.String()))
 		attributes = append(attributes, otelFtlVerbModuleAttr.String(verb.Module))
+	}
+	if verbs, ok := VerbsFromContext(ctx); ok {
+		verbStrings := make([]string, len(verbs))
+		for i, v := range verbs {
+			verbStrings[i] = v.String()
+		}
+		attributes = append(attributes, otelFtlVerbChainAttr.StringSlice(verbStrings))
 	}
 	return attributes
 }


### PR DESCRIPTION
also adds an array of sent and received message sizes (in addition to the unary fields) for the streaming interceptors