### PR TITLE
fix: ftl new fails

### DIFF
--- a/cmd/ftl/cmd_new.go
+++ b/cmd/ftl/cmd_new.go
@@ -79,7 +79,7 @@ func (i newGoCmd) Run(ctx context.Context) error {
 				return err
 			}
 		}
-		if err := maybeGitAdd(ctx, i.Dir, filepath.Join(path, "*")); err != nil {
+		if err := maybeGitAdd(ctx, i.Dir, filepath.Join(i.Name, "*")); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The directory was being prefixed to the path twice.

fixes #2297