### PR TITLE
chore(ci): don't require CI to pass on main in order to auto-version

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -1,13 +1,10 @@
 on:
-  workflow_run:
-    workflows: ["CI"]
-    branches: ["main"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 name: Auto-version
 jobs:
   semver-tag:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Conventional Commits Auto-version
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Because we've switched to a merge queue, CI will have already passed with an identical git tree, so we just auto-version immediately.