### PR TITLE
refactor: decouple conflicting ModuleContext requirements

### DIFF
--- a/go-runtime/ftl/database.go
+++ b/go-runtime/ftl/database.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
+	"github.com/alecthomas/types/once"
 	_ "github.com/jackc/pgx/v5/stdlib" // Register Postgres driver
 
 	"github.com/TBD54566975/ftl/internal/modulecontext"
@@ -13,6 +14,8 @@ import (
 type Database struct {
 	Name   string
 	DBType modulecontext.DBType
+
+	db *once.Handle[*sql.DB]
 }
 
 // PostgresDatabase returns a handler for the named database.
@@ -20,17 +23,28 @@ func PostgresDatabase(name string) Database {
 	return Database{
 		Name:   name,
 		DBType: modulecontext.DBTypePostgres,
+		db: once.Once(func(ctx context.Context) (*sql.DB, error) {
+			provider := modulecontext.FromContext(ctx).CurrentContext()
+			dsn, err := provider.GetDatabase(name, modulecontext.DBTypePostgres)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get database %q: %w", name, err)
+			}
+			db, err := sql.Open("pgx", dsn)
+			if err != nil {
+				return nil, fmt.Errorf("failed to open database %q: %w", name, err)
+			}
+			return db, nil
+		}),
 	}
 }
 
 func (d Database) String() string { return fmt.Sprintf("database %q", d.Name) }
 
-// Get returns the sql db connection for the database.
+// Get returns the SQL DB connection for the database.
 func (d Database) Get(ctx context.Context) *sql.DB {
-	provider := modulecontext.FromContext(ctx).CurrentContext()
-	db, err := provider.GetDatabase(d.Name, d.DBType)
+	db, err := d.db.Get(ctx)
 	if err != nil {
-		panic(err.Error())
+		panic(err)
 	}
 	return db
 }

--- a/internal/modulecontext/database.go
+++ b/internal/modulecontext/database.go
@@ -1,7 +1,6 @@
 package modulecontext
 
 import (
-	"database/sql"
 	"fmt"
 	"strconv"
 
@@ -14,19 +13,13 @@ type Database struct {
 	DSN      string
 	DBType   DBType
 	isTestDB bool
-	db       *sql.DB
 }
 
 // NewDatabase creates a Database that can be added to ModuleContext
 func NewDatabase(dbType DBType, dsn string) (Database, error) {
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		return Database{}, fmt.Errorf("failed to bring up DB connection: %w", err)
-	}
 	return Database{
 		DSN:    dsn,
 		DBType: dbType,
-		db:     db,
 	}, nil
 }
 


### PR DESCRIPTION
The ModuleContext was designed to be an abstract data model in the Controller for the resources required by a module, but along the way it started to be used for storing DB connections for use by the go-runtime. This change cleanly separates those requirements so that the go-runtime is entirely responsible for creating new connections from the DSN provided by the ModuleContext.

I think there's a bit more work to be done here, in that the ModuleContext knows about testing in the go-runtime, which it really shouldn't, but this will unblock #2373 for now.