### PR TITLE
feat: hitting tab key inserts a tab in codemirror

### DIFF
--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -10,7 +10,7 @@ import { autocompletion, closeBrackets, closeBracketsKeymap } from '@codemirror/
 import { atomone } from '@uiw/codemirror-theme-atomone'
 import { githubLight } from '@uiw/codemirror-theme-github'
 
-import { defaultKeymap } from '@codemirror/commands'
+import { defaultKeymap, indentWithTab } from '@codemirror/commands'
 import { handleRefresh, jsonSchemaHover, jsonSchemaLinter, stateExtensions } from 'codemirror-json-schema'
 import { json5, json5ParseLinter } from 'codemirror-json5'
 import { useCallback, useEffect, useRef } from 'react'
@@ -21,7 +21,7 @@ const commonExtensions = [
   bracketMatching(),
   highlightActiveLineGutter(),
   closeBrackets(),
-  keymap.of([...closeBracketsKeymap, ...foldKeymap, ...lintKeymap, ...defaultKeymap]),
+  keymap.of([indentWithTab, ...closeBracketsKeymap, ...foldKeymap, ...lintKeymap, ...defaultKeymap]),
   EditorView.lineWrapping,
   EditorState.tabSize.of(2),
 ]


### PR DESCRIPTION
Fixes https://github.com/TBD54566975/ftl/issues/2458

Before, tabbing would change the focus to the next element on the page. This adds the correct key binding so that hitting tab within the codemirror editor actually inserts 2 spaces.