### PR TITLE
chore: add teams for the various subsystems

### DIFF
--- a/deployment/CODEOWNERS
+++ b/deployment/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alec-brooks @tlongwell-block @stuartwdouglas @alecthomas
+* @TBD54566975/ftl-infra-team

--- a/frontend/CODEOWNERS
+++ b/frontend/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wesbillman @deniseli
+* @TBD54566975/ftl-frontend-team

--- a/go-runtime/CODEOWNERS
+++ b/go-runtime/CODEOWNERS
@@ -1,1 +1,1 @@
-* @worstell @alecthomas @matt2e
+* @TBD54566975/ftl-go-team

--- a/jvm-runtime/CODEOWNERS
+++ b/jvm-runtime/CODEOWNERS
@@ -1,1 +1,1 @@
-* @stuartwdouglas @tomdaffurn @worstell
+* @TBD54566975/ftl-jvm-team


### PR DESCRIPTION
This will assign a single reviewer rather than every single CODEOWNER being assigned. GitHub is annoying.