### PR TITLE
chore: create seperate renovate PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -9,6 +9,12 @@
     "group:allNonMajor",
     "schedule:earlyMondays",
   ],
+  "js": {
+    "managerBranchPrefix": "js-"
+  },
+  "java": {
+    "managerBranchPrefix": "java-"
+  },
   lockFileMaintenance: {
     enabled: true, // Automatically update lock files like pnpm-lock.yaml
   },


### PR DESCRIPTION
This should split out Java and Javascript updates to make the resulting PRs easier to manage.

The current PRs can end up with multiple cross ecosystem issues that require more colaberation to fully resolve.