### PR TITLE
fix: more reasonable defaults for retry directives

### DIFF
--- a/backend/schema/metadataretry.go
+++ b/backend/schema/metadataretry.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	DefaultRetryCount  = 100
+	DefaultRetryCount  = 10
 	MinBackoffLimitStr = "1s"
 	MinBackoffLimit    = 1 * time.Second
 	MaxBackoffLimitStr = "1d"

--- a/backend/schema/metadataretry.go
+++ b/backend/schema/metadataretry.go
@@ -18,6 +18,7 @@ const (
 	DefaultRetryCount  = 10
 	MinBackoffLimitStr = "1s"
 	MinBackoffLimit    = 1 * time.Second
+	DefaultMaxBackoff  = 1 * time.Hour
 	MaxBackoffLimitStr = "1d"
 	MaxBackoffLimit    = 24 * time.Hour
 )
@@ -118,7 +119,7 @@ func (m *MetadataRetry) RetryParams() (RetryParams, error) {
 
 	// max backoff
 	if m.MaxBackoff == "" {
-		params.MaxBackoff = MaxBackoffLimit
+		params.MaxBackoff = max(minBackoff, DefaultMaxBackoff)
 	} else {
 		maxBackoff, err := parseRetryDuration(m.MaxBackoff)
 		if err != nil {

--- a/docs/content/docs/reference/retries.md
+++ b/docs/content/docs/reference/retries.md
@@ -16,10 +16,8 @@ top = false
 Any verb called asynchronously (specifically, PubSub subscribers and FSM states), may optionally specify a basic exponential backoff retry policy via a Go comment directive. The directive has the following syntax:
 
 ```go
-//ftl:retry [<attempts>] <min-backoff> [<max-backoff>] [catch <catchVerb>]
+//ftl:retry [<attempts=10>] <min-backoff> [<max-backoff=1hr>] [catch <catchVerb>]
 ```
-
-`attempts` and `max-backoff` default to unlimited if not specified.
 
 For example, the following function will retry up to 10 times, with a delay of 5s, 10s, 20s, 40s, 60s, 60s, etc.
 

--- a/lsp/markdown/completion/retry.md
+++ b/lsp/markdown/completion/retry.md
@@ -3,7 +3,7 @@ Directive for retrying an async operation.
 Any verb called asynchronously (specifically, PubSub subscribers and FSM states), may optionally specify a basic exponential backoff retry policy.
 
 ```go
-//ftl:retry [<attempts>] <min-backoff> [<max-backoff>]
+//ftl:retry [<attempts=10>] <min-backoff> [<max-backoff=1hr>] [catch <catchVerb>]
 ```
 
 See https://tbd54566975.github.io/ftl/docs/reference/retries/


### PR DESCRIPTION
closes #2292
Previous behaviour:
- Default max backoff is 24hrs.
- Default retry count was 100

New behaviour:
- Default max backoff is 1hr (or min backoff if it is larger), but users can specify values up to 24hrs still.
- Default retry count is now 10