### PR TITLE
fix: add go.mod file to jvm scaffolding dirs

### DIFF
--- a/jvm-runtime/java/scaffolding/go.mod
+++ b/jvm-runtime/java/scaffolding/go.mod
@@ -1,0 +1,3 @@
+module ignore
+
+go 1.22.6

--- a/jvm-runtime/kotlin/scaffolding/go.mod
+++ b/jvm-runtime/kotlin/scaffolding/go.mod
@@ -1,0 +1,3 @@
+module ignore
+
+go 1.22.6


### PR DESCRIPTION
Without these the Go toolchain tries to scan the directories and fails due to the | characters, which are not supported by Go's build system.

Fixes the following failure:

```
info: go: finding module for package github.com/TBD54566975/ftl/go-runtime/ftl
go: downloading github.com/TBD54566975/ftl v0.345.0
go: ftl/builtin imports
	github.com/TBD54566975/ftl/go-runtime/ftl: create zip: jvm-runtime/java/scaffolding/{{ .Name | camel | lower }}/ftl.toml: malformed file path "jvm-runtime/java/scaffolding/{{ .Name | camel | lower }}/ftl.toml": invalid char '|'
jvm-runtime/java/scaffolding/{{ .Name | camel | lower }}/pom.xml.tmpl: malformed file path "jvm-runtime/java/scaffolding/{{ .Name | camel | lower }}/pom.xml.tmpl": invalid char '|'
jvm-runtime/java/scaffolding/{{ .Name | camel | lower }}/src/main/java/{{ .PackageDir }}/EchoVerb.java: malformed file path "jvm-runtime/java/scaffolding/{{ .Name | camel | lower }}/src/main/java/{{ .PackageDir }}/EchoVerb.java": invalid char '|'
jvm-runtime/kotlin/scaffolding/{{ .Name | camel | lower }}/ftl.toml: malformed file path "jvm-runtime/kotlin/scaffolding/{{ .Name | camel | lower }}/ftl.toml": invalid char '|'
jvm-runtime/kotlin/scaffolding/{{ .Name | camel | lower }}/pom.xml.tmpl: malformed file path "jvm-runtime/kotlin/scaffolding/{{ .Name | camel | lower }}/pom.xml.tmpl": invalid char '|'
jvm-runtime/kotlin/scaffolding/{{ .Name | camel | lower }}/src/main/kotlin/{{ .PackageDir }}/EchoVerb.kt: malformed file path "jvm-runtime/kotlin/scaffolding/{{ .Name | camel | lower }}/src/main/kotlin/{{ .PackageDir }}/EchoVerb.kt": invalid char '|'
```

There is an underlying bug that is triggering this, whereby replace directives aren't correctly propagated to the shared Go FTL module stubs. Filed #2415 for this.