### PR TITLE
fix: just dev now works

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -36,7 +36,7 @@ live-rebuild:
 
 # Run "ftl dev" with live-reloading whenever source changes.
 dev *args:
-  watchexec -r {{WATCHEXEC_ARGS}} -- "just build-sqlc && ftl dev {{args}}"
+  watchexec -r {{WATCHEXEC_ARGS}} -- "just build-sqlc && ftl dev --plain {{args}}"
 
 # Build everything
 build-all: build-protos-unconditionally build-backend build-backend-tests build-frontend build-generate build-sqlc build-zips lsp-generate build-java generate-kube-migrations
@@ -86,7 +86,9 @@ init-db:
 
 # Regenerate SQLC code (requires init-db to be run first)
 build-sqlc:
-  @mk backend/controller/sql/{db.go,models.go,querier.go,queries.sql.go} backend/controller/cronjobs/sql/{db.go,models.go,querier.go,queries.sql.go} internal/configuration/sql/{db.go,models.go,querier.go,queries.sql.go} : backend/controller/sql/queries.sql backend/controller/sql/async_queries.sql backend/controller/cronjobs/sql/queries.sql internal/configuration/sql/queries.sql backend/controller/sql/schema sqlc.yaml -- "just init-db && sqlc generate"
+  @mk $(eval echo $(yq '.sql[].gen.go.out + "/{db.go,models.go,querier.go,queries.sql.go}"' sqlc.yaml)) \
+    : sqlc.yaml $(yq '.sql[].queries[]' sqlc.yaml) \
+    --  "just init-db && sqlc generate"
 
 # Build the ZIP files that are embedded in the FTL release binaries
 build-zips:


### PR DESCRIPTION
This was because `just build-sqlc` didn't have correct dependencies, resulting in it always rebuilding. I've updated it to pull the dep locations directly out of sqlc.yaml, which will future-proof it.

Fixes #2846 