### PR TITLE
fix: avoid race when allocating ports

### DIFF
--- a/internal/bind/bind_allocator.go
+++ b/internal/bind/bind_allocator.go
@@ -34,15 +34,15 @@ func (b *BindAllocator) NextPort() int {
 	var l *net.TCPListener
 	var err error
 	for {
-		b.port.Add(1)
-		l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP(b.baseURL.Hostname()), Port: int(b.port.Load())})
+		port := int(b.port.Add(1))
+		l, err = net.ListenTCP("tcp", &net.TCPAddr{IP: net.ParseIP(b.baseURL.Hostname()), Port: port})
 
 		if err != nil {
 			continue
 		}
 		_ = l.Close()
 
-		return int(b.port.Load())
+		return port
 	}
 }
 


### PR DESCRIPTION
The port can change between when we increment and when we return the value. This can cause ports to not be unique when calling `Next()`.