### PR TITLE
feat: add `ftl.call.requests` and `ftl.async_call.ms_to_complete`

### DIFF
--- a/backend/controller/observability/calls.go
+++ b/backend/controller/observability/calls.go
@@ -1,0 +1,72 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
+	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/TBD54566975/ftl/internal/observability"
+	"github.com/alecthomas/types/optional"
+)
+
+const (
+	callMeterName         = "ftl.call"
+	callVerbRefAttr       = "ftl.call.verb.ref"
+	callFailureModeAttr   = "ftl.call.failure_mode"
+	callRunTimeBucketAttr = "ftl.call.run_time_ms.bucket"
+)
+
+type CallMetrics struct {
+	requests     metric.Int64Counter
+	msToComplete metric.Int64Histogram
+}
+
+func initCallMetrics() (*CallMetrics, error) {
+	result := &CallMetrics{
+		requests:     noop.Int64Counter{},
+		msToComplete: noop.Int64Histogram{},
+	}
+
+	var err error
+	meter := otel.Meter(callMeterName)
+
+	signalName := fmt.Sprintf("%s.requests", callMeterName)
+	if result.requests, err = meter.Int64Counter(signalName, metric.WithUnit("1"),
+		metric.WithDescription("the number of times that the FTL controller receives a verb call request")); err != nil {
+		return nil, wrapErr(signalName, err)
+	}
+
+	signalName = fmt.Sprintf("%s.ms_to_complete", asyncCallMeterName)
+	if result.msToComplete, err = meter.Int64Histogram(signalName, metric.WithUnit("ms"),
+		metric.WithDescription("duration in ms to complete a verb call")); err != nil {
+		return nil, wrapErr(signalName, err)
+	}
+
+	return result, nil
+}
+
+func (m *CallMetrics) Request(ctx context.Context, verb *schemapb.Ref, startTime time.Time, maybeFailureMode optional.Option[string]) {
+	attrs := []attribute.KeyValue{
+		attribute.String(observability.ModuleNameAttribute, verb.Module),
+		attribute.String(callVerbRefAttr, schema.RefFromProto(verb).String()),
+	}
+
+	failureMode, ok := maybeFailureMode.Get()
+	attrs = append(attrs, attribute.Bool(observability.StatusSucceededAttribute, !ok))
+	if ok {
+		attrs = append(attrs, attribute.String(callFailureModeAttr, failureMode))
+	}
+
+	msToComplete := timeSinceMS(startTime)
+	m.msToComplete.Record(ctx, msToComplete, metric.WithAttributes(attrs...))
+
+	attrs = append(attrs, attribute.String(callRunTimeBucketAttr, logBucket(2, msToComplete)))
+	m.requests.Add(ctx, 1, metric.WithAttributes(attrs...))
+}

--- a/backend/controller/observability/calls.go
+++ b/backend/controller/observability/calls.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alecthomas/types/optional"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -13,7 +14,6 @@ import (
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/internal/observability"
-	"github.com/alecthomas/types/optional"
 )
 
 const (

--- a/backend/controller/observability/observability.go
+++ b/backend/controller/observability/observability.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	AsyncCalls *AsyncCallMetrics
+	Calls      *CallMetrics
 	Deployment *DeploymentMetrics
 	FSM        *FSMMetrics
 	PubSub     *PubSubMetrics
@@ -22,6 +23,8 @@ func init() {
 	var err error
 
 	AsyncCalls, err = initAsyncCallMetrics()
+	errs = errors.Join(errs, err)
+	Calls, err = initCallMetrics()
 	errs = errors.Join(errs, err)
 	Deployment, err = initDeploymentMetrics()
 	errs = errors.Join(errs, err)


### PR DESCRIPTION
Replaces the original toy `requests` metric with `ftl.call.requests` and adds a new `ftl.async_call.ms_to_complete` histogram metric. Latency attribute is bucketed by powers of 2, rather than 8 as async calls are, because (1) direct verb calls should be faster and (2) this is a new metric, so while we know less about realistic production values, it's better to err on the side of more granularity.

```
InstrumentationScope ftl.call 

Metric #0
Descriptor:
     -> Name: ftl.call.requests
     -> Description: the number of times that the FTL controller receives a verb call request
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.call.run_time_ms.bucket: Str([8,16))
     -> ftl.call.verb.ref: Str(time.time)
     -> ftl.module.name: Str(time)
     -> ftl.status.succeeded: Bool(true)
StartTimestamp: 2024-08-06 19:50:37.269674 +0000 UTC
Timestamp: 2024-08-06 19:51:17.271013 +0000 UTC
Value: 1

NumberDataPoints #1
Data point attributes:
     -> ftl.call.run_time_ms.bucket: Str([32,64))
     -> ftl.call.verb.ref: Str(echo.echo)
     -> ftl.module.name: Str(echo)
     -> ftl.status.succeeded: Bool(true)
StartTimestamp: 2024-08-06 19:50:37.269674 +0000 UTC
Timestamp: 2024-08-06 19:51:17.271013 +0000 UTC
Value: 1

Metric #1
Descriptor:
     -> Name: ftl.async_call.ms_to_complete
     -> Description: duration in ms to complete a verb call
     -> Unit: ms
     -> DataType: Histogram
     -> AggregationTemporality: Cumulative

HistogramDataPoints #0
Data point attributes:
     -> ftl.call.verb.ref: Str(echo.echo)
     -> ftl.module.name: Str(echo)
     -> ftl.status.succeeded: Bool(true)
StartTimestamp: 2024-08-06 19:50:37.269677 +0000 UTC
Timestamp: 2024-08-06 19:51:17.271014 +0000 UTC
Count: 1
Sum: 32.000000
Min: 32.000000
Max: 32.000000
```

Sample output when a verb call fails:
```
     -> ftl.call.failure_mode: Str(invalid request: missing verb)
     -> ftl.call.run_time_ms.bucket: Str(<1)
     -> ftl.call.verb.ref: Str(echo.echo)
     -> ftl.module.name: Str(echo)
     -> ftl.status.succeeded: Bool(false)
```

Issue: https://github.com/TBD54566975/ftl/issues/2194