### PR TITLE
feat: add `ftl.async_call.queue_depth` and `ftl.async_call.created` metrics

### DIFF
--- a/backend/controller/dal/async_calls.go
+++ b/backend/controller/dal/async_calls.go
@@ -76,6 +76,7 @@ type AsyncCall struct {
 	Verb        schema.RefKey
 	Request     json.RawMessage
 	ScheduledAt time.Time
+	QueueDepth  int64
 
 	RemainingAttempts int32
 	Backoff           time.Duration
@@ -120,6 +121,7 @@ func (d *DAL) AcquireAsyncCall(ctx context.Context) (call *AsyncCall, err error)
 		Request:           decryptedRequest,
 		Lease:             lease,
 		ScheduledAt:       row.ScheduledAt,
+		QueueDepth:        row.QueueDepth,
 		RemainingAttempts: row.RemainingAttempts,
 		Backoff:           row.Backoff,
 		MaxBackoff:        row.MaxBackoff,

--- a/backend/controller/dal/fsm.go
+++ b/backend/controller/dal/fsm.go
@@ -45,8 +45,15 @@ func (d *DAL) StartFSMTransition(ctx context.Context, fsm schema.RefKey, executi
 		Backoff:           retryParams.MinBackoff,
 		MaxBackoff:        retryParams.MaxBackoff,
 	})
+	observability.AsyncCalls.Created(ctx, destinationState, origin.String(), int64(retryParams.Count), err)
 	if err != nil {
 		return fmt.Errorf("failed to create FSM async call: %w", dalerrs.TranslatePGError(err))
+	}
+	queueDepth, err := d.db.AsyncCallQueueDepth(ctx)
+	if err == nil && queueDepth > 0 {
+		// Don't error out of an FSM transition just over a queue depth retrieval
+		// error because this is only used for an observability gauge.
+		observability.AsyncCalls.RecordQueueDepth(ctx, queueDepth)
 	}
 
 	// Start a transition.

--- a/backend/controller/dal/fsm.go
+++ b/backend/controller/dal/fsm.go
@@ -50,7 +50,7 @@ func (d *DAL) StartFSMTransition(ctx context.Context, fsm schema.RefKey, executi
 		return fmt.Errorf("failed to create FSM async call: %w", dalerrs.TranslatePGError(err))
 	}
 	queueDepth, err := d.db.AsyncCallQueueDepth(ctx)
-	if err == nil && queueDepth > 0 {
+	if err == nil {
 		// Don't error out of an FSM transition just over a queue depth retrieval
 		// error because this is only used for an observability gauge.
 		observability.AsyncCalls.RecordQueueDepth(ctx, queueDepth)

--- a/backend/controller/dal/fsm_test.go
+++ b/backend/controller/dal/fsm_test.go
@@ -46,7 +46,8 @@ func TestSendFSMEvent(t *testing.T) {
 			FSM: schema.RefKey{Module: "test", Name: "test"},
 			Key: "invoiceID",
 		},
-		Request: []byte(`{}`),
+		Request:    []byte(`{}`),
+		QueueDepth: 2,
 	}
 	assert.Equal(t, expectedCall, call, assert.Exclude[*Lease](), assert.Exclude[time.Time]())
 
@@ -55,5 +56,6 @@ func TestSendFSMEvent(t *testing.T) {
 
 	actual, err := dal.LoadAsyncCall(ctx, call.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, call, actual, assert.Exclude[*Lease](), assert.Exclude[time.Time]())
+	assert.Equal(t, call, actual, assert.Exclude[*Lease](), assert.Exclude[time.Time](), assert.Exclude[int64]())
+	assert.Equal(t, call.ID, actual.ID)
 }

--- a/backend/controller/observability/async_calls.go
+++ b/backend/controller/observability/async_calls.go
@@ -20,28 +20,39 @@ const (
 	asyncCallOriginAttr               = "ftl.async_call.origin"
 	asyncCallVerbRefAttr              = "ftl.async_call.verb.ref"
 	asyncCallTimeSinceScheduledAtAttr = "ftl.async_call.time_since_scheduled_at_ms"
+	asyncCallRemainingAttemptsAttr    = "ftl.async_call.remaining_attempts"
 	asyncCallExecFailureModeAttr      = "ftl.async_call.execution.failure_mode"
 )
 
 type AsyncCallMetrics struct {
+	created      metric.Int64Counter
 	acquired     metric.Int64Counter
 	executed     metric.Int64Counter
 	completed    metric.Int64Counter
 	msToComplete metric.Int64Histogram
+	queueDepth   metric.Int64Gauge
 }
 
 func initAsyncCallMetrics() (*AsyncCallMetrics, error) {
 	result := &AsyncCallMetrics{
+		created:      noop.Int64Counter{},
 		acquired:     noop.Int64Counter{},
 		executed:     noop.Int64Counter{},
 		completed:    noop.Int64Counter{},
 		msToComplete: noop.Int64Histogram{},
+		queueDepth:   noop.Int64Gauge{},
 	}
 
 	var err error
 	meter := otel.Meter(asyncCallMeterName)
 
-	signalName := fmt.Sprintf("%s.acquired", asyncCallMeterName)
+	signalName := fmt.Sprintf("%s.created", asyncCallMeterName)
+	if result.created, err = meter.Int64Counter(signalName, metric.WithUnit("1"),
+		metric.WithDescription("the number of times that an async call was created")); err != nil {
+		return nil, wrapErr(signalName, err)
+	}
+
+	signalName = fmt.Sprintf("%s.acquired", asyncCallMeterName)
 	if result.acquired, err = meter.Int64Counter(signalName, metric.WithUnit("1"),
 		metric.WithDescription("the number of times that the controller tries acquiring an async call")); err != nil {
 		return nil, wrapErr(signalName, err)
@@ -65,11 +76,29 @@ func initAsyncCallMetrics() (*AsyncCallMetrics, error) {
 		return nil, wrapErr(signalName, err)
 	}
 
+	signalName = fmt.Sprintf("%s.queue_depth", asyncCallMeterName)
+	if result.queueDepth, err = meter.Int64Gauge(signalName, metric.WithUnit("1"),
+		metric.WithDescription("number of async calls queued up")); err != nil {
+		return nil, wrapErr(signalName, err)
+	}
+
 	return result, nil
 }
 
 func wrapErr(signalName string, err error) error {
 	return fmt.Errorf("failed to create %q signal: %w", signalName, err)
+}
+
+func (m *AsyncCallMetrics) Created(ctx context.Context, verb schema.RefKey, origin string, remainingAttempts int64, maybeErr error) {
+	attrs := extractRefAttrs(verb, origin)
+	attrs = append(attrs, attribute.Bool(observability.StatusSucceededAttribute, maybeErr == nil))
+	attrs = append(attrs, attribute.Int64(asyncCallRemainingAttemptsAttr, remainingAttempts))
+
+	m.created.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+func (m *AsyncCallMetrics) RecordQueueDepth(ctx context.Context, queueDepth int64) {
+	m.queueDepth.Record(ctx, queueDepth)
 }
 
 func (m *AsyncCallMetrics) Acquired(ctx context.Context, verb schema.RefKey, origin string, scheduledAt time.Time, maybeErr error) {
@@ -90,7 +119,7 @@ func (m *AsyncCallMetrics) Executed(ctx context.Context, verb schema.RefKey, ori
 	m.executed.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
-func (m *AsyncCallMetrics) Completed(ctx context.Context, verb schema.RefKey, origin string, scheduledAt time.Time, maybeErr error) {
+func (m *AsyncCallMetrics) Completed(ctx context.Context, verb schema.RefKey, origin string, scheduledAt time.Time, queueDepth int64, maybeErr error) {
 	msToComplete := timeSinceMS(scheduledAt)
 
 	attrs := extractRefAttrs(verb, origin)
@@ -99,6 +128,8 @@ func (m *AsyncCallMetrics) Completed(ctx context.Context, verb schema.RefKey, or
 
 	attrs = append(attrs, attribute.Int64(asyncCallTimeSinceScheduledAtAttr, msToComplete))
 	m.completed.Add(ctx, 1, metric.WithAttributes(attrs...))
+
+	m.queueDepth.Record(ctx, queueDepth)
 }
 
 func extractAsyncCallAttrs(verb schema.RefKey, origin string, scheduledAt time.Time) []attribute.KeyValue {

--- a/backend/controller/sql/querier.go
+++ b/backend/controller/sql/querier.go
@@ -17,9 +17,10 @@ import (
 
 type Querier interface {
 	// Reserve a pending async call for execution, returning the associated lease
-	// reservation key.
+	// reservation key and accompanying metadata.
 	AcquireAsyncCall(ctx context.Context, ttl time.Duration) (AcquireAsyncCallRow, error)
 	AssociateArtefactWithDeployment(ctx context.Context, arg AssociateArtefactWithDeploymentParams) error
+	AsyncCallQueueDepth(ctx context.Context) (int64, error)
 	BeginConsumingTopicEvent(ctx context.Context, subscription model.SubscriptionKey, event model.TopicEventKey) error
 	CompleteEventForSubscription(ctx context.Context, name string, module string) error
 	// Create a new artefact and return the artefact ID.


### PR DESCRIPTION
Adds 2 metrics:

`ftl.async_call.queue_depth` is a gauge, so not all recorded values will appear in the stream. Locally, enqueued async calls complete so quickly that the gauge gets reset to 0 before the incremented value (1) can appear in the stream. I confirmed the enqueue `Record()` does work by temporarily removing the `Record()` call upon completion.
```
Metric #5
Descriptor:
     -> Name: ftl.async_call.queue_depth
     -> Description: number of async calls queued up
     -> Unit: 1
     -> DataType: Gauge

NumberDataPoints #0
StartTimestamp: 2024-08-05 18:13:41.233336 +0000 UTC
Timestamp: 2024-08-05 18:14:01.232978 +0000 UTC
Value: 0
```

`ftl.async_call.created` is a simple counter:
```
Metric #0
Descriptor:
     -> Name: ftl.async_call.created
     -> Description: the number of times that an async call was created
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.async_call.origin: Str(sub:echo.sub)
     -> ftl.async_call.remaining_attempts: Int(0)
     -> ftl.async_call.verb.ref: Str(echo.echoSinkOne)
     -> ftl.module.name: Str(echo)
     -> ftl.status.succeeded: Bool(true)
StartTimestamp: 2024-08-05 18:13:41.233319 +0000 UTC
Timestamp: 2024-08-05 18:14:06.233054 +0000 UTC
Value: 1
```

Issue: https://github.com/TBD54566975/ftl/issues/2194