### PR TITLE
feat: otel metrics for ingress

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -336,22 +336,27 @@ func New(ctx context.Context, conn *sql.DB, config Config, runnerScaling scaling
 }
 
 func (s *Service) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
 	routes, err := s.dal.GetIngressRoutes(r.Context(), r.Method)
 	if err != nil {
 		if errors.Is(err, dalerrs.ErrNotFound) {
 			http.NotFound(w, r)
+			observability.Ingress.Request(r.Context(), r.Method, r.URL.Path, optional.None[*schemapb.Ref](), start, optional.Some("route not found in dal"))
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		observability.Ingress.Request(r.Context(), r.Method, r.URL.Path, optional.None[*schemapb.Ref](), start, optional.Some("failed to resolve route from dal"))
 		return
 	}
 	sch, err := s.dal.GetActiveSchema(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		observability.Ingress.Request(r.Context(), r.Method, r.URL.Path, optional.None[*schemapb.Ref](), start, optional.Some("could not get active schema"))
 		return
 	}
 	requestKey := model.NewRequestKey(model.OriginIngress, fmt.Sprintf("%s %s", r.Method, r.URL.Path))
-	ingress.Handle(sch, requestKey, routes, w, r, s.callWithRequest)
+	ingress.Handle(start, sch, requestKey, routes, w, r, s.callWithRequest)
 }
 
 func (s *Service) ProcessList(ctx context.Context, req *connect.Request[ftlv1.ProcessListRequest]) (*connect.Response[ftlv1.ProcessListResponse], error) {

--- a/backend/controller/ingress/handler_test.go
+++ b/backend/controller/ingress/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/alecthomas/assert/v2"
@@ -99,7 +100,7 @@ func TestIngress(t *testing.T) {
 			req := httptest.NewRequest(test.method, test.path, bytes.NewBuffer(test.payload)).WithContext(ctx)
 			req.URL.RawQuery = test.query.Encode()
 			reqKey := model.NewRequestKey(model.OriginIngress, "test")
-			ingress.Handle(sch, reqKey, routes, rec, req, func(ctx context.Context, r *connect.Request[ftlv1.CallRequest], requestKey optional.Option[model.RequestKey], parentRequestKey optional.Option[model.RequestKey], requestSource string) (*connect.Response[ftlv1.CallResponse], error) {
+			ingress.Handle(time.Now(), sch, reqKey, routes, rec, req, func(ctx context.Context, r *connect.Request[ftlv1.CallRequest], requestKey optional.Option[model.RequestKey], parentRequestKey optional.Option[model.RequestKey], requestSource string) (*connect.Response[ftlv1.CallResponse], error) {
 				body, err := encoding.Marshal(response)
 				assert.NoError(t, err)
 				return connect.NewResponse(&ftlv1.CallResponse{Response: &ftlv1.CallResponse_Body{Body: body}}), nil

--- a/backend/controller/observability/ingress.go
+++ b/backend/controller/observability/ingress.go
@@ -1,0 +1,76 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
+	"github.com/TBD54566975/ftl/backend/schema"
+	"github.com/TBD54566975/ftl/internal/observability"
+	"github.com/alecthomas/types/optional"
+)
+
+const (
+	ingressMeterName         = "ftl.ingress"
+	ingressMethodAttr        = "ftl.ingress.method"
+	ingressPathAttr          = "ftl.ingress.path"
+	ingressVerbRefAttr       = "ftl.ingress.verb.ref"
+	ingressFailureModeAttr   = "ftl.ingress.failure_mode"
+	ingressRunTimeBucketAttr = "ftl.ingress.run_time_ms.bucket"
+)
+
+type IngressMetrics struct {
+	requests     metric.Int64Counter
+	msToComplete metric.Int64Histogram
+}
+
+func initIngressMetrics() (*IngressMetrics, error) {
+	result := &IngressMetrics{
+		requests:     noop.Int64Counter{},
+		msToComplete: noop.Int64Histogram{},
+	}
+
+	var err error
+	meter := otel.Meter(ingressMeterName)
+
+	signalName := fmt.Sprintf("%s.requests", ingressMeterName)
+	if result.requests, err = meter.Int64Counter(signalName, metric.WithUnit("1"),
+		metric.WithDescription("the number of ingress requests that the FTL controller receives")); err != nil {
+		return nil, wrapErr(signalName, err)
+	}
+
+	signalName = fmt.Sprintf("%s.ms_to_complete", ingressMeterName)
+	if result.msToComplete, err = meter.Int64Histogram(signalName, metric.WithUnit("ms"),
+		metric.WithDescription("duration in ms to complete an ingress request")); err != nil {
+		return nil, wrapErr(signalName, err)
+	}
+
+	return result, nil
+}
+
+func (m *IngressMetrics) Request(ctx context.Context, method string, path string, verb optional.Option[*schemapb.Ref], startTime time.Time, failureMode optional.Option[string]) {
+	attrs := []attribute.KeyValue{
+		attribute.String(ingressMethodAttr, method),
+		attribute.String(ingressPathAttr, path),
+	}
+	if v, ok := verb.Get(); ok {
+		attrs = append(attrs,
+			attribute.String(observability.ModuleNameAttribute, v.Module),
+			attribute.String(ingressVerbRefAttr, schema.RefFromProto(v).String()))
+	}
+	if f, ok := failureMode.Get(); ok {
+		attrs = append(attrs, attribute.String(ingressFailureModeAttr, f))
+	}
+
+	msToComplete := timeSinceMS(startTime)
+	m.msToComplete.Record(ctx, msToComplete, metric.WithAttributes(attrs...))
+
+	attrs = append(attrs, attribute.String(ingressRunTimeBucketAttr, logBucket(2, msToComplete)))
+	m.requests.Add(ctx, 1, metric.WithAttributes(attrs...))
+}

--- a/backend/controller/observability/ingress.go
+++ b/backend/controller/observability/ingress.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/alecthomas/types/optional"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -13,7 +14,6 @@ import (
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	"github.com/TBD54566975/ftl/backend/schema"
 	"github.com/TBD54566975/ftl/internal/observability"
-	"github.com/alecthomas/types/optional"
 )
 
 const (

--- a/backend/controller/observability/observability.go
+++ b/backend/controller/observability/observability.go
@@ -12,6 +12,7 @@ var (
 	Calls      *CallMetrics
 	Deployment *DeploymentMetrics
 	FSM        *FSMMetrics
+	Ingress    *IngressMetrics
 	PubSub     *PubSubMetrics
 	Cron       *CronMetrics
 )
@@ -27,6 +28,8 @@ func init() {
 	Deployment, err = initDeploymentMetrics()
 	errs = errors.Join(errs, err)
 	FSM, err = initFSMMetrics()
+	errs = errors.Join(errs, err)
+	Ingress, err = initIngressMetrics()
 	errs = errors.Join(errs, err)
 	PubSub, err = initPubSubMetrics()
 	errs = errors.Join(errs, err)


### PR DESCRIPTION
```
InstrumentationScope ftl.ingress 

Metric #0
Descriptor:
     -> Name: ftl.ingress.requests
     -> Description: the number of ingress requests that the FTL controller receives
     -> Unit: 1
     -> DataType: Sum
     -> IsMonotonic: true
     -> AggregationTemporality: Cumulative

NumberDataPoints #0
Data point attributes:
     -> ftl.ingress.method: Str(GET)
     -> ftl.ingress.path: Str(/http/echo)
     -> ftl.ingress.run_time_ms.bucket: Str([16,32))
     -> ftl.ingress.verb.ref: Str(echo.getEcho)
     -> ftl.module.name: Str(echo)
StartTimestamp: 2024-08-12 17:44:51.923107 +0000 UTC
Timestamp: 2024-08-12 17:45:26.923594 +0000 UTC
Value: 1

Metric #1
Descriptor:
     -> Name: ftl.ingress.ms_to_complete
     -> Description: duration in ms to complete an ingress request
     -> Unit: ms
     -> DataType: Histogram
     -> AggregationTemporality: Cumulative

HistogramDataPoints #0
Data point attributes:
     -> ftl.ingress.method: Str(GET)
     -> ftl.ingress.path: Str(/http/echo)
     -> ftl.ingress.verb.ref: Str(echo.getEcho)
     -> ftl.module.name: Str(echo)
StartTimestamp: 2024-08-12 17:44:51.92311 +0000 UTC
Timestamp: 2024-08-12 17:45:26.923622 +0000 UTC
Count: 1
Sum: 27.000000
Min: 27.000000
Max: 27.000000
```