### PR TITLE
fix: console verb page loading

### DIFF
--- a/frontend/src/features/verbs/VerbPage.tsx
+++ b/frontend/src/features/verbs/VerbPage.tsx
@@ -47,7 +47,7 @@ export const VerbPage = () => {
   const callEvents = useStreamVerbCalls(module?.name, verb?.verb?.name)
   const calls: CallEvent[] = callEvents.data || []
 
-  if (!module || !verb || callEvents.isLoading) {
+  if (!module || !verb) {
     return (
       <div className='flex justify-center items-center min-h-screen'>
         <Loader />


### PR DESCRIPTION
Less broke now! 😂 

I think with streaming queries, `isLoading` will always be true with tanstack since it's like streaming yo.

![Screenshot 2024-08-19 at 5 22 22 PM](https://github.com/user-attachments/assets/ab8615ed-5766-4049-839f-9f30d4020f8f)
