### PR TITLE
chore(renovate): enable lockfile maintenance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,9 @@
     "group:allNonMajor",
     "schedule:earlyMondays",
   ],
+  lockFileMaintenance: {
+    enabled: true, // Automatically update lock files like pnpm-lock.yaml
+  },
   packageRules: [
     {
       matchUpdateTypes: ["minor", "patch"],


### PR DESCRIPTION
Hopefully, this will resolve renovate issues with `pnpm`

https://docs.renovatebot.com/configuration-options/#lockfilemaintenance