### PR TITLE
feat: send ingress requests via http

### DIFF
--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -113,6 +113,15 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 		controllerAddresses = append(controllerAddresses, bindAllocator.Next())
 	}
 
+	for _, addr := range controllerAddresses {
+		// Add controller address to allow origins for console requests.
+		// The console is run on `localhost` so we replace 127.0.0.1 with localhost.
+		if addr.Hostname() == "127.0.0.1" {
+			addr.Host = "localhost" + ":" + addr.Port()
+		}
+		s.CommonConfig.AllowOrigins = append(s.CommonConfig.AllowOrigins, addr)
+	}
+
 	runnerScaling, err := localscaling.NewLocalScaling(bindAllocator, controllerAddresses, projConfig.Path, devMode && !projConfig.DisableIDEIntegration)
 	if err != nil {
 		return err

--- a/frontend/console/src/features/verbs/VerbFormInput.tsx
+++ b/frontend/console/src/features/verbs/VerbFormInput.tsx
@@ -1,28 +1,22 @@
-import { useEffect, useState } from 'react'
-
 export const VerbFormInput = ({
   requestType,
-  initialPath,
+  path,
+  setPath,
   requestPath,
   readOnly,
   onSubmit,
 }: {
   requestType: string
-  initialPath: string
+  path: string
+  setPath: (path: string) => void
   requestPath: string
   readOnly: boolean
   onSubmit: (path: string) => void
 }) => {
-  const [path, setPath] = useState(initialPath)
-
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
     onSubmit(path)
   }
-
-  useEffect(() => {
-    setPath(initialPath)
-  }, [initialPath])
 
   return (
     <form onSubmit={handleSubmit} className='rounded-lg'>
@@ -41,7 +35,7 @@ export const VerbFormInput = ({
           Send
         </button>
       </div>
-      {!readOnly && <span className='text-xs text-gray-500'>{requestPath}</span>}
+      {!readOnly && <span className='ml-4 text-xs text-gray-500'>{requestPath}</span>}
     </form>
   )
 }

--- a/frontend/console/src/features/verbs/verb.utils.ts
+++ b/frontend/console/src/features/verbs/verb.utils.ts
@@ -179,3 +179,31 @@ export const createVerbRequest = (path: string, verb?: Verb, editorText?: string
 export const verbCalls = (verb?: Verb) => {
   return verb?.verb?.metadata.filter((meta) => meta.value.case === 'calls').map((meta) => meta.value.value as MetadataCalls) ?? null
 }
+
+export const generateCliCommand = (verb: Verb, path: string, header: string, body: string) => {
+  const method = requestType(verb)
+  return method === 'CALL' ? generateFtlCallCommand(path, body) : generateCurlCommand(method, path, header, body)
+}
+
+const generateFtlCallCommand = (path: string, editorText: string) => {
+  const command = `ftl call ${path} '${editorText}'`
+  return command
+}
+
+const generateCurlCommand = (method: string, path: string, header: string, body: string) => {
+  const headers = JSON.parse(header)
+
+  let curlCommand = `curl -X ${method.toUpperCase()} "${path}"`
+
+  for (const [key, value] of Object.entries(headers)) {
+    curlCommand += ` -H "${key}: ${value}"`
+  }
+
+  curlCommand += ' -H "Content-Type: application/json"'
+
+  if (method === 'POST' || method === 'PUT') {
+    curlCommand += ` -d '${body}'`
+  }
+
+  return curlCommand
+}

--- a/frontend/console/src/layout/Notification.tsx
+++ b/frontend/console/src/layout/Notification.tsx
@@ -1,5 +1,5 @@
 import { Transition } from '@headlessui/react'
-import { Alert02Icon, AlertCircleIcon, Cancel02Icon, CheckmarkCircle02Icon, InformationCircleIcon } from 'hugeicons-react'
+import { Alert02Icon, AlertCircleIcon, Cancel01Icon, CheckmarkCircle02Icon, InformationCircleIcon } from 'hugeicons-react'
 import { Fragment, useContext } from 'react'
 import { NotificationType, NotificationsContext } from '../providers/notifications-provider'
 import { textColor } from '../utils'
@@ -67,7 +67,7 @@ export const Notification = () => {
                     }}
                   >
                     <span className='sr-only'>Close</span>
-                    <Cancel02Icon className='h-5 w-5' aria-hidden='true' />
+                    <Cancel01Icon className='h-5 w-5' aria-hidden='true' />
                   </button>
                 </div>
               </div>

--- a/frontend/console/src/providers/app-providers.tsx
+++ b/frontend/console/src/providers/app-providers.tsx
@@ -1,3 +1,4 @@
+import { Notification } from '../layout/Notification'
 import { NotificationsProvider } from './notifications-provider'
 import { ReactQueryProvider } from './react-query-provider'
 import { RoutingProvider } from './routing-provider'
@@ -9,6 +10,7 @@ export const AppProvider = () => {
       <UserPreferencesProvider>
         <NotificationsProvider>
           <RoutingProvider />
+          <Notification />
         </NotificationsProvider>
       </UserPreferencesProvider>
     </ReactQueryProvider>


### PR DESCRIPTION
Fixes #2720
Fixes #2753 (will add similar functionality to request/events page in the future)

With this change we can now see `ingress` events are part of the request since we're using fetch.

![Screenshot 2024-09-25 at 1 06 11 PM](https://github.com/user-attachments/assets/23ad70e4-30cc-4e92-a85c-f57f627fdb10)

Copy `curl`
![Screenshot 2024-09-25 at 1 06 36 PM](https://github.com/user-attachments/assets/9a28bf54-fc3e-42a8-a84a-d4cc9be40b38)

Copy `ftl.call`
![Screenshot 2024-09-25 at 1 06 42 PM](https://github.com/user-attachments/assets/018634ac-2e53-404f-b16e-697521803960)
