### PR TITLE
fix: imports for non-referenced external types

### DIFF
--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -813,6 +813,17 @@ func (b *mainModuleContextBuilder) getGoSchemaType(typ schema.Type) (goSchemaTyp
 
 	switch t := typ.(type) {
 	case *schema.Ref:
+		// we add native types for all refs traversed from the main module. however, if this
+		// ref was not directly traversed by the main module (e.g. the request of a verb in an external module, where
+		// the main module needs a generated client for this verb), we can infer its native qualified name to get the
+		// native type here.
+		if !result.nativeType.Ok() {
+			nt, err := b.getNativeType("ftl/" + t.Module + "." + t.Name)
+			if err != nil {
+				return goSchemaType{}, err
+			}
+			result.nativeType = optional.Some(nt)
+		}
 		if len(t.TypeParameters) > 0 {
 			for _, tp := range t.TypeParameters {
 				_r, err := b.getGoSchemaType(tp)


### PR DESCRIPTION
sometimes these need to be genned even if they're not referenced by the main module, e.g. the request in an external verb for which the main module needs a client. we need to generate the client with its resolved request type