### PR TITLE
chore: support extending ftltest context with additional options

### DIFF
--- a/go-runtime/ftl/ftltest/fake.go
+++ b/go-runtime/ftl/ftltest/fake.go
@@ -53,6 +53,10 @@ type subscriber func(context.Context, any) error
 type fakeFTL struct {
 	fsm *fakeFSMManager
 
+	// We store the options used to construct this fake, so they can be
+	// replayed to extend the fake with new options
+	options []Option
+
 	mockMaps      map[uintptr]mapImpl
 	allowMapCalls bool
 	configValues  map[string][]byte
@@ -64,13 +68,14 @@ type fakeFTL struct {
 // type but is not constrained by input/output type like ftl.Map.
 type mapImpl func(context.Context) (any, error)
 
-func contextWithFakeFTL(ctx context.Context) context.Context {
+func contextWithFakeFTL(ctx context.Context, options ...Option) context.Context {
 	fake := &fakeFTL{
 		fsm:           newFakeFSMManager(),
 		mockMaps:      map[uintptr]mapImpl{},
 		allowMapCalls: false,
 		configValues:  map[string][]byte{},
 		secretValues:  map[string][]byte{},
+		options:       options,
 	}
 	ctx = internal.WithContext(ctx, fake)
 	fake.pubSub = newFakePubSub(ctx)

--- a/go-runtime/ftl/ftltest/ftltest_test.go
+++ b/go-runtime/ftl/ftltest/ftltest_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	_ "unsafe"
 
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
+	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+	"github.com/TBD54566975/ftl/go-runtime/internal"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/alecthomas/assert/v2"
 )
@@ -34,5 +37,69 @@ func TestFtlTestProjectNotLoadedInContext(t *testing.T) {
 	})
 	PanicsWithErr(t, "ftltest.WithDefaultProjectFile()", func() {
 		_ = ftl.Config[string]("moo").Get(ctx)
+	})
+}
+
+func TestFtlTextContextExtension(t *testing.T) {
+	withFakeModule(t, "ftl/test")
+
+	t.Run("extends with a new project file", func(t *testing.T) {
+		original := Context(WithProjectFile("testdata/go/wrapped/ftl-project.toml"))
+		extended := SubContext(original, WithProjectFile("testdata/go/wrapped/ftl-project-test-1.toml"))
+
+		var config string
+		assert.NoError(t, internal.FromContext(original).(*fakeFTL).GetConfig(original, "config", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "bazbaz", config, "does not change the original context")
+		assert.NoError(t, internal.FromContext(extended).(*fakeFTL).GetConfig(extended, "config", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "foobar", config, "overwrites configuration values from the new file")
+	})
+	t.Run("extends with a new config value", func(t *testing.T) {
+		configA := ftl.ConfigValue[string]{Ref: reflection.Ref{Module: "ftl/test", Name: "configA"}}
+		configB := ftl.ConfigValue[string]{Ref: reflection.Ref{Module: "ftl/test", Name: "configB"}}
+
+		original := Context(WithConfig(configA, "a"), WithConfig(configB, "b"))
+		extended := SubContext(original, WithConfig(configA, "a.2"))
+
+		var config string
+		assert.NoError(t, internal.FromContext(original).(*fakeFTL).GetConfig(original, "configA", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "a", config, "does not change the original context")
+		assert.NoError(t, internal.FromContext(extended).(*fakeFTL).GetConfig(extended, "configA", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "a.2", config, "overwrites configuration values from the new file")
+		assert.NoError(t, internal.FromContext(extended).(*fakeFTL).GetConfig(extended, "configB", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "b", config, "retains other config from the original context")
+	})
+	t.Run("extends with a new secret value", func(t *testing.T) {
+		secretA := ftl.SecretValue[string]{Ref: reflection.Ref{Module: "ftl/test", Name: "secretA"}}
+		secretB := ftl.SecretValue[string]{Ref: reflection.Ref{Module: "ftl/test", Name: "secretB"}}
+
+		original := Context(WithSecret(secretA, "a"), WithSecret(secretB, "b"))
+		extended := SubContext(original, WithSecret(secretA, "a.2"))
+
+		var config string
+		assert.NoError(t, internal.FromContext(original).(*fakeFTL).GetSecret(original, "secretA", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "a", config, "does not change the original context")
+		assert.NoError(t, internal.FromContext(extended).(*fakeFTL).GetSecret(extended, "secretA", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "a.2", config, "overwrites secret values from the new file")
+		assert.NoError(t, internal.FromContext(extended).(*fakeFTL).GetSecret(extended, "secretB", &config)) //nolint:forcetypeassert
+		assert.Equal(t, "b", config, "retains other secret from the original context")
+	})
+	t.Run("retains the existing context.Context state", func(t *testing.T) {
+		type keyType string
+		original := context.WithValue(Context(), keyType("key"), "value")
+		extended := SubContext(original, WithProjectFile("testdata/go/wrapped/ftl-project.toml"))
+
+		assert.Equal(t, "value", extended.Value(keyType("key")), "keeps context.Context value from the original context")
+	})
+}
+
+// mock out module reflection to make it testable
+func withFakeModule(t *testing.T, name string) {
+	t.Helper()
+	var previousModuleGetter = moduleGetter
+	moduleGetter = func() string {
+		return name
+	}
+	t.Cleanup(func() {
+		moduleGetter = previousModuleGetter
 	})
 }

--- a/go-runtime/ftl/ftltest/testdata/go/verbtypes/verbtypes_test.go
+++ b/go-runtime/ftl/ftltest/testdata/go/verbtypes/verbtypes_test.go
@@ -47,6 +47,29 @@ func TestVerbs(t *testing.T) {
 	assert.Equal(t, knockOnEffects["empty"], "test")
 }
 
+func TestContextExtension(t *testing.T) {
+	ctx1 := ftltest.Context(
+		ftltest.WhenSource(Source, func(ctx context.Context) (Response, error) {
+			return Response{Output: "fake"}, nil
+		}),
+	)
+
+	ctx2 := ftltest.SubContext(
+		ctx1,
+		ftltest.WhenSource(Source, func(ctx context.Context) (Response, error) {
+			return Response{Output: "another fake"}, nil
+		}),
+	)
+
+	sourceResp, err := ftl.CallSource(ctx1, Source)
+	assert.NoError(t, err)
+	assert.Equal(t, Response{Output: "fake"}, sourceResp)
+
+	sourceResp, err = ftl.CallSource(ctx2, Source)
+	assert.NoError(t, err)
+	assert.Equal(t, Response{Output: "another fake"}, sourceResp)
+}
+
 func TestVerbErrors(t *testing.T) {
 	ctx := ftltest.Context(
 		ftltest.WhenVerb(Verb, func(ctx context.Context, req Request) (Response, error) {


### PR DESCRIPTION
Adds a new `SubContext` function, that replays options from a previous fakeFTL creation, appending new options to it.

Closes https://github.com/TBD54566975/ftl/issues/2393