### PR TITLE
fix: scheduled tasks should not derive names

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -344,7 +344,7 @@ func New(ctx context.Context, conn *sql.DB, config Config, devel bool, runnerSca
 	singletonTask(svc.reapStaleControllers, "reap-stale-controllers", time.Second*2, time.Second*20, time.Second*20)
 	singletonTask(svc.reapStaleRunners, "reap-stale-runners", time.Second*2, time.Second, time.Second*10)
 	singletonTask(svc.reapCallEvents, "reap-call-events", time.Minute*5, time.Minute, time.Minute*30)
-	singletonTask(svc.reapAsyncCalls, "reap-async-calls", time.Second*1, time.Second, time.Second*1)
+	singletonTask(svc.reapAsyncCalls, "reap-async-calls", time.Second*5, time.Second, time.Second*5)
 	return svc, nil
 }
 

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -319,22 +319,32 @@ func New(ctx context.Context, conn *sql.DB, config Config, devel bool, runnerSca
 		return makeBackoff(minDelay, maxDelay), job
 	}
 
+	parallelTask := func(job scheduledtask.Job, name string, maxNext, minDelay, maxDelay time.Duration, develBackoff ...backoff.Backoff) {
+		maybeDevelJob, backoff := maybeDevelTask(job, name, maxNext, minDelay, maxDelay, develBackoff...)
+		svc.tasks.Parallel(name, maybeDevelJob, backoff)
+	}
+
+	singletonTask := func(job scheduledtask.Job, name string, maxNext, minDelay, maxDelay time.Duration, develBackoff ...backoff.Backoff) {
+		maybeDevelJob, backoff := maybeDevelTask(job, name, maxNext, minDelay, maxDelay, develBackoff...)
+		svc.tasks.Singleton(name, maybeDevelJob, backoff)
+	}
+
 	// Parallel tasks.
-	svc.tasks.Parallel(maybeDevelTask(svc.syncRoutes, "sync-routes", time.Second, time.Second, time.Second*5))
-	svc.tasks.Parallel(maybeDevelTask(svc.heartbeatController, "controller-heartbeat", time.Second, time.Second*3, time.Second*5))
-	svc.tasks.Parallel(maybeDevelTask(svc.updateControllersList, "update-controllers-list", time.Second, time.Second*5, time.Second*5))
-	svc.tasks.Parallel(maybeDevelTask(svc.executeAsyncCalls, "execute-async-calls", time.Second, time.Second*5, time.Second*10))
+	parallelTask(svc.syncRoutes, "sync-routes", time.Second, time.Second, time.Second*5)
+	parallelTask(svc.heartbeatController, "controller-heartbeat", time.Second, time.Second*3, time.Second*5)
+	parallelTask(svc.updateControllersList, "update-controllers-list", time.Second, time.Second*5, time.Second*5)
+	parallelTask(svc.executeAsyncCalls, "execute-async-calls", time.Second, time.Second*5, time.Second*10)
 
 	// This should be a singleton task, but because this is the task that
 	// actually expires the leases used to run singleton tasks, it must be
 	// parallel.
-	svc.tasks.Parallel(maybeDevelTask(svc.expireStaleLeases, "expire-stale-leases", time.Second*2, time.Second, time.Second*5))
+	parallelTask(svc.expireStaleLeases, "expire-stale-leases", time.Second*2, time.Second, time.Second*5)
 
 	// Singleton tasks use leases to only run on a single controller.
-	svc.tasks.Singleton(maybeDevelTask(svc.reapStaleControllers, "reap-stale-controllers", time.Second*2, time.Second*20, time.Second*20))
-	svc.tasks.Singleton(maybeDevelTask(svc.reapStaleRunners, "reap-stale-runners", time.Second*2, time.Second, time.Second*10))
-	svc.tasks.Singleton(maybeDevelTask(svc.reapCallEvents, "reap-call-events", time.Minute*5, time.Minute, time.Minute*30))
-	svc.tasks.Singleton(maybeDevelTask(svc.reapAsyncCalls, "reap-async-calls", time.Second*5, time.Second, time.Second*5))
+	singletonTask(svc.reapStaleControllers, "reap-stale-controllers", time.Second*2, time.Second*20, time.Second*20)
+	singletonTask(svc.reapStaleRunners, "reap-stale-runners", time.Second*2, time.Second, time.Second*10)
+	singletonTask(svc.reapCallEvents, "reap-call-events", time.Minute*5, time.Minute, time.Minute*30)
+	singletonTask(svc.reapAsyncCalls, "reap-async-calls", time.Second*1, time.Second, time.Second*1)
 	return svc, nil
 }
 

--- a/backend/controller/pubsub/service.go
+++ b/backend/controller/pubsub/service.go
@@ -26,8 +26,8 @@ const (
 )
 
 type Scheduler interface {
-	Singleton(retry backoff.Backoff, job scheduledtask.Job)
-	Parallel(retry backoff.Backoff, job scheduledtask.Job)
+	Singleton(name string, retry backoff.Backoff, job scheduledtask.Job)
+	Parallel(name string, retry backoff.Backoff, job scheduledtask.Job)
 }
 
 type AsyncCallListener interface {
@@ -46,7 +46,7 @@ func New(conn libdal.Connection, encryption *encryption.Service, scheduler Sched
 		scheduler:         scheduler,
 		asyncCallListener: asyncCallListener,
 	}
-	m.scheduler.Parallel(backoff.Backoff{
+	m.scheduler.Parallel("progress-subs", backoff.Backoff{
 		Min:    1 * time.Second,
 		Max:    5 * time.Second,
 		Jitter: true,

--- a/backend/controller/scheduledtask/scheduledtask.go
+++ b/backend/controller/scheduledtask/scheduledtask.go
@@ -5,10 +5,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
-	"reflect"
-	"runtime"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/alecthomas/types/optional"
@@ -74,19 +71,16 @@ func NewForTesting(ctx context.Context, id model.ControllerKey, clock clock.Cloc
 //
 // This is not guaranteed, however, as controllers may have inconsistent views
 // of the hash ring.
-func (s *Scheduler) Singleton(retry backoff.Backoff, job Job) {
-	s.schedule(retry, job, true)
+func (s *Scheduler) Singleton(name string, retry backoff.Backoff, job Job) {
+	s.schedule(name, retry, job, true)
 }
 
 // Parallel schedules a job to run on every controller.
-func (s *Scheduler) Parallel(retry backoff.Backoff, job Job) {
-	s.schedule(retry, job, false)
+func (s *Scheduler) Parallel(name string, retry backoff.Backoff, job Job) {
+	s.schedule(name, retry, job, false)
 }
 
-func (s *Scheduler) schedule(retry backoff.Backoff, job Job, singlyHomed bool) {
-	name := runtime.FuncForPC(reflect.ValueOf(job).Pointer()).Name()
-	name = name[strings.LastIndex(name, ".")+1:]
-	name = strings.TrimSuffix(name, "-fm")
+func (s *Scheduler) schedule(name string, retry backoff.Backoff, job Job, singlyHomed bool) {
 	s.jobs <- &descriptor{
 		name:        name,
 		retry:       retry,

--- a/backend/controller/scheduledtask/scheduledtask_test.go
+++ b/backend/controller/scheduledtask/scheduledtask_test.go
@@ -42,11 +42,11 @@ func TestScheduledTask(t *testing.T) {
 
 	for _, c := range controllers {
 		c.cron = NewForTesting(ctx, c.controller.Key, clock, leaser)
-		c.cron.Singleton(backoff.Backoff{}, func(ctx context.Context) (time.Duration, error) {
+		c.cron.Singleton("singleton", backoff.Backoff{}, func(ctx context.Context) (time.Duration, error) {
 			singletonCount.Add(1)
 			return time.Second, nil
 		})
-		c.cron.Parallel(backoff.Backoff{}, func(ctx context.Context) (time.Duration, error) {
+		c.cron.Parallel("parallel", backoff.Backoff{}, func(ctx context.Context) (time.Duration, error) {
 			multiCount.Add(1)
 			return time.Second, nil
 		})

--- a/backend/controller/sql/databasetesting/devel.go
+++ b/backend/controller/sql/databasetesting/devel.go
@@ -84,16 +84,7 @@ func CreateForDevel(ctx context.Context, dsn string, recreate bool) (*stdsql.DB,
 	// controller/runner registration, etc. but not anything more.
 	if !recreate {
 		_, err = realConn.ExecContext(ctx, `
-			WITH deleted AS (
-				DELETE FROM async_calls
-				RETURNING 1
-			), deleted_fsm_instances AS (
-				DELETE FROM fsm_instances
-				RETURNING 1
-			), deleted_leases AS (
-				DELETE FROM leases
-				RETURNING 1
-			), deleted_controllers AS (
+			WITH deleted_controllers AS (
 				DELETE FROM controllers
 				RETURNING 1
 			), deleted_runners AS (

--- a/backend/controller/sql/databasetesting/devel.go
+++ b/backend/controller/sql/databasetesting/devel.go
@@ -84,7 +84,16 @@ func CreateForDevel(ctx context.Context, dsn string, recreate bool) (*stdsql.DB,
 	// controller/runner registration, etc. but not anything more.
 	if !recreate {
 		_, err = realConn.ExecContext(ctx, `
-			WITH deleted_controllers AS (
+			WITH deleted AS (
+				DELETE FROM async_calls
+				RETURNING 1
+			), deleted_fsm_instances AS (
+				DELETE FROM fsm_instances
+				RETURNING 1
+			), deleted_leases AS (
+				DELETE FROM leases
+				RETURNING 1
+			), deleted_controllers AS (
 				DELETE FROM controllers
 				RETURNING 1
 			), deleted_runners AS (


### PR DESCRIPTION
Singleton scheduled tasks were broken due to the job functions being wrapped. This was causing the derived name for each job to be the same, which meant they all competed for the same lease.

Since we recently added a name for each of the scheduled tasks, this PR passes those names along to the scheduler rather than relying on a derived name.