### PR TITLE
fix: do not replace deployment with itself

### DIFF
--- a/backend/controller/dal/dal.go
+++ b/backend/controller/dal/dal.go
@@ -752,6 +752,9 @@ func (d *DAL) ReplaceDeployment(ctx context.Context, newDeploymentKey model.Depl
 	var replacedDeploymentKey optional.Option[model.DeploymentKey]
 	oldDeployment, err := tx.GetExistingDeploymentForModule(ctx, newDeployment.ModuleName)
 	if err == nil {
+		if oldDeployment.Key.String() == newDeploymentKey.String() {
+			return fmt.Errorf("replace deployment failed: deployment already exists from %v to %v: %w", oldDeployment.Key, newDeploymentKey, ErrReplaceDeploymentAlreadyActive)
+		}
 		err = tx.SetDeploymentDesiredReplicas(ctx, oldDeployment.Key, 0)
 		if err != nil {
 			return fmt.Errorf("replace deployment failed to set old deployment replicas from %v to %v: %w", oldDeployment.Key, newDeploymentKey, dalerrs.TranslatePGError(err))


### PR DESCRIPTION
fixes #2225

This was breaking pubsub because we would:
- upsert all subscribers and subscriptions to the new deployment (which is the same as the old deployment)
- then delete all subscribers and subscriptions from the old deployment (which is... bad)

We also had comments saying that the func would return that specific error in this case, but we were not returning it.