### PR TITLE
fix: restore kube health check

### DIFF
--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -132,6 +132,7 @@ func Start(ctx context.Context, config Config) error {
 	return rpc.Serve(ctx, config.Bind,
 		rpc.GRPC(ftlv1connect.NewVerbServiceHandler, svc),
 		rpc.HTTP("/", svc),
+		rpc.HealthCheck(svc.healthCheck),
 	)
 }
 


### PR DESCRIPTION
With the recent changes to the protocol and to routing there is no real need for the controller to ping the runner. This ping was causing the ISTIO RBAC issues that resulted in us disabling the health check.

fixes: #2710