### PR TITLE
feat: console: add verb request editor + reset button

### DIFF
--- a/frontend/src/components/CodeEditorV2.tsx
+++ b/frontend/src/components/CodeEditorV2.tsx
@@ -27,6 +27,7 @@ export const CodeEditor = ({
   schema?: string
   readOnly?: boolean
   onChange?: (text: string) => void
+  // A "Reset" button will be shown if and only if this prop is provided.
   defaultContent?: string
 }) => {
   const { isDarkMode } = useUserPreferences()

--- a/frontend/src/components/CodeEditorV2.tsx
+++ b/frontend/src/components/CodeEditorV2.tsx
@@ -1,0 +1,130 @@
+import { EditorState, type Extension } from '@codemirror/state'
+import { EditorView, drawSelection, gutter, highlightActiveLineGutter, hoverTooltip, keymap, lineNumbers } from '@codemirror/view'
+
+import { bracketMatching, defaultHighlightStyle, foldGutter, foldKeymap, indentOnInput, syntaxHighlighting } from '@codemirror/language'
+import { lintGutter } from '@codemirror/lint'
+import { lintKeymap } from '@codemirror/lint'
+import { linter } from '@codemirror/lint'
+
+import { autocompletion, closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete'
+import { atomone } from '@uiw/codemirror-theme-atomone'
+import { githubLight } from '@uiw/codemirror-theme-github'
+
+import { defaultKeymap, history, indentWithTab, redo, undo } from '@codemirror/commands'
+import { handleRefresh, jsonSchemaHover, jsonSchemaLinter, stateExtensions } from 'codemirror-json-schema'
+import { json5, json5ParseLinter } from 'codemirror-json5'
+import { useEffect, useRef, useState } from 'react'
+import { useUserPreferences } from '../providers/user-preferences-provider'
+
+export const CodeEditor = ({
+  content,
+  schema,
+  readOnly,
+  onChange,
+  defaultContent,
+}: {
+  content: string
+  schema?: string
+  readOnly?: boolean
+  onChange?: (text: string) => void
+  defaultContent?: string
+}) => {
+  const { isDarkMode } = useUserPreferences()
+  const containerRef = useRef(null)
+  const viewRef = useRef<EditorView | null>(null)
+  const [lastReset, setLastReset] = useState(Date.now())
+
+  useEffect(() => {
+    const sch = schema ? JSON.parse(schema) : null
+
+    const editingExtensions: Extension[] =
+      readOnly || false
+        ? [EditorState.readOnly.of(true)]
+        : [
+            autocompletion(),
+            lineNumbers(),
+            lintGutter(),
+            indentOnInput(),
+            drawSelection(),
+            foldGutter(),
+            linter(json5ParseLinter(), {
+              delay: 300,
+            }),
+            linter(jsonSchemaLinter(), {
+              needsRefresh: handleRefresh,
+            }),
+            hoverTooltip(jsonSchemaHover()),
+            stateExtensions(sch),
+          ]
+
+    viewRef.current = new EditorView({
+      state: EditorState.create({
+        doc: content,
+        extensions: [
+          ...editingExtensions,
+          EditorView.updateListener.of(({ state }) => {
+            if (onChange) {
+              onChange(state.doc.toString())
+            }
+          }),
+          EditorView.theme({
+            '&': { height: '100%' },
+          }),
+          isDarkMode ? atomone : githubLight,
+          json5(),
+          gutter({ class: 'CodeMirror-lint-markers' }),
+          highlightActiveLineGutter(),
+          closeBrackets(),
+          EditorView.lineWrapping,
+          EditorState.tabSize.of(2),
+          history(),
+          keymap.of([
+            ...defaultKeymap,
+            ...closeBracketsKeymap,
+            ...foldKeymap,
+            ...lintKeymap,
+            indentWithTab,
+            { key: 'Mod-z', run: undo, preventDefault: true },
+            { key: 'Mod-Shift-z', run: redo, preventDefault: true },
+          ]),
+          bracketMatching(),
+          syntaxHighlighting(defaultHighlightStyle),
+        ],
+      }),
+      parent: containerRef.current || undefined,
+    })
+
+    return () => {
+      viewRef.current?.destroy()
+      viewRef.current = null
+    }
+  }, [lastReset, schema, readOnly, isDarkMode])
+
+  useEffect(() => {
+    if (viewRef.current && viewRef.current.state.doc.toString() !== content) {
+      viewRef.current.dispatch({
+        changes: { from: 0, to: viewRef.current.state.doc.length, insert: '' },
+      })
+    }
+  }, [content])
+
+  function onReset() {
+    if (!onChange || !defaultContent) return
+    onChange(defaultContent)
+    setLastReset(Date.now())
+  }
+
+  return (
+    <div className='h-full relative'>
+      {defaultContent && (
+        <div
+          className='absolute z-10 top-2 text-sm px-2 py-0.5 right-4 cursor-pointer shadow-lg rounded-md bg-gray-300 hover:bg-gray-200 dark:bg-gray-900 hover:dark:bg-gray-700'
+          onClick={onReset}
+        >
+          Reset
+        </div>
+      )}
+      <div className='h-full' ref={containerRef} />
+    </div>
+  )
+}

--- a/frontend/src/features/modules/decls/VerbPanel.tsx
+++ b/frontend/src/features/modules/decls/VerbPanel.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom'
 import { Badge } from '../../../components/Badge'
 import type { Ref, Type, Verb } from '../../../protos/xyz/block/ftl/v1/schema/schema_pb'
+import { VerbRequestEditor } from './VerbRequestEditor'
 
 const DataRef = ({ heading, r }: { heading: string; r: Ref }) => {
   const navigate = useNavigate()
@@ -62,6 +63,7 @@ export const VerbPanel = ({ value, moduleName, declName }: { value: Verb; module
   return (
     <div className='h-full'>
       <VerbHeader value={value} moduleName={moduleName} declName={declName} />
+      <VerbRequestEditor moduleName={moduleName} v={value} />
     </div>
   )
 }

--- a/frontend/src/features/modules/decls/VerbRequestEditor.tsx
+++ b/frontend/src/features/modules/decls/VerbRequestEditor.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useModules } from '../../../api/modules/use-modules'
+import { CodeEditor } from '../../../components/CodeEditorV2'
+import type { Verb } from '../../../protos/xyz/block/ftl/v1/console/console_pb'
+import type { Verb as SchemaVerb } from '../../../protos/xyz/block/ftl/v1/schema/schema_pb'
+import { defaultRequest, simpleJsonSchema } from '../../verbs/verb.utils'
+
+export const VerbRequestEditor = ({ moduleName, v }: { moduleName: string; v: SchemaVerb }) => {
+  const modules = useModules()
+
+  const [verb, setVerb] = useState<Verb | undefined>()
+  const defaultContent = useMemo(() => defaultRequest(verb), [verb])
+
+  const [editorText, setEditorText] = useState(defaultContent)
+  const schemaString = useMemo(() => (verb ? JSON.stringify(simpleJsonSchema(verb)) : '{}'), [verb])
+
+  useEffect(() => {
+    if (!modules.isSuccess) return
+    if (modules.data.modules.length === 0) return
+    const module = modules.data.modules.find((module) => module.name === moduleName)
+    const verb = module?.verbs.find((verb) => verb.verb?.name.toLocaleLowerCase() === v.name.toLocaleLowerCase())
+    setVerb(verb)
+    setEditorText(defaultContent)
+  }, [modules.data])
+
+  if (!verb) {
+    // Editor text has not yet been populated with the default request
+    return <CodeEditor readOnly={true} content='' />
+  }
+
+  return <CodeEditor content={editorText} schema={schemaString} onChange={setEditorText} defaultContent={defaultContent} />
+}


### PR DESCRIPTION
Adds new externally-controlled codemirror component with a reset button

Really basic, UI-side only. Doesn't hook into actually sending the call yet.

https://github.com/user-attachments/assets/f773bf49-6bb4-4ed9-862d-2f4b180b151b

