### PR TITLE
fix: handle custom local names for widened types

### DIFF
--- a/go-runtime/schema/schema_test.go
+++ b/go-runtime/schema/schema_test.go
@@ -194,6 +194,9 @@ func TestExtractModuleSchemaTwo(t *testing.T) {
 	}
 	actual := schema.Normalise(r.Module)
 	expected := `module two {
+			typealias BackoffAlias Any
+        		+typemap go "github.com/jpillora/backoff.Backoff"
+        
 			typealias ExplicitAliasAlias Any
 				+typemap kotlin "com.foo.bar.NonFTLType"
 				+typemap go "github.com/TBD54566975/ftl/go-runtime/schema/testdata.lib.NonFTLType"

--- a/go-runtime/schema/testdata/two/go.mod
+++ b/go-runtime/schema/testdata/two/go.mod
@@ -4,7 +4,10 @@ go 1.22.2
 
 replace github.com/TBD54566975/ftl => ../../../..
 
-require github.com/TBD54566975/ftl v0.150.3
+require (
+	github.com/TBD54566975/ftl v0.150.3
+	github.com/jpillora/backoff v1.0.0
+)
 
 require (
 	connectrpc.com/connect v1.16.2 // indirect
@@ -26,7 +29,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
 	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
-	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/multiformats/go-base36 v0.2.0 // indirect

--- a/go-runtime/schema/testdata/two/two.go
+++ b/go-runtime/schema/testdata/two/two.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	lib "github.com/TBD54566975/ftl/go-runtime/schema/testdata"
+	libbackoff "github.com/jpillora/backoff"
 
 	"ftl/builtin"
 )
@@ -102,6 +103,9 @@ type TransitiveAliasType lib.NonFTLType
 type TransitiveAliasAlias = lib.NonFTLType
 
 type TransitiveAlias lib.NonFTLType
+
+//ftl:typealias
+type BackoffAlias libbackoff.Backoff
 
 func transitiveVerbCall(ctx context.Context, req Payload[string]) error {
 	_, err := ftl.Call(ctx, Two, req)

--- a/go-runtime/schema/typealias/analyzer.go
+++ b/go-runtime/schema/typealias/analyzer.go
@@ -86,16 +86,14 @@ func qualifiedNameFromSelectorExpr(pass *analysis.Pass, node ast.Node) string {
 	if !ok {
 		return ""
 	}
-	for _, im := range pass.Pkg.Imports() {
-		if im.Name() != ident.Name {
-			continue
-		}
-		fqName := im.Path()
-		if parts := strings.Split(im.Path(), "/"); parts[len(parts)-1] != ident.Name {
-			// if package differs from the directory name, add the package name to the fqName
-			fqName = fqName + "." + ident.Name
-		}
-		return fqName + "." + se.Sel.Name
+	pkgName, ok := pass.TypesInfo.ObjectOf(ident).(*types.PkgName)
+	if !ok {
+		return ""
 	}
-	return ""
+	fqName := pkgName.Imported().Path()
+	if parts := strings.Split(fqName, "/"); parts[len(parts)-1] != pkgName.Imported().Name() {
+		// if package differs from the directory name, add the package name to the fqName
+		fqName = fqName + "." + ident.Name
+	}
+	return fqName + "." + se.Sel.Name
 }


### PR DESCRIPTION
fixes #2397

`pass.Pkg.Imports()` did not always* include the local name alias from the import statement, so instead we need to do our checks via `PkgName` which does include it.

*it includes it in the example in our tests, but didn't in the case that our partner project was hitting...
I've added another test case that previously failed like theirs did.