### PR TITLE
feat: propagate `Publish` caller through all pubsub metrics

### DIFF
--- a/backend/controller/cronjobs/sql/models.go
+++ b/backend/controller/cronjobs/sql/models.go
@@ -522,8 +522,8 @@ type TopicEvent struct {
 	CreatedAt time.Time
 	Key       model.TopicEventKey
 	TopicID   int64
-	Caller    string
 	Payload   []byte
+	Caller    string
 }
 
 type TopicSubscriber struct {

--- a/backend/controller/cronjobs/sql/models.go
+++ b/backend/controller/cronjobs/sql/models.go
@@ -522,6 +522,7 @@ type TopicEvent struct {
 	CreatedAt time.Time
 	Key       model.TopicEventKey
 	TopicID   int64
+	Caller    string
 	Payload   []byte
 }
 

--- a/backend/controller/dal/pubsub.go
+++ b/backend/controller/dal/pubsub.go
@@ -24,14 +24,10 @@ func (d *DAL) PublishEventForTopic(ctx context.Context, module, topic, caller st
 		Caller:  caller,
 		Payload: payload,
 	})
-	//panic(fmt.Sprintf("persisting caller: %q", caller)) // prints "Echo"
 	observability.PubSub.Published(ctx, module, topic, caller, err)
 	if err != nil {
 		return dalerrs.TranslatePGError(err)
 	}
-	// confirmed this part works
-	//rows, err := d.db.GetTopicEvents(ctx)
-	//panic(fmt.Sprintf("GetTopicEvents: %v", rows[0].Caller))
 	return nil
 }
 

--- a/backend/controller/sql/models.go
+++ b/backend/controller/sql/models.go
@@ -522,8 +522,8 @@ type TopicEvent struct {
 	CreatedAt time.Time
 	Key       model.TopicEventKey
 	TopicID   int64
-	Caller    string
 	Payload   []byte
+	Caller    string
 }
 
 type TopicSubscriber struct {

--- a/backend/controller/sql/models.go
+++ b/backend/controller/sql/models.go
@@ -522,6 +522,7 @@ type TopicEvent struct {
 	CreatedAt time.Time
 	Key       model.TopicEventKey
 	TopicID   int64
+	Caller    string
 	Payload   []byte
 }
 

--- a/backend/controller/sql/queries.sql
+++ b/backend/controller/sql/queries.sql
@@ -647,6 +647,7 @@ VALUES (
 INSERT INTO topic_events (
     "key",
     topic_id,
+    caller,
     payload
   )
 VALUES (
@@ -658,6 +659,7 @@ VALUES (
     WHERE modules.name = sqlc.arg('module')::TEXT
       AND topics.name = sqlc.arg('topic')::TEXT
   ),
+  sqlc.arg('caller'),
   sqlc.arg('payload')
 );
 
@@ -690,6 +692,7 @@ WITH cursor AS (
 SELECT events."key" as event,
         events.payload,
         events.created_at,
+        events.caller,
         NOW() - events.created_at >= sqlc.arg('consumption_delay')::interval AS ready
 FROM topics
 LEFT JOIN topic_events as events ON events.topic_id = topics.id

--- a/backend/controller/sql/queries.sql.go
+++ b/backend/controller/sql/queries.sql.go
@@ -103,7 +103,7 @@ func (q *Queries) AssociateArtefactWithDeployment(ctx context.Context, arg Assoc
 
 const beginConsumingTopicEvent = `-- name: BeginConsumingTopicEvent :exec
 WITH event AS (
-  SELECT id, created_at, key, topic_id, caller, payload
+  SELECT id, created_at, key, topic_id, payload, caller
   FROM topic_events
   WHERE "key" = $2::topic_event_key
 )
@@ -1514,7 +1514,7 @@ func (q *Queries) GetTopic(ctx context.Context, dollar_1 int64) (Topic, error) {
 }
 
 const getTopicEvent = `-- name: GetTopicEvent :one
-SELECT id, created_at, key, topic_id, caller, payload
+SELECT id, created_at, key, topic_id, payload, caller
 FROM topic_events
 WHERE id = $1::BIGINT
 `
@@ -1527,8 +1527,8 @@ func (q *Queries) GetTopicEvent(ctx context.Context, dollar_1 int64) (TopicEvent
 		&i.CreatedAt,
 		&i.Key,
 		&i.TopicID,
-		&i.Caller,
 		&i.Payload,
+		&i.Caller,
 	)
 	return i, err
 }

--- a/backend/controller/sql/schema/20231103205514_init.sql
+++ b/backend/controller/sql/schema/20231103205514_init.sql
@@ -337,6 +337,7 @@ CREATE TABLE topic_events (
 
     "key" topic_event_key UNIQUE NOT NULL,
     topic_id BIGINT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
+    caller TEXT NOT NULL,
     payload BYTEA NOT NULL
 );
 

--- a/backend/controller/sql/schema/20231103205514_init.sql
+++ b/backend/controller/sql/schema/20231103205514_init.sql
@@ -337,7 +337,6 @@ CREATE TABLE topic_events (
 
     "key" topic_event_key UNIQUE NOT NULL,
     topic_id BIGINT NOT NULL REFERENCES topics(id) ON DELETE CASCADE,
-    caller TEXT NOT NULL,
     payload BYTEA NOT NULL
 );
 

--- a/backend/controller/sql/schema/20240731230343_create_topic_events_caller.sql
+++ b/backend/controller/sql/schema/20240731230343_create_topic_events_caller.sql
@@ -1,6 +1,6 @@
 -- migrate:up
 
 ALTER TABLE topic_events
-    ADD COLUMN caller TEXT NOT NULL;
+    ADD COLUMN caller TEXT;
 
 -- migrate:down

--- a/backend/controller/sql/schema/20240731230343_create_topic_events_caller.sql
+++ b/backend/controller/sql/schema/20240731230343_create_topic_events_caller.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+
+ALTER TABLE topic_events
+    ADD COLUMN caller TEXT NOT NULL;
+
+-- migrate:down

--- a/common/configuration/sql/models.go
+++ b/common/configuration/sql/models.go
@@ -522,8 +522,8 @@ type TopicEvent struct {
 	CreatedAt time.Time
 	Key       model.TopicEventKey
 	TopicID   int64
-	Caller    string
 	Payload   []byte
+	Caller    string
 }
 
 type TopicSubscriber struct {

--- a/common/configuration/sql/models.go
+++ b/common/configuration/sql/models.go
@@ -522,6 +522,7 @@ type TopicEvent struct {
 	CreatedAt time.Time
 	Key       model.TopicEventKey
 	TopicID   int64
+	Caller    string
 	Payload   []byte
 }
 


### PR DESCRIPTION
Previously, only `ftl.pubsub.published` had the caller attribute. This PR adds caller to the rest of the pubsub metrics and also slightly restructures the topic name/ref logging to be more consistent with the rest of this file

```
Metric #0
Descriptor:
     -> Name: ftl.pubsub.published
     -> Description: the number of times that an event is published to a topic
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.module.name: Str(echo)
     -> ftl.pubsub.publish.caller.verb.ref: Str(echo.Echo)
     -> ftl.pubsub.topic.ref: Str(echo.echotopic)
     -> ftl.status.succeeded: Bool(true)
StartTimestamp: 2024-08-01 01:19:43.556864 +0000 UTC
Timestamp: 2024-08-01 01:20:08.558236 +0000 UTC
Value: 1

Metric #1
Descriptor:
     -> Name: ftl.pubsub.sink.called
     -> Description: the number of times that a pubsub event has been enqueued to asynchronously send to a subscriber
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.pubsub.publish.caller.verb.ref: Str(echo.Echo)
     -> ftl.pubsub.sink.module.name: Str(echo)
     -> ftl.pubsub.sink.ref: Str(echo.echoSinkOne)
     -> ftl.pubsub.subscription.module.name: Str(echo)
     -> ftl.pubsub.subscription.ref: Str(echo.sub)
     -> ftl.pubsub.topic.module.name: Str(echo)
     -> ftl.pubsub.topic.ref: Str(echo.echotopic)
```

Issue: https://github.com/TBD54566975/ftl/issues/2194