### PR TITLE
feat: add console decl page for fsm

### DIFF
--- a/frontend/console/src/features/modules/decls/DeclPanel.tsx
+++ b/frontend/console/src/features/modules/decls/DeclPanel.tsx
@@ -7,6 +7,7 @@ import { ConfigPanel } from './ConfigPanel'
 import { DataPanel } from './DataPanel'
 import { DatabasePanel } from './DatabasePanel'
 import { EnumPanel } from './EnumPanel'
+import { FsmPanel } from './FsmPanel'
 import { SecretPanel } from './SecretPanel'
 import { TypeAliasPanel } from './TypeAliasPanel'
 
@@ -33,6 +34,8 @@ export const DeclPanel = () => {
       return <DatabasePanel value={decl.value.value} {...nameProps} />
     case 'enum':
       return <EnumPanel value={decl.value.value} {...nameProps} />
+    case 'fsm':
+      return <FsmPanel value={decl.value.value} {...nameProps} />
     case 'secret':
       return <SecretPanel value={decl.value.value} {...nameProps} />
     case 'typeAlias':

--- a/frontend/console/src/features/modules/decls/FsmPanel.tsx
+++ b/frontend/console/src/features/modules/decls/FsmPanel.tsx
@@ -1,0 +1,26 @@
+import type { FSM } from '../../../protos/xyz/block/ftl/v1/schema/schema_pb'
+import { PanelHeader } from './PanelHeader'
+import { RefLink } from './TypeEl'
+
+export const FsmPanel = ({ value, moduleName, declName }: { value: FSM; moduleName: string; declName: string }) => {
+  return (
+    <div className='py-2 px-4'>
+      <PanelHeader exported={false} comments={value.comments}>
+        FSM: {moduleName}.{declName}
+      </PanelHeader>
+      <div className='mt-8'>
+        Start{value.start.length === 1 ? '' : 's'}: {value.start.map((r, i) => [<RefLink key={i} r={r} />, i === value.start.length - 1 ? '' : ', '])}
+      </div>
+      <div className='mt-8'>
+        Transitions
+        <ul className='list-disc ml-8 text-sm'>
+          {value.transitions.map((t, i) => (
+            <li key={i} className='mt-2'>
+              From <RefLink r={t.from} /> to <RefLink r={t.to} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/frontend/console/src/features/modules/decls/TypeEl.tsx
+++ b/frontend/console/src/features/modules/decls/TypeEl.tsx
@@ -18,6 +18,18 @@ const TypeParams = ({ types }: { types?: (Type | undefined)[] }) => {
   )
 }
 
+export const RefLink = ({ r }: { r?: Ref }) => {
+  if (!r) {
+    return
+  }
+  return (
+    <span>
+      <DeclLink moduleName={r.module} declName={r.name} />
+      <TypeParams types={r.typeParameters} />
+    </span>
+  )
+}
+
 export const TypeEl = ({ t }: { t?: Type }) => {
   if (!t) {
     return ''
@@ -51,12 +63,7 @@ export const TypeEl = ({ t }: { t?: Type }) => {
         </span>
       )
     case 'ref':
-      return (
-        <span>
-          <DeclLink moduleName={(v as Ref).module} declName={(v as Ref).name} />
-          <TypeParams types={(v as Ref).typeParameters} />
-        </span>
-      )
+      return <RefLink r={v as Ref} />
     default:
       return t.value.case || ''
   }


### PR DESCRIPTION
Tested with `ftl dev --recreate backend/controller/dal/testdata/go/fsm`

This PR steals the `RefLink` change from https://github.com/TBD54566975/ftl/pull/2662, so whichever one merges first, the other will have to rebase.

Later, we should make this a graph, but for this base page, the list of links is sufficient.

<img width="1048" alt="Screenshot 2024-09-12 at 4 20 23 PM" src="https://github.com/user-attachments/assets/b1a88570-0452-46f8-a2c9-29ab4e6a1bba">

Fixes https://github.com/TBD54566975/ftl/issues/2616