### PR TITLE
fix: run pnpmDedupe after renovate update

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,7 +12,7 @@
   lockFileMaintenance: {
     enabled: true, // Automatically update lock files like pnpm-lock.yaml
   },
-  postUpdateOptions: ["gomodTidy"],
+  postUpdateOptions: ["gomodTidy", "pnpmDedupe"],
   packageRules: [
     {
       matchUpdateTypes: ["minor", "patch"],


### PR DESCRIPTION
This should fix some of the issues we are having on renovate pull requests