### PR TITLE
fix: s/ftl.async_call.ms_to_complete/ftl.call.ms_to_complete

### DIFF
--- a/backend/controller/observability/calls.go
+++ b/backend/controller/observability/calls.go
@@ -43,7 +43,7 @@ func initCallMetrics() (*CallMetrics, error) {
 		return nil, wrapErr(signalName, err)
 	}
 
-	signalName = fmt.Sprintf("%s.ms_to_complete", asyncCallMeterName)
+	signalName = fmt.Sprintf("%s.ms_to_complete", callMeterName)
 	if result.msToComplete, err = meter.Int64Histogram(signalName, metric.WithUnit("ms"),
 		metric.WithDescription("duration in ms to complete a verb call")); err != nil {
 		return nil, wrapErr(signalName, err)


### PR DESCRIPTION
whoops

```
Metric #1
Descriptor:
     -> Name: ftl.call.ms_to_complete
     -> Description: duration in ms to complete a verb call
     -> Unit: ms
     -> DataType: Histogram
     -> AggregationTemporality: Cumulative

HistogramDataPoints #0
Data point attributes:
     -> ftl.call.verb.ref: Str(echo.echo)
     -> ftl.module.name: Str(echo)
     -> ftl.status.succeeded: Bool(true)
StartTimestamp: 2024-08-06 21:59:38.317129 +0000 UTC
Timestamp: 2024-08-06 22:00:33.317447 +0000 UTC
Count: 1
Sum: 17.000000
Min: 17.000000
Max: 17.000000
```

Issue: https://github.com/TBD54566975/ftl/issues/2194