### PR TITLE
fix: update cli status icons

### DIFF
--- a/internal/console/status.go
+++ b/internal/console/status.go
@@ -23,12 +23,12 @@ import (
 
 type BuildState string
 
-const BuildStateWaiting BuildState = " 🚦️"
-const BuildStateBuilding BuildState = " 🏗️"
+const BuildStateWaiting BuildState = "🕗"
+const BuildStateBuilding BuildState = "🛠️ "
 const BuildStateBuilt BuildState = "📦️️"
-const BuildStateDeploying BuildState = " 🚚️"
-const BuildStateDeployed BuildState = " ✅️️"
-const BuildStateFailed BuildState = "💥"
+const BuildStateDeploying BuildState = "🚀"
+const BuildStateDeployed BuildState = "✅"
+const BuildStateFailed BuildState = "❌"
 
 // moduleStatusPadding is the padding between module status entries
 // it accounts for the colon, space and the emoji


### PR DESCRIPTION
This might help keep some icon/ideas in sync between cli and console.

Changing from:
```sh
const BuildStateWaiting BuildState = " 🚦️"
const BuildStateBuilding BuildState = " 🏗️"
const BuildStateBuilt BuildState = "📦️️"
const BuildStateDeploying BuildState = " 🚚️"
const BuildStateDeployed BuildState = " ✅️️"
const BuildStateFailed BuildState = "💥"
```

To:
```sh
const BuildStateWaiting BuildState = " 🕗"
const BuildStateBuilding BuildState = " 🛠️"
const BuildStateBuilt BuildState = " 📦️️"
const BuildStateDeploying BuildState = " 🚀"
const BuildStateDeployed BuildState = " ✅"
const BuildStateFailed BuildState = " ❌"
```

![Screenshot 2024-09-24 at 2 59 10 PM](https://github.com/user-attachments/assets/e6c5a911-a824-48b4-a988-cb48c84c0126)
![Screenshot 2024-09-24 at 2 59 26 PM](https://github.com/user-attachments/assets/c32b653e-d575-4cff-88bb-4fb08fe252c7)
![Screenshot 2024-09-24 at 2 59 31 PM](https://github.com/user-attachments/assets/6cf65a7b-2f8e-495c-9b87-bb060c94212b)
