### PR TITLE
feat: add support for code and SQL based database migrations

### DIFF
--- a/backend/controller/sql/migrate/migrate.go
+++ b/backend/controller/sql/migrate/migrate.go
@@ -1,0 +1,132 @@
+// Package migrate supports a dbmate-compatible superset of migration files.
+//
+// The superset is that in addition to a migration being a .sql file, it can
+// also be a Go function which is called to execute the migration.
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/TBD54566975/ftl/backend/dal"
+	"github.com/TBD54566975/ftl/internal/log"
+)
+
+var migrationFileNameRe = regexp.MustCompile(`^.*(\d{14})_(.*)\.sql$`)
+var migrationFuncNameRe = regexp.MustCompile(`^.*\.Migrate(\d{14})(.*)$`)
+
+type Migration func(ctx context.Context, db *sql.Tx) error
+
+type namedMigration struct {
+	name      string
+	version   string
+	migration Migration
+}
+
+func (m namedMigration) String() string { return m.name }
+
+// Migrate applies all migrations in the provided fs.FS and migrationFuncs to the provided database.
+//
+// Migration functions must be named in the form "MigrationYYYYMMDDHHMMSS<detail>".
+func Migrate(ctx context.Context, db *sql.DB, migrationFiles fs.FS, migrationFuncs ...Migration) error {
+	// Create schema_migrations table if it doesn't exist.
+	// This table structure is compatible with dbmate.
+	_, _ = db.ExecContext(ctx, `CREATE TABLE schema_migrations (version TEXT PRIMARY KEY)`) //nolint:errcheck
+
+	sqlFiles, err := fs.Glob(migrationFiles, "*.sql")
+	if err != nil {
+		return fmt.Errorf("failed to read migration files: %w", err)
+	}
+
+	migrations := make([]namedMigration, 0, len(sqlFiles)+len(migrationFuncs))
+
+	// Collect .sql files.
+	for _, sqlFile := range sqlFiles {
+		name := filepath.Base(sqlFile)
+		groups := migrationFileNameRe.FindStringSubmatch(name)
+		if groups == nil {
+			return fmt.Errorf("invalid migration file name %q, must be in the form <date>_<detail>.sql", sqlFile)
+		}
+		version := groups[1]
+		migrations = append(migrations, namedMigration{name, version, func(ctx context.Context, db *sql.Tx) error {
+			sqlMigration, err := fs.ReadFile(migrationFiles, sqlFile)
+			if err != nil {
+				return fmt.Errorf("failed to read migration file %q: %w", sqlFile, err)
+			}
+			return migrateSQLFile(ctx, db, sqlFile, sqlMigration)
+		}})
+	}
+	for _, migration := range migrationFuncs {
+		name, version := migrationFuncVersion(migration)
+		migrations = append(migrations, namedMigration{name, version, migration})
+	}
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].version < migrations[j].version
+	})
+	for _, migration := range migrations {
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("migration %s: failed to begin transaction: %w", migration, err)
+		}
+		err = applyMigration(ctx, tx, migration)
+		if err != nil {
+			if txerr := tx.Rollback(); txerr != nil {
+				return fmt.Errorf("migration %s: failed to rollback transaction: %w", migration, txerr)
+			}
+			return fmt.Errorf("migration %s: %w", migration, err)
+		}
+		err = tx.Commit()
+		if err != nil {
+			return fmt.Errorf("migration %s: failed to commit transaction: %w", migration, err)
+		}
+	}
+	return nil
+}
+
+func applyMigration(ctx context.Context, tx *sql.Tx, migration namedMigration) error {
+	start := time.Now()
+	logger := log.FromContext(ctx).Scope("migrate")
+	_, err := tx.ExecContext(ctx, "INSERT INTO schema_migrations (version) VALUES ($1)", migration.version)
+	err = dal.TranslatePGError(err)
+	if errors.Is(err, dal.ErrConflict) {
+		if txerr := tx.Rollback(); txerr != nil {
+			return fmt.Errorf("failed to rollback transaction: %w", txerr)
+		}
+		logger.Debugf("Skipping: %s", migration)
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to insert migration: %w", err)
+	}
+	logger.Debugf("Applying: %s", migration)
+	if err := migration.migration(ctx, tx); err != nil {
+		return fmt.Errorf("migration failed: %w", err)
+	}
+	logger.Debugf("Applied: %s in %s", migration, time.Since(start))
+	return nil
+}
+
+func migrationFuncVersion(i any) (name string, version string) {
+	name = runtime.FuncForPC(reflect.ValueOf(i).Pointer()).Name()
+	groups := migrationFuncNameRe.FindStringSubmatch(name)
+	if groups == nil {
+		panic(fmt.Sprintf("invalid migration name %q, must be in the form Migrate<date><detail>", name))
+	}
+	return name, groups[1]
+}
+
+func migrateSQLFile(ctx context.Context, db *sql.Tx, name string, sqlMigration []byte) error {
+	_, err := db.ExecContext(ctx, string(sqlMigration))
+	if err != nil {
+		return fmt.Errorf("failed to execute migration %q: %w", name, err)
+	}
+	return nil
+}

--- a/backend/controller/sql/migrate/migrate_test.go
+++ b/backend/controller/sql/migrate/migrate_test.go
@@ -1,0 +1,112 @@
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"fmt"
+	"io/fs"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+
+	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
+	"github.com/TBD54566975/ftl/internal/log"
+)
+
+func TestMigrate(t *testing.T) {
+	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	db := sqltest.OpenForTesting(ctx, t)
+
+	mfs, err := fs.Sub(migrations, "testdata")
+	assert.NoError(t, err)
+
+	err = Migrate(ctx, db, mfs, Migrate30280103221530SplitNameAge)
+	assert.NoError(t, err)
+
+	rows, err := db.QueryContext(ctx, "SELECT name, age FROM test")
+	assert.NoError(t, err)
+	defer rows.Close()
+	type user struct {
+		name string
+		age  int
+	}
+	actual := []user{}
+	for rows.Next() {
+		var u user
+		assert.NoError(t, rows.Scan(&u.name, &u.age))
+		actual = append(actual, u)
+	}
+	expected := []user{
+		{"Alice", 30},
+	}
+	assert.Equal(t, expected, actual)
+}
+
+//go:embed testdata
+var migrations embed.FS
+
+func Migrate30280103221530SplitNameAge(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+		ALTER TABLE test
+			ADD COLUMN name TEXT,
+			ADD COLUMN age INT
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to add columns: %w", err)
+	}
+	rows, err := tx.QueryContext(ctx, "SELECT id, name_and_age FROM test")
+	if err != nil {
+		return fmt.Errorf("failed to query test: %w", err)
+	}
+	defer rows.Close()
+	type userUpdate struct {
+		name string
+		age  int64
+	}
+	updates := map[int]userUpdate{}
+	for rows.Next() {
+		var id int
+		var name string
+		var age int64
+		err = rows.Scan(&id, &name)
+		if err != nil {
+			return fmt.Errorf("failed to scan user: %w", err)
+		}
+		nameAge := strings.Fields(name)
+		name = nameAge[0]
+		switch len(nameAge) {
+		case 1:
+		case 2:
+			age, err = strconv.ParseInt(nameAge[1], 10, 64)
+			if err != nil {
+				return fmt.Errorf("failed to parse age: %w", err)
+			}
+		default:
+			return fmt.Errorf("invalid name %q", name)
+		}
+		// We can't update the table while iterating over it, so we store the updates in a map.
+		updates[id] = userUpdate{name, age}
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("failed to close rows: %w", err)
+	}
+	for id, update := range updates {
+		_, err = tx.ExecContext(ctx, "UPDATE test SET name = $1, age = $2 WHERE id = $3", update.name, update.age, id)
+		if err != nil {
+			return fmt.Errorf("failed to update user %d: %w", id, err)
+		}
+	}
+	_, err = tx.ExecContext(ctx, `
+		ALTER TABLE test
+			DROP COLUMN name_and_age,
+			ALTER COLUMN name SET NOT NULL,
+			ALTER COLUMN age SET NOT NULL
+  `)
+	if err != nil {
+		return fmt.Errorf("failed to drop column: %w", err)
+	}
+	return nil
+}

--- a/backend/controller/sql/migrate/testdata/30280101000000_init.sql
+++ b/backend/controller/sql/migrate/testdata/30280101000000_init.sql
@@ -1,0 +1,6 @@
+CREATE TABLE test (
+  id SERIAL PRIMARY KEY,
+  name_and_age TEXT NOT NULL
+);
+
+INSERT INTO test (name_and_age) VALUES ('Alice 30');

--- a/backend/controller/sql/sqltest/testing.go
+++ b/backend/controller/sql/sqltest/testing.go
@@ -27,5 +27,6 @@ func OpenForTesting(ctx context.Context, t testing.TB) *sql.DB {
 	testDSN := "postgres://localhost:15432/ftl-test?user=postgres&password=secret&sslmode=disable"
 	conn, err := databasetesting.CreateForDevel(ctx, testDSN, true)
 	assert.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, conn.Close()) })
 	return conn
 }

--- a/backend/controller/sql/sqltest/testing.go
+++ b/backend/controller/sql/sqltest/testing.go
@@ -20,7 +20,7 @@ func OpenForTesting(ctx context.Context, t testing.TB) *sql.DB {
 	t.Helper()
 	// Acquire lock for this DB.
 	lockPath := filepath.Join(os.TempDir(), "ftl-db-test.lock")
-	release, err := flock.Acquire(ctx, lockPath, 10*time.Second)
+	release, err := flock.Acquire(ctx, lockPath, 20*time.Second)
 	assert.NoError(t, err)
 	t.Cleanup(func() { _ = release() }) //nolint:errcheck
 


### PR DESCRIPTION
We'll need to be doing data migrations quite a bit in the near future, and while at some point we will need to do proper [zero downtime migrations](https://teamplify.com/blog/zero-downtime-DB-migrations/) with all that this entails, for now it will be more expedient to accept some downtime. With that in mind, this PR adds a function for applying a mix of SQL and code-based migrations to a database.

An example of where this will be used is our encrypted table columns, which are currently JSONB with a base-64 encoded JSON envelope which we want to move to raw encrypted bytes. We might also need to re-encrypt some data with new keys soon. etc.

Note: this is not hooked up to `ftl migrate` or `ftl dev`'s migration subsystems yet.