### PR TITLE
fix: avoid reusing servers for e2e tests

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -38,6 +38,6 @@ export default defineConfig({
   webServer: {
     command: 'ftl dev --recreate',
     url: 'http://localhost:8892',
-    reuseExistingServer: true,
+    reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
Hoping to make the `Console e2e` tests more stable.
