### PR TITLE
refactor: simplify terminal.KongContextBinder

### DIFF
--- a/frontend/cli/cmd_dev.go
+++ b/frontend/cli/cmd_dev.go
@@ -29,7 +29,7 @@ type devCmd struct {
 	Build          buildCmd `embed:""`
 }
 
-func (d *devCmd) Run(ctx context.Context, k *kong.Kong, projConfig projectconfig.Config, cancel context.CancelFunc) error {
+func (d *devCmd) Run(ctx context.Context, k *kong.Kong, projConfig projectconfig.Config, bindContext terminal.KongContextBinder) error {
 	startTime := time.Now()
 	if len(d.Build.Dirs) == 0 {
 		d.Build.Dirs = projConfig.AbsModuleDirs()
@@ -39,7 +39,7 @@ func (d *devCmd) Run(ctx context.Context, k *kong.Kong, projConfig projectconfig
 	}
 
 	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
-	terminal.LaunchEmbeddedConsole(ctx, k, projConfig, bindContext, cancel, client)
+	terminal.LaunchEmbeddedConsole(ctx, k, bindContext, client)
 
 	g, ctx := errgroup.WithContext(ctx)
 

--- a/frontend/cli/cmd_interactive.go
+++ b/frontend/cli/cmd_interactive.go
@@ -15,7 +15,7 @@ type interactiveCmd struct {
 }
 
 func (i *interactiveCmd) Run(ctx context.Context, k *kong.Kong, projectConfig projectconfig.Config, binder terminal.KongContextBinder, cancel context.CancelFunc, client ftlv1connect.ControllerServiceClient) error {
-	err := terminal.RunInteractiveConsole(ctx, k, projectConfig, binder, cancel, client)
+	err := terminal.RunInteractiveConsole(ctx, k, binder, client)
 	if err != nil {
 		return fmt.Errorf("interactive console: %w", err)
 	}

--- a/internal/terminal/interactive.go
+++ b/internal/terminal/interactive.go
@@ -15,7 +15,6 @@ import (
 	"github.com/posener/complete"
 
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
-	"github.com/TBD54566975/ftl/internal/projectconfig"
 )
 
 const interactivePrompt = "\033[32m>\033[0m "
@@ -23,9 +22,9 @@ const interactivePrompt = "\033[32m>\033[0m "
 var _ readline.AutoCompleter = &FTLCompletion{}
 var errExitTrap = errors.New("exit trap")
 
-type KongContextBinder func(ctx context.Context, kctx *kong.Context, projectConfig projectconfig.Config, app *kong.Kong, cancel context.CancelFunc) context.Context
+type KongContextBinder func(ctx context.Context, kctx *kong.Context) context.Context
 
-func RunInteractiveConsole(ctx context.Context, k *kong.Kong, projectConfig projectconfig.Config, binder KongContextBinder, cancelContext context.CancelFunc, client ftlv1connect.ControllerServiceClient) error {
+func RunInteractiveConsole(ctx context.Context, k *kong.Kong, binder KongContextBinder, client ftlv1connect.ControllerServiceClient) error {
 
 	l, err := readline.NewEx(&readline.Config{
 		Prompt:          interactivePrompt,
@@ -90,7 +89,7 @@ func RunInteractiveConsole(ctx context.Context, k *kong.Kong, projectConfig proj
 				errorf("%s", err)
 				return
 			}
-			subctx := binder(ctx, kctx, projectConfig, k, cancelContext)
+			subctx := binder(ctx, kctx)
 
 			err = kctx.Run(subctx)
 			if err != nil {

--- a/internal/terminal/status.go
+++ b/internal/terminal/status.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/internal/log"
-	"github.com/TBD54566975/ftl/internal/projectconfig"
 )
 
 type BuildState string
@@ -489,11 +488,11 @@ func (r *terminalStatusLine) SetMessage(message string) {
 	r.manager.recalculateLines()
 }
 
-func LaunchEmbeddedConsole(ctx context.Context, k *kong.Kong, projectConfig projectconfig.Config, binder KongContextBinder, cancel context.CancelFunc, client ftlv1connect.ControllerServiceClient) {
+func LaunchEmbeddedConsole(ctx context.Context, k *kong.Kong, binder KongContextBinder, client ftlv1connect.ControllerServiceClient) {
 	sm := FromContext(ctx)
 	if _, ok := sm.(*terminalStatusManager); ok {
 		go func() {
-			err := RunInteractiveConsole(ctx, k, projectConfig, binder, cancel, client)
+			err := RunInteractiveConsole(ctx, k, binder, client)
 			if err != nil {
 				fmt.Printf("\033[31mError: %s\033[0m\n", err)
 				return


### PR DESCRIPTION
Instead of passing around all the parameters required manually, we capture them in a closure once at startup.