### PR TITLE
chore: delete cmd/ftl symlink

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -10,7 +10,7 @@ components:
   protos: { in: backend/protos/** }
   schema: { in: backend/schema/** }
   ftl: { in: . }
-  ftl-cmd: { in: cmd/ftl/** }
+  ftl-cmd: { in: frontend/cli/ftl/** }
   go-runtime: { in: go-runtime/** }
   jvm-runtime: { in: jvm-runtime/** }
   rust-runtime: { in: rust-runtime/** }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 builds:
   - id: ftl
-    main: ./cmd/ftl
+    main: ./frontend/cli/ftl
     binary: ftl
     env:
       - CGO_ENABLED=0
@@ -18,18 +18,18 @@ archives:
   - format: tar.gz
     name_template: "{{ .ProjectName }}-{{ .Version }}.{{- .Os }}-{{ .Arch }}"
     format_overrides:
-    - goos: windows
-      format: zip
+      - goos: windows
+        format: zip
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 snapshot:
   name_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"
 
 brews:
   - name: ftl
@@ -39,7 +39,6 @@ brews:
       owner: TBD54566975
       name: homebrew-ftl
       token: "{{ .Env.FTL_HOMEBREW_TOKEN }}"
-
 # The lines beneath this are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json

--- a/Justfile
+++ b/Justfile
@@ -54,13 +54,16 @@ build-generate:
 build +tools: build-protos build-zips build-frontend
   #!/bin/bash
   shopt -s extglob
-  set -x
 
-  if [ "${FTL_DEBUG:-}" = "true" ]; then
-    for tool in $@; do go build -o "{{RELEASE}}/$tool" -tags release -gcflags=all="-N -l" -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.Timestamp={{TIMESTAMP}}" "./cmd/$tool"; done
-  else
-    for tool in $@; do mk "{{RELEASE}}/$tool" : !(build|integration|infrastructure|node_modules|Procfile*|Dockerfile*) -- go build -o "{{RELEASE}}/$tool" -tags release -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.Timestamp={{TIMESTAMP}}" "./cmd/$tool"; done
-  fi
+  for tool in $@; do
+    path="cmd/$tool"
+    test "$tool" = "ftl" && path="frontend/cli"
+    if [ "${FTL_DEBUG:-}" = "true" ]; then
+      go build -o "{{RELEASE}}/$tool" -tags release -gcflags=all="-N -l" -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.Timestamp={{TIMESTAMP}}" "./$path"
+    else
+      mk "{{RELEASE}}/$tool" : !(build|integration|infrastructure|node_modules|Procfile*|Dockerfile*) -- go build -o "{{RELEASE}}/$tool" -tags release -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.Timestamp={{TIMESTAMP}}" "./$path"
+    fi
+  done
 
 # Build all backend binaries
 build-backend:

--- a/cmd/ftl
+++ b/cmd/ftl
@@ -1,1 +1,0 @@
-../frontend/cli

--- a/scripts/ftl
+++ b/scripts/ftl
@@ -3,5 +3,9 @@ set -euo pipefail
 ftldir="$(dirname "$(readlink -f "$0")")/.."
 name="$(basename "$0")"
 dest="${ftldir}/build/devel"
+src="./cmd/${name}"
+if [ "${name}" = "ftl" ]; then
+  src="./frontend/cli"
+fi
 mkdir -p "$dest"
-(cd "${ftldir}/cmd/${name}" && "${ftldir}/bin/go" build -ldflags="-s -w -buildid=" -o "$dest/${name}" ./) && exec "$dest/${name}" "$@"
+(cd "${ftldir}/${src}" && "${ftldir}/bin/go" build -ldflags="-s -w -buildid=" -o "$dest/${name}" .) && exec "$dest/${name}" "$@"


### PR DESCRIPTION
It's annoying because some editors will index both directories and every file will show up twice.