### PR TITLE
fix: prevent implicit conversions to/from EncryptedColumn

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -253,7 +253,7 @@ func New(ctx context.Context, conn *sql.DB, config Config, devel bool) (*Service
 	svc.routes.Store(map[string][]dal.Route{})
 	svc.schema.Store(&schema.Schema{})
 
-	cronSvc := cronjobs.New(ctx, key, svc.config.Advertise.Host, conn)
+	cronSvc := cronjobs.New(ctx, key, svc.config.Advertise.Host, encryptionSrv, conn)
 	svc.cronJobs = cronSvc
 
 	pubSub := pubsub.New(ctx, db, svc.tasks, svc)

--- a/backend/controller/cronjobs/dal/internal/sql/models.go
+++ b/backend/controller/cronjobs/dal/internal/sql/models.go
@@ -414,7 +414,7 @@ type FsmNextEvent struct {
 	CreatedAt     time.Time
 	FsmInstanceID int64
 	NextState     schema.RefKey
-	Request       []byte
+	Request       encryption.EncryptedAsyncColumn
 	RequestType   sqltypes.Type
 }
 
@@ -505,7 +505,7 @@ type TopicEvent struct {
 	CreatedAt    time.Time
 	Key          model.TopicEventKey
 	TopicID      int64
-	Payload      []byte
+	Payload      encryption.EncryptedAsyncColumn
 	Caller       optional.Option[string]
 	RequestKey   optional.Option[string]
 	TraceContext pqtype.NullRawMessage

--- a/backend/controller/dal/internal/sql/models.go
+++ b/backend/controller/dal/internal/sql/models.go
@@ -414,7 +414,7 @@ type FsmNextEvent struct {
 	CreatedAt     time.Time
 	FsmInstanceID int64
 	NextState     schema.RefKey
-	Request       []byte
+	Request       encryption.EncryptedAsyncColumn
 	RequestType   sqltypes.Type
 }
 
@@ -505,7 +505,7 @@ type TopicEvent struct {
 	CreatedAt    time.Time
 	Key          model.TopicEventKey
 	TopicID      int64
-	Payload      []byte
+	Payload      encryption.EncryptedAsyncColumn
 	Caller       optional.Option[string]
 	RequestKey   optional.Option[string]
 	TraceContext pqtype.NullRawMessage

--- a/backend/controller/dal/internal/sql/queries.sql.go
+++ b/backend/controller/dal/internal/sql/queries.sql.go
@@ -1159,7 +1159,7 @@ LIMIT 1
 
 type GetNextEventForSubscriptionRow struct {
 	Event        optional.Option[model.TopicEventKey]
-	Payload      []byte
+	Payload      encryption.OptionalEncryptedAsyncColumn
 	CreatedAt    optional.Option[time.Time]
 	Caller       optional.Option[string]
 	RequestKey   optional.Option[string]
@@ -2127,7 +2127,7 @@ type PublishEventForTopicParams struct {
 	Module       string
 	Topic        string
 	Caller       string
-	Payload      []byte
+	Payload      encryption.EncryptedAsyncColumn
 	RequestKey   string
 	TraceContext json.RawMessage
 }
@@ -2172,7 +2172,7 @@ type SetNextFSMEventParams struct {
 	Fsm         schema.RefKey
 	InstanceKey string
 	Event       schema.RefKey
-	Request     []byte
+	Request     encryption.EncryptedAsyncColumn
 	RequestType sqltypes.Type
 }
 

--- a/backend/controller/encryption/dal/internal/sql/models.go
+++ b/backend/controller/encryption/dal/internal/sql/models.go
@@ -414,7 +414,7 @@ type FsmNextEvent struct {
 	CreatedAt     time.Time
 	FsmInstanceID int64
 	NextState     schema.RefKey
-	Request       []byte
+	Request       encryption.EncryptedAsyncColumn
 	RequestType   sqltypes.Type
 }
 
@@ -505,7 +505,7 @@ type TopicEvent struct {
 	CreatedAt    time.Time
 	Key          model.TopicEventKey
 	TopicID      int64
-	Payload      []byte
+	Payload      encryption.EncryptedAsyncColumn
 	Caller       optional.Option[string]
 	RequestKey   optional.Option[string]
 	TraceContext pqtype.NullRawMessage

--- a/backend/controller/leases/dal/internal/sql/models.go
+++ b/backend/controller/leases/dal/internal/sql/models.go
@@ -414,7 +414,7 @@ type FsmNextEvent struct {
 	CreatedAt     time.Time
 	FsmInstanceID int64
 	NextState     schema.RefKey
-	Request       []byte
+	Request       encryption.EncryptedAsyncColumn
 	RequestType   sqltypes.Type
 }
 
@@ -505,7 +505,7 @@ type TopicEvent struct {
 	CreatedAt    time.Time
 	Key          model.TopicEventKey
 	TopicID      int64
-	Payload      []byte
+	Payload      encryption.EncryptedAsyncColumn
 	Caller       optional.Option[string]
 	RequestKey   optional.Option[string]
 	TraceContext pqtype.NullRawMessage

--- a/backend/controller/sql/schema/20240913035022_encrypted_fsm_next_request.sql
+++ b/backend/controller/sql/schema/20240913035022_encrypted_fsm_next_request.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+
+ALTER TABLE fsm_next_event
+    ALTER COLUMN request TYPE encrypted_async;
+
+-- migrate:down

--- a/backend/controller/sql/schema/20240913041619_encrypted_topic_events_payload.sql
+++ b/backend/controller/sql/schema/20240913041619_encrypted_topic_events_payload.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+
+ALTER TABLE topic_events
+  ALTER COLUMN payload TYPE encrypted_async;
+
+-- migrate:down

--- a/internal/configuration/dal/internal/sql/models.go
+++ b/internal/configuration/dal/internal/sql/models.go
@@ -414,7 +414,7 @@ type FsmNextEvent struct {
 	CreatedAt     time.Time
 	FsmInstanceID int64
 	NextState     schema.RefKey
-	Request       []byte
+	Request       encryption.EncryptedAsyncColumn
 	RequestType   sqltypes.Type
 }
 
@@ -505,7 +505,7 @@ type TopicEvent struct {
 	CreatedAt    time.Time
 	Key          model.TopicEventKey
 	TopicID      int64
-	Payload      []byte
+	Payload      encryption.EncryptedAsyncColumn
 	Caller       optional.Option[string]
 	RequestKey   optional.Option[string]
 	TraceContext pqtype.NullRawMessage

--- a/internal/encryption/database.go
+++ b/internal/encryption/database.go
@@ -13,28 +13,25 @@ var _ Encrypted = &EncryptedColumn[TimelineSubKey]{}
 // EncryptedColumn is a type that represents an encrypted column.
 //
 // It can be used by sqlc to map to/from a bytea column in the database.
-type EncryptedColumn[SK SubKey] []byte
+type EncryptedColumn[SK SubKey] struct{ data []byte }
 
 var _ driver.Valuer = &EncryptedColumn[TimelineSubKey]{}
 var _ sql.Scanner = &EncryptedColumn[TimelineSubKey]{}
 
-func (e *EncryptedColumn[SK]) SubKey() string { var sk SK; return sk.SubKey() }
-func (e *EncryptedColumn[SK]) Bytes() []byte  { return *e }
-func (e *EncryptedColumn[SK]) Set(b []byte)   { *e = b }
-func (e *EncryptedColumn[SK]) Value() (driver.Value, error) {
-	return []byte(*e), nil
+func (e *EncryptedColumn[SK]) SubKey() string              { var sk SK; return sk.SubKey() }
+func (e *EncryptedColumn[SK]) Bytes() []byte               { return e.data }
+func (e *EncryptedColumn[SK]) Set(b []byte)                { e.data = b }
+func (e EncryptedColumn[SK]) Value() (driver.Value, error) { return e.data, nil }
+func (e *EncryptedColumn[SK]) GoString() string {
+	return fmt.Sprintf("EncryptedColumn[%s](%d bytes)", e.SubKey(), len(e.data))
 }
 
 func (e *EncryptedColumn[SK]) Scan(src interface{}) error {
-	if src == nil {
-		*e = nil
-		return nil
-	}
 	b, ok := src.([]byte)
 	if !ok {
 		return fmt.Errorf("expected []byte, got %T", src)
 	}
-	*e = b
+	e.data = b
 	return nil
 }
 

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -232,12 +232,12 @@ func (k *KMSEncryptor) getDerivedPrimitive(subKey SubKey) (tink.AEAD, error) {
 func (k *KMSEncryptor) Encrypt(cleartext []byte, dest Encrypted) error {
 	primitive, err := k.getDerivedPrimitive(dest)
 	if err != nil {
-		return fmt.Errorf("failed to get derived primitive: %w", err)
+		return fmt.Errorf("%s: failed to get derived primitive: %w", dest.SubKey(), err)
 	}
 
 	encrypted, err := primitive.Encrypt(cleartext, nil)
 	if err != nil {
-		return fmt.Errorf("failed to encrypt: %w", err)
+		return fmt.Errorf("%s: failed to encrypt: %w", dest.SubKey(), err)
 	}
 
 	dest.Set(encrypted)
@@ -247,12 +247,12 @@ func (k *KMSEncryptor) Encrypt(cleartext []byte, dest Encrypted) error {
 func (k *KMSEncryptor) Decrypt(encrypted Encrypted) ([]byte, error) {
 	primitive, err := k.getDerivedPrimitive(encrypted)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get derived primitive: %w", err)
+		return nil, fmt.Errorf("%s: failed to get derived primitive: %w", encrypted.SubKey(), err)
 	}
 
 	decrypted, err := primitive.Decrypt(encrypted.Bytes(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decrypt: %w", err)
+		return nil, fmt.Errorf("%s: failed to decrypt: %w", encrypted.SubKey(), err)
 	}
 
 	return decrypted, nil


### PR DESCRIPTION
Make EncryptedColumn a struct so we can't accidentally implicitly convert `[]byte` to/from it. As a side-effect, discovered a few columns in the DB that weren't the correct types.