### PR TITLE
feat: add "ftl profile ..." command tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.ftl-project/
 .hermit/
 .vscode/*
 !/.vscode/settings.json
@@ -42,3 +41,4 @@ junit*.xml
 /docs/public
 .ftl.lock
 docker-build/
+**/.ftl

--- a/frontend/cli/cmd_profile.go
+++ b/frontend/cli/cmd_profile.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/alecthomas/types/either"
+
+	"github.com/TBD54566975/ftl"
+	"github.com/TBD54566975/ftl/internal/configuration"
+	"github.com/TBD54566975/ftl/internal/configuration/providers"
+	"github.com/TBD54566975/ftl/internal/profiles"
+)
+
+type profileCmd struct {
+	Init    profileInitCmd    `cmd:"" help:"Initialize a new project."`
+	List    profileListCmd    `cmd:"" help:"List all profiles."`
+	Default profileDefaultCmd `cmd:"" help:"Set a profile as default."`
+	Switch  profileSwitchCmd  `cmd:"" help:"Switch locally active profile."`
+	New     profileNewCmd     `cmd:"" help:"Create a new profile."`
+}
+
+type profileInitCmd struct {
+	Project     string   `arg:"" help:"Name of the project."`
+	Dir         string   `arg:"" help:"Directory to initialize the project in." default:"${gitroot}" required:""`
+	ModuleRoots []string `help:"Root directories of existing modules."`
+	NoGit       bool     `help:"Don't add files to the git repository."`
+}
+
+func (p profileInitCmd) Run(
+	configRegistry *providers.Registry[configuration.Configuration],
+	secretsRegistry *providers.Registry[configuration.Secrets],
+) error {
+	_, err := profiles.Init(profiles.ProjectConfig{
+		Realm:         p.Project,
+		FTLMinVersion: ftl.Version,
+		ModuleRoots:   p.ModuleRoots,
+		NoGit:         p.NoGit,
+		Root:          p.Dir,
+	}, secretsRegistry, configRegistry)
+	if err != nil {
+		return fmt.Errorf("init project: %w", err)
+	}
+	fmt.Printf("Project initialized in %s.\n", p.Dir)
+	return nil
+}
+
+type profileListCmd struct{}
+
+func (profileListCmd) Run(project *profiles.Project) error {
+	active, err := project.ActiveProfile()
+	if err != nil {
+		return fmt.Errorf("active profile: %w", err)
+	}
+	p, err := project.List()
+	if err != nil {
+		return fmt.Errorf("list profiles: %w", err)
+	}
+	for _, profile := range p {
+		attrs := []string{}
+		switch profile.Config.(type) {
+		case either.Left[profiles.LocalProfileConfig, profiles.RemoteProfileConfig]:
+			attrs = append(attrs, "local")
+		case either.Right[profiles.LocalProfileConfig, profiles.RemoteProfileConfig]:
+			attrs = append(attrs, "remote")
+		}
+		if project.DefaultProfile() == profile.Name {
+			attrs = append(attrs, "default")
+		}
+		if active == profile.Name {
+			attrs = append(attrs, "active")
+		}
+		fmt.Printf("%s (%s)\n", profile, strings.Join(attrs, ", "))
+	}
+	return nil
+}
+
+type profileDefaultCmd struct {
+	Profile string `arg:"" help:"Profile name."`
+}
+
+func (p profileDefaultCmd) Run(project *profiles.Project) error {
+	err := project.SetDefault(p.Profile)
+	if err != nil {
+		return fmt.Errorf("set default profile: %w", err)
+	}
+	return nil
+}
+
+type profileSwitchCmd struct {
+	Profile string `arg:"" help:"Profile name."`
+}
+
+func (p profileSwitchCmd) Run(project *profiles.Project) error {
+	err := project.Switch(p.Profile)
+	if err != nil {
+		return fmt.Errorf("switch profile: %w", err)
+	}
+	return nil
+}
+
+type profileNewCmd struct {
+	Local         bool                      `help:"Create a local profile." xor:"location" and:"providers"`
+	Remote        *url.URL                  `help:"Create a remote profile." xor:"location"`
+	Secrets       configuration.ProviderKey `help:"Secrets provider." placeholder:"PROVIDER" default:"inline" and:"providers"`
+	Configuration configuration.ProviderKey `help:"Configuration provider." placeholder:"PROVIDER" default:"inline" and:"providers"`
+	Name          string                    `arg:"" help:"Profile name."`
+}
+
+func (p profileNewCmd) Run(project *profiles.Project) error {
+	var config either.Either[profiles.LocalProfileConfig, profiles.RemoteProfileConfig]
+	switch {
+	case p.Local:
+		config = either.LeftOf[profiles.RemoteProfileConfig](profiles.LocalProfileConfig{
+			SecretsProvider: p.Secrets,
+			ConfigProvider:  p.Configuration,
+		})
+
+	case p.Remote != nil:
+		config = either.RightOf[profiles.LocalProfileConfig](profiles.RemoteProfileConfig{
+			Endpoint: p.Remote,
+		})
+	}
+	err := project.New(profiles.ProfileConfig{
+		Name:   p.Name,
+		Config: config,
+	})
+	if err != nil {
+		return fmt.Errorf("new profile: %w", err)
+	}
+	return nil
+}

--- a/internal/profiles/internal/persistence.go
+++ b/internal/profiles/internal/persistence.go
@@ -22,9 +22,11 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/TBD54566975/ftl/internal/configuration"
-	"github.com/TBD54566975/ftl/internal/slices"
+	"github.com/TBD54566975/ftl/internal/sha256"
 )
 
 type ProfileType string
@@ -60,14 +62,67 @@ type Project struct {
 	Root string `json:"-"`
 }
 
-// Profiles returns the names of all profiles in the project.
-func (p Project) Profiles() ([]string, error) {
+// ActiveProfile returns the name of the active profile.
+//
+// If no profile is active, it returns the default.
+func (p Project) ActiveProfile() (string, error) {
+	cacheDir, err := p.ensureUserProjectDir()
+	if err != nil {
+		return "", err
+	}
+	profile, err := os.ReadFile(filepath.Join(cacheDir, "active-profile"))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+		return "", fmt.Errorf("read active profile: %w", err)
+	}
+	return strings.TrimSpace(string(profile)), nil
+}
+
+func (p Project) SetActiveProfile(profile string) error {
+	cacheDir, err := p.ensureUserProjectDir()
+	if err != nil {
+		return err
+	}
+	err = os.WriteFile(filepath.Join(cacheDir, "active-profile"), []byte(profile), 0600)
+	if err != nil {
+		return fmt.Errorf("write active profile: %w", err)
+	}
+	return nil
+}
+
+func (p Project) ensureUserProjectDir() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("user cache dir: %w", err)
+	}
+
+	cacheDir = filepath.Join(cacheDir, "ftl-projects", sha256.Sum([]byte(p.Root)).String())
+	if err = os.MkdirAll(cacheDir, 0700); err != nil {
+		return "", fmt.Errorf("mkdir cache dir: %w", err)
+	}
+	return cacheDir, nil
+}
+
+// ListProfiles returns the names of all profiles in the project.
+func (p Project) ListProfiles() ([]Profile, error) {
 	profileDir := filepath.Join(p.Root, ".ftl-project", "profiles")
 	profiles, err := filepath.Glob(filepath.Join(profileDir, "*", "profile.json"))
 	if err != nil {
 		return nil, fmt.Errorf("profiles: %s: %w", profileDir, err)
 	}
-	return slices.Map(profiles, func(p string) string { return filepath.Base(filepath.Dir(p)) }), nil
+	out := make([]Profile, 0, len(profiles))
+	for _, profile := range profiles {
+		name := filepath.Base(filepath.Dir(profile))
+		profile, err := p.LoadProfile(name)
+		if err != nil {
+			return nil, fmt.Errorf("%s: load profile: %w", name, err)
+		}
+		out = append(out, profile)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
 }
 
 func (p Project) LoadProfile(name string) (Profile, error) {
@@ -108,7 +163,7 @@ func (p Project) SaveProfile(profile Profile) error {
 	return nil
 }
 
-func (p *Project) Save() error {
+func (p Project) Save() error {
 	profilePath := filepath.Join(p.Root, ".ftl-project", "project.json")
 	if err := os.MkdirAll(filepath.Dir(profilePath), 0700); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(profilePath), err)
@@ -129,12 +184,12 @@ func (p *Project) Save() error {
 }
 
 // LocalSecretsPath returns the path to the secrets file for the given local profile.
-func (p *Project) LocalSecretsPath(profile string) string {
+func (p Project) LocalSecretsPath(profile string) string {
 	return filepath.Join(p.Root, ".ftl-project", "profiles", profile, "secrets.json")
 }
 
 // LocalConfigPath returns the path to the config file for the given local profile.
-func (p *Project) LocalConfigPath(profile string) string {
+func (p Project) LocalConfigPath(profile string) string {
 	return filepath.Join(p.Root, ".ftl-project", "profiles", profile, "config.json")
 }
 
@@ -177,6 +232,10 @@ func Init(project Project) error {
 
 // Load the project configuration from the given root directory.
 func Load(root string) (Project, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return Project{}, fmt.Errorf("failed to get absolute path: %w", err)
+	}
 	profilePath := filepath.Join(root, ".ftl-project", "project.json")
 	r, err := os.Open(profilePath)
 	if errors.Is(err, os.ErrNotExist) {

--- a/internal/profiles/profiles.go
+++ b/internal/profiles/profiles.go
@@ -2,14 +2,20 @@ package profiles
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
+	"os"
+
+	"github.com/alecthomas/types/either"
 
 	"github.com/TBD54566975/ftl/internal/configuration"
 	"github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
 	"github.com/TBD54566975/ftl/internal/configuration/routers"
 	"github.com/TBD54566975/ftl/internal/profiles/internal"
+	"github.com/TBD54566975/ftl/internal/reflect"
+	"github.com/TBD54566975/ftl/internal/slices"
 )
 
 type ProjectConfig internal.Project
@@ -26,37 +32,201 @@ type Profile struct {
 	cm     *manager.Manager[configuration.Configuration]
 }
 
-// ProjectConfig is static project-wide configuration shared by all profiles.
+// ProjectConfig is the static project-wide configuration shared by all profiles.
 func (p *Profile) ProjectConfig() ProjectConfig { return p.shared }
 
 // Config is the static configuration for a Profile.
-func (p *Profile) Config() Config { return p.config }
+func (p *Profile) Config() Config { return reflect.DeepCopy(p.config) }
 
-func (p *Profile) SecretsManager() *manager.Manager[configuration.Secrets]             { return p.sm }
+// SecretsManager returns the secrets manager for this profile.
+func (p *Profile) SecretsManager() *manager.Manager[configuration.Secrets] { return p.sm }
+
+// ConfigurationManager returns the configuration manager for this profile.
 func (p *Profile) ConfigurationManager() *manager.Manager[configuration.Configuration] { return p.cm }
 
-// Init a new project with a default "local" profile.
-func Init(project ProjectConfig) error {
+type LocalProfileConfig struct {
+	SecretsProvider configuration.ProviderKey
+	ConfigProvider  configuration.ProviderKey
+}
+
+type RemoteProfileConfig struct {
+	Endpoint *url.URL
+}
+
+type ProfileConfig struct {
+	Name   string
+	Config either.Either[LocalProfileConfig, RemoteProfileConfig]
+}
+
+func (p ProfileConfig) String() string { return p.Name }
+
+type Project struct {
+	project         internal.Project
+	secretsRegistry *providers.Registry[configuration.Secrets]
+	configRegistry  *providers.Registry[configuration.Configuration]
+}
+
+// Open a project.
+func Open(
+	root string,
+	secretsRegistry *providers.Registry[configuration.Secrets],
+	configRegistry *providers.Registry[configuration.Configuration],
+) (*Project, error) {
+	project, err := internal.Load(root)
+	if err != nil {
+		return nil, fmt.Errorf("open project: %w", err)
+	}
+	return &Project{
+		project:         project,
+		secretsRegistry: secretsRegistry,
+		configRegistry:  configRegistry,
+	}, nil
+}
+
+// Init a new project with a default local profile.
+//
+// If "project.Default" is empty a new project will be created with a default "local" profile.
+func Init(
+	project ProjectConfig,
+	secretsRegistry *providers.Registry[configuration.Secrets],
+	configRegistry *providers.Registry[configuration.Configuration],
+) (*Project, error) {
 	err := internal.Init(internal.Project(project))
 	if err != nil {
-		return fmt.Errorf("init project: %w", err)
+		return nil, fmt.Errorf("init project: %w", err)
+	}
+	return &Project{
+		project:         internal.Project(project),
+		secretsRegistry: secretsRegistry,
+		configRegistry:  configRegistry,
+	}, nil
+}
+
+// SetDefault profile for the project.
+func (p *Project) SetDefault(profile string) error {
+	_, err := p.project.LoadProfile(profile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s: profile does not exist", profile)
+		}
+		return fmt.Errorf("%s: load profile: %w", profile, err)
+	}
+	p.project.DefaultProfile = profile
+	err = p.project.Save()
+	if err != nil {
+		return fmt.Errorf("%s: save project: %w", profile, err)
+	}
+	return nil
+}
+
+// Switch active profiles.
+func (p *Project) Switch(profile string) error {
+	_, err := p.project.LoadProfile(profile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%s: profile does not exist", profile)
+		}
+		return fmt.Errorf("%s: load profile: %w", profile, err)
+	}
+	err = p.project.SetActiveProfile(profile)
+	if err != nil {
+		return fmt.Errorf("set active profile: %w", err)
+	}
+	return nil
+}
+
+// ActiveProfile returns the name of the active profile.
+//
+// If no profile is active, the default profile is returned.
+func (p *Project) ActiveProfile() (string, error) {
+	profile, err := p.project.ActiveProfile()
+	if err != nil {
+		return "", fmt.Errorf("active profile: %w", err)
+	}
+	return profile, nil
+}
+
+// DefaultProfile returns the name of the default profile.
+func (p *Project) DefaultProfile() string {
+	return p.project.DefaultProfile
+}
+
+// List all profiles in the project.
+func (p *Project) List() ([]ProfileConfig, error) {
+	profiles, err := p.project.ListProfiles()
+	if err != nil {
+		return nil, fmt.Errorf("load profiles: %w", err)
+	}
+	configs, err := slices.MapErr(profiles, func(profile internal.Profile) (ProfileConfig, error) {
+		var config either.Either[LocalProfileConfig, RemoteProfileConfig]
+		switch profile.Type {
+		case internal.ProfileTypeLocal:
+			config = either.LeftOf[RemoteProfileConfig](LocalProfileConfig{
+				SecretsProvider: profile.SecretsProvider,
+				ConfigProvider:  profile.ConfigProvider,
+			})
+		case internal.ProfileTypeRemote:
+			endpoint, err := profile.EndpointURL()
+			if err != nil {
+				return ProfileConfig{}, fmt.Errorf("profile endpoint: %w", err)
+			}
+			config = either.RightOf[LocalProfileConfig](RemoteProfileConfig{
+				Endpoint: endpoint,
+			})
+		}
+		return ProfileConfig{
+			Name:   profile.Name,
+			Config: config,
+		}, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("map profiles: %w", err)
+	}
+	return configs, nil
+}
+
+// New creates a new profile in the project.
+func (p *Project) New(profileConfig ProfileConfig) error {
+	_, err := p.project.LoadProfile(profileConfig.Name)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("load profile: %w", err)
+		}
+	} else {
+		return fmt.Errorf("profile %s already exists", profileConfig.Name)
+	}
+	var profile internal.Profile
+	switch handle := profileConfig.Config.(type) {
+	case either.Left[LocalProfileConfig, RemoteProfileConfig]:
+		config := handle.Get()
+		profile = internal.Profile{
+			Name:            profileConfig.Name,
+			Type:            internal.ProfileTypeLocal,
+			SecretsProvider: config.SecretsProvider,
+			ConfigProvider:  config.ConfigProvider,
+		}
+
+	case either.Right[LocalProfileConfig, RemoteProfileConfig]:
+		config := handle.Get()
+		profile = internal.Profile{
+			Name:     profileConfig.Name,
+			Endpoint: config.Endpoint.String(),
+			Type:     internal.ProfileTypeRemote,
+		}
+
+	case nil:
+		return fmt.Errorf("profile config is nil")
+	}
+	err = p.project.SaveProfile(profile)
+	if err != nil {
+		return fmt.Errorf("save profile: %w", err)
 	}
 	return nil
 }
 
 // Load a profile from the project.
-func Load(
-	ctx context.Context,
-	secretsRegistry *providers.Registry[configuration.Secrets],
-	configRegistry *providers.Registry[configuration.Configuration],
-	root string,
-	profile string,
-) (Profile, error) {
-	project, err := internal.Load(root)
-	if err != nil {
-		return Profile{}, fmt.Errorf("load project: %w", err)
-	}
-	prof, err := project.LoadProfile(profile)
+func (p *Project) Load(ctx context.Context, profile string) (Profile, error) {
+	prof, err := p.project.LoadProfile(profile)
 	if err != nil {
 		return Profile{}, fmt.Errorf("load profile: %w", err)
 	}
@@ -69,21 +239,21 @@ func Load(
 	var cm *manager.Manager[configuration.Configuration]
 	switch prof.Type {
 	case internal.ProfileTypeLocal:
-		sp, err := secretsRegistry.Get(ctx, prof.SecretsProvider)
+		sp, err := p.secretsRegistry.Get(ctx, prof.SecretsProvider)
 		if err != nil {
 			return Profile{}, fmt.Errorf("get secrets provider: %w", err)
 		}
-		secretsRouter := routers.NewFileRouter[configuration.Secrets](project.LocalSecretsPath(profile))
+		secretsRouter := routers.NewFileRouter[configuration.Secrets](p.project.LocalSecretsPath(profile))
 		sm, err = manager.New[configuration.Secrets](ctx, secretsRouter, []configuration.Provider[configuration.Secrets]{sp})
 		if err != nil {
 			return Profile{}, fmt.Errorf("create secrets manager: %w", err)
 		}
 
-		cp, err := configRegistry.Get(ctx, prof.ConfigProvider)
+		cp, err := p.configRegistry.Get(ctx, prof.ConfigProvider)
 		if err != nil {
 			return Profile{}, fmt.Errorf("get config provider: %w", err)
 		}
-		configRouter := routers.NewFileRouter[configuration.Configuration](project.LocalConfigPath(profile))
+		configRouter := routers.NewFileRouter[configuration.Configuration](p.project.LocalConfigPath(profile))
 		cm, err = manager.New[configuration.Configuration](ctx, configRouter, []configuration.Provider[configuration.Configuration]{cp})
 		if err != nil {
 			return Profile{}, fmt.Errorf("create configuration manager: %w", err)
@@ -96,7 +266,7 @@ func Load(
 		return Profile{}, fmt.Errorf("%s: unknown profile type: %q", profile, prof.Type)
 	}
 	return Profile{
-		shared: ProjectConfig(project),
+		shared: ProjectConfig(p.project),
 		config: Config{
 			Name:     prof.Name,
 			Endpoint: profileEndpoint,


### PR DESCRIPTION
Also refactor profiles package a bit to be more flexible.


```
🐚 ~/dev/ftl $ ftl profile init ftl
Project initialized in /Users/alec/dev/ftl.
🐚 ~/dev/ftl $ ftl profile new --local test
🐚 ~/dev/ftl $ ftl profile list
local (local, default)
test (local)
🐚 ~/dev/ftl $ ftl profile switch test
🐚 ~/dev/ftl $ ftl profile list
local (local, default)
test (local, active)
```