### PR TITLE
feat: fix browser resizing + scrolling bug on console table rendering

### DIFF
--- a/frontend/src/features/calls/CallList.tsx
+++ b/frontend/src/features/calls/CallList.tsx
@@ -20,7 +20,7 @@ export const CallList = ({ calls }: { calls: CallEvent[] | undefined }) => {
   }
 
   return (
-    <div className='flex flex-col h-full relative'>
+    <div className='flex flex-col h-full relative min-w-[710px]'>
       <div className='border border-gray-100 dark:border-slate-700 rounded h-full absolute inset-0'>
         <table className={'w-full table-fixed text-gray-600 dark:text-gray-300'}>
           <thead>


### PR DESCRIPTION
Set min width on console's calls table to prevent tbody rows from getting chopped.

Steps to reproduce:
1. Make browser window so small that the table cannot fit
1. Scroll to the table all the way to the right to see the full Error column
1. Observe how the border lies too far to the left, chopping off the contents of the table below the header.

<img width="199" alt="Screenshot 2024-08-20 at 4 35 17 PM" src="https://github.com/user-attachments/assets/845de044-f3a8-45e8-a4eb-d784e83ca7c1">

Before fix:
<img width="194" alt="Screenshot 2024-08-20 at 4 35 40 PM" src="https://github.com/user-attachments/assets/69eea725-61ca-4d00-95a6-dec11171c59c">

Issue: https://github.com/TBD54566975/ftl/issues/2460