### PR TITLE
feat: allow catch verbs to receive request types as `any`

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -1498,14 +1498,10 @@ func (s *Service) catchAsyncCall(ctx context.Context, logger *log.Logger, call *
 	}
 	logger.Debugf("Catching async call %s with %s", call.Verb, catchVerb)
 
-	sch, err := s.dal.GetActiveSchema(ctx)
-	if err != nil {
-		logger.Warnf("Async call %s could not catch, could not get active schema: %s", call.Verb, err)
-		return fmt.Errorf("async call %s could not catch, could not get active schema: %w", call.Verb, err)
-	}
+	sch := s.schema.Load()
 
 	verb := &schema.Verb{}
-	if err = sch.ResolveToType(call.Verb.ToRef(), verb); err != nil {
+	if err := sch.ResolveToType(call.Verb.ToRef(), verb); err != nil {
 		logger.Warnf("Async call %s could not catch, could not resolve original verb: %s", call.Verb, err)
 		return fmt.Errorf("async call %s could not catch, could not resolve original verb: %w", call.Verb, err)
 	}

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -1514,9 +1514,13 @@ func (s *Service) catchAsyncCall(ctx context.Context, logger *log.Logger, call *
 	originalResult := either.RightOf[[]byte](originalError)
 
 	request := map[string]any{
+		"verb": map[string]string{
+			"module": call.Verb.Module,
+			"name":   call.Verb.Name,
+		},
+		"requestType": verb.Request.String(),
 		"request":     json.RawMessage(call.Request),
 		"error":       originalError,
-		"requestType": verb.Request.String(),
 	}
 	body, err := json.Marshal(request)
 	if err != nil {

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -1498,12 +1498,25 @@ func (s *Service) catchAsyncCall(ctx context.Context, logger *log.Logger, call *
 	}
 	logger.Debugf("Catching async call %s with %s", call.Verb, catchVerb)
 
+	sch, err := s.dal.GetActiveSchema(ctx)
+	if err != nil {
+		logger.Warnf("Async call %s could not catch, could not get active schema: %s", call.Verb, err)
+		return fmt.Errorf("async call %s could not catch, could not get active schema: %w", call.Verb, err)
+	}
+
+	verb := &schema.Verb{}
+	if err = sch.ResolveToType(call.Verb.ToRef(), verb); err != nil {
+		logger.Warnf("Async call %s could not catch, could not resolve original verb: %s", call.Verb, err)
+		return fmt.Errorf("async call %s could not catch, could not resolve original verb: %w", call.Verb, err)
+	}
+
 	originalError := call.Error.Default("unknown error")
 	originalResult := either.RightOf[[]byte](originalError)
 
 	request := map[string]any{
-		"request": json.RawMessage(call.Request),
-		"error":   originalError,
+		"request":     json.RawMessage(call.Request),
+		"error":       originalError,
+		"requestType": verb.Request.String(),
 	}
 	body, err := json.Marshal(request)
 	if err != nil {

--- a/backend/controller/pubsub/integration_test.go
+++ b/backend/controller/pubsub/integration_test.go
@@ -140,7 +140,8 @@ func TestRetry(t *testing.T) {
 			1),
 
 		// check that there was one successful attempt to catchAny
-		in.QueryRow("ftl",
+		// CatchRequest<Any> is not supported in java yet
+		in.IfLanguage("go", in.QueryRow("ftl",
 			fmt.Sprintf(`
 		SELECT COUNT(*)
 		FROM async_calls
@@ -151,7 +152,7 @@ func TestRetry(t *testing.T) {
 			AND catching = true
 			AND origin = '%s'
 `, dal.AsyncOriginPubSub{Subscription: schema.RefKey{Module: "subscriber", Name: "doomedSubscription2"}}.String()),
-			1),
+			1)),
 	)
 }
 

--- a/backend/controller/pubsub/integration_test.go
+++ b/backend/controller/pubsub/integration_test.go
@@ -86,7 +86,7 @@ func TestConsumptionDelay(t *testing.T) {
 func TestRetry(t *testing.T) {
 	retriesPerCall := 2
 	in.Run(t,
-		in.WithLanguages( /*"java",*/ "go"),
+		in.WithLanguages("java", "go"),
 		in.CopyModule("publisher"),
 		in.CopyModule("subscriber"),
 		in.Deploy("publisher"),

--- a/backend/schema/builtin.go
+++ b/backend/schema/builtin.go
@@ -6,6 +6,12 @@ import "github.com/TBD54566975/ftl/internal/reflect"
 const BuiltinsSource = `
 // Built-in types for FTL.
 builtin module builtin {
+  // Ref is used to reference types, verbs and resources.
+  export data Ref {
+    module String
+    name String
+  }
+  
   // HTTP request structure used for HTTP ingress verbs.
   export data HttpRequest<Body> {
     method String
@@ -30,6 +36,7 @@ builtin module builtin {
   // CatchRequest is a request structure for catch verbs.
   export data CatchRequest<Req> {
     request Req
+    requestType Ref
     error String
   }
 }

--- a/backend/schema/builtin.go
+++ b/backend/schema/builtin.go
@@ -5,13 +5,7 @@ import "github.com/TBD54566975/ftl/internal/reflect"
 // BuiltinsSource is the schema source code for built-in types.
 const BuiltinsSource = `
 // Built-in types for FTL.
-builtin module builtin {
-  // Ref is used to reference types, verbs and resources.
-  export data Ref {
-    module String
-    name String
-  }
-  
+builtin module builtin {  
   // HTTP request structure used for HTTP ingress verbs.
   export data HttpRequest<Body> {
     method String
@@ -36,7 +30,7 @@ builtin module builtin {
   // CatchRequest is a request structure for catch verbs.
   export data CatchRequest<Req> {
     request Req
-    requestType Ref
+    requestType String
     error String
   }
 }

--- a/backend/schema/builtin.go
+++ b/backend/schema/builtin.go
@@ -5,7 +5,13 @@ import "github.com/TBD54566975/ftl/internal/reflect"
 // BuiltinsSource is the schema source code for built-in types.
 const BuiltinsSource = `
 // Built-in types for FTL.
-builtin module builtin {  
+builtin module builtin {
+  // A reference to a declaration in the schema.
+  export data Ref {
+    module String
+    name String
+  }
+
   // HTTP request structure used for HTTP ingress verbs.
   export data HttpRequest<Body> {
     method String
@@ -29,6 +35,7 @@ builtin module builtin {
 
   // CatchRequest is a request structure for catch verbs.
   export data CatchRequest<Req> {
+    verb builtin.Ref
     request Req
     requestType String
     error String

--- a/backend/schema/schema_test.go
+++ b/backend/schema/schema_test.go
@@ -548,6 +548,7 @@ func TestParsing(t *testing.T) {
 
 					verb consumesA(test.eventA) Unit
 						+subscribe subA1
+						+retry 1m5s 1h catch catchesAny
 
 					verb consumesB1(test.eventB) Unit
 						+subscribe subB
@@ -561,6 +562,8 @@ func TestParsing(t *testing.T) {
 					verb catchesA(builtin.CatchRequest<test.eventA>) Unit
 
 					verb catchesB(builtin.CatchRequest<test.eventB>) Unit
+
+					verb catchesAny(builtin.CatchRequest<Any>) Unit
 				}
 			`,
 			expected: &Schema{
@@ -627,6 +630,19 @@ func TestParsing(t *testing.T) {
 							},
 						},
 						&Verb{
+							Name: "catchesAny",
+							Request: &Ref{
+								Module: "builtin",
+								Name:   "CatchRequest",
+								TypeParameters: []Type{
+									&Any{},
+								},
+							},
+							Response: &Unit{
+								Unit: true,
+							},
+						},
+						&Verb{
 							Name: "catchesB",
 							Request: &Ref{
 								Module: "builtin",
@@ -654,6 +670,14 @@ func TestParsing(t *testing.T) {
 							Metadata: []Metadata{
 								&MetadataSubscriber{
 									Name: "subA1",
+								},
+								&MetadataRetry{
+									MinBackoff: "1m5s",
+									MaxBackoff: "1h",
+									Catch: &Ref{
+										Module: "test",
+										Name:   "catchesAny",
+									},
 								},
 							},
 						},

--- a/backend/schema/validate_test.go
+++ b/backend/schema/validate_test.go
@@ -478,10 +478,10 @@ func TestValidate(t *testing.T) {
 		}
 		`,
 			errs: []string{
-				"34:5-5: catch verb must have a request type of builtin.CatchRequest<test.EventA> but found builtin.CatchRequest<test.EventB>",
+				"34:5-5: catch verb must have a request type of builtin.CatchRequest<test.EventA> or builtin.CatchRequest<Any>, but found builtin.CatchRequest<test.EventB>",
 				"38:5-5: catch verb must not have a response type but found test.EventA",
-				"42:5-5: catch verb must have a request type of builtin.CatchRequest<test.EventB> but found Unit",
-				"46:5-5: catch verb must have a request type of builtin.CatchRequest<test.EventB> but found test.EventB",
+				"42:5-5: catch verb must have a request type of builtin.CatchRequest<test.EventB> or builtin.CatchRequest<Any>, but found Unit",
+				"46:5-5: catch verb must have a request type of builtin.CatchRequest<test.EventB> or builtin.CatchRequest<Any>, but found test.EventB",
 				"50:5-5: expected catch to be a verb",
 			},
 		},


### PR DESCRIPTION
closes #2213

`builtin.CatchRequest` now has the following features:
- the associated request type can be `any` to allow for catching multiple verbs with different request types
    - The request will be unmarshalled to primitives (like string, int, map, array etc) rather than ftl structs
- Includes the verb that failed as a `builtin.Ref`, which is a data type with `module` and `name` strings
- Includes the request type as a string, eg: `example.Input`, `String`, etc
    - Originally I had this as a `builtin.Ref` but that doesnt work for non-ref types

There is certainly room for improvement in terms of how we want to expose these schema definitions, but this PR doesn't try go too far down that road.