### PR TITLE
chore: add ftlDebug script

### DIFF
--- a/scripts/ftlDebug
+++ b/scripts/ftlDebug
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Note that this does not seem to work in intellij, as it can't handle dlv without --continue
+# VS Code works great though
+set -euo pipefail
+ftldir="$(dirname "$(readlink -f "$0")")/.."
+name="ftl"
+dest="${ftldir}/build/devel"
+src="./cmd/${name}"
+if [ "${name}" = "ftl" ]; then
+  src="./frontend/cli"
+fi
+mkdir -p "$dest"
+(cd "${ftldir}/${src}" && dlv debug --headless --listen=:2345 --api-version=2 --log --accept-multiclient -- "$@" )


### PR DESCRIPTION
This makes it easy to run FTL under dlv, and dlv will wait for the IDE to attach. This is useful if you want to debug commands other than ftl dev