### PR TITLE
chore: integration test option to use `ftl-provisioner`

### DIFF
--- a/backend/provisioner/provisioner_integration_test.go
+++ b/backend/provisioner/provisioner_integration_test.go
@@ -1,0 +1,21 @@
+//go:build integration
+
+package provisioner_test
+
+import (
+	"testing"
+
+	in "github.com/TBD54566975/ftl/internal/integration"
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestDeploymentThroughProvisioner(t *testing.T) {
+	in.Run(t,
+		in.WithProvisioner(),
+		in.CopyModule("echo"),
+		in.Deploy("echo"),
+		in.Call("echo", "echo", "Bob", func(t testing.TB, response string) {
+			assert.Equal(t, "Hello, Bob!!!", response)
+		}),
+	)
+}

--- a/backend/provisioner/service.go
+++ b/backend/provisioner/service.go
@@ -47,6 +47,7 @@ var _ provisionerconnect.ProvisionerServiceHandler = (*Service)(nil)
 func New(ctx context.Context, config Config, controllerClient ftlv1connect.ControllerServiceClient, devel bool) (*Service, error) {
 	return &Service{
 		controllerClient: controllerClient,
+		currentResources: map[string][]*provisioner.Resource{},
 	}, nil
 }
 

--- a/backend/provisioner/testdata/go/echo/echo.go
+++ b/backend/provisioner/testdata/go/echo/echo.go
@@ -1,0 +1,14 @@
+// This is the echo module.
+package echo
+
+import (
+	"context"
+	"fmt"
+)
+
+// Echo returns a greeting with the current time.
+//
+//ftl:verb export
+func Echo(ctx context.Context, req string) (string, error) {
+	return fmt.Sprintf("Hello, %s!!!", req), nil
+}

--- a/backend/provisioner/testdata/go/echo/ftl.toml
+++ b/backend/provisioner/testdata/go/echo/ftl.toml
@@ -1,0 +1,2 @@
+module = "echo"
+language = "go"

--- a/backend/provisioner/testdata/go/echo/go.mod
+++ b/backend/provisioner/testdata/go/echo/go.mod
@@ -1,0 +1,5 @@
+module ftl/echo
+
+go 1.23.0
+
+replace github.com/TBD54566975/ftl => ./../../../../../..

--- a/cmd/ftl-provisioner/main.go
+++ b/cmd/ftl-provisioner/main.go
@@ -41,5 +41,5 @@ func main() {
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
 	err = provisioner.Start(ctx, cli.ProvisionerConfig, false)
-	kctx.FatalIfErrorf(err)
+	kctx.FatalIfErrorf(err, "failed to start provisioner")
 }

--- a/frontend/cli/cmd_deploy.go
+++ b/frontend/cli/cmd_deploy.go
@@ -4,19 +4,26 @@ import (
 	"context"
 
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner/provisionerconnect"
 	"github.com/TBD54566975/ftl/internal/buildengine"
 	"github.com/TBD54566975/ftl/internal/projectconfig"
 	"github.com/TBD54566975/ftl/internal/rpc"
 )
 
 type deployCmd struct {
-	Replicas int32    `short:"n" help:"Number of replicas to deploy." default:"1"`
-	NoWait   bool     `help:"Do not wait for deployment to complete." default:"false"`
-	Build    buildCmd `embed:""`
+	Replicas       int32    `short:"n" help:"Number of replicas to deploy." default:"1"`
+	NoWait         bool     `help:"Do not wait for deployment to complete." default:"false"`
+	UseProvisioner bool     `help:"Use the ftl-provisioner to deploy the application." default:"false" hidden:"true"`
+	Build          buildCmd `embed:""`
 }
 
 func (d *deployCmd) Run(ctx context.Context, projConfig projectconfig.Config) error {
-	client := rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
+	var client buildengine.DeployClient
+	if d.UseProvisioner {
+		client = rpc.ClientFromContext[provisionerconnect.ProvisionerServiceClient](ctx)
+	} else {
+		client = rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
+	}
 	engine, err := buildengine.New(ctx, client, projConfig.Root(), d.Build.Dirs, buildengine.BuildEnv(d.Build.BuildEnv), buildengine.Parallelism(d.Build.Parallelism))
 	if err != nil {
 		return err

--- a/internal/buildengine/deploy.go
+++ b/internal/buildengine/deploy.go
@@ -57,7 +57,7 @@ func Deploy(ctx context.Context, module Module, replicas int32, waitForDeployOnl
 
 	gadResp, err := client.GetArtefactDiffs(ctx, connect.NewRequest(&ftlv1.GetArtefactDiffsRequest{ClientDigests: maps.Keys(filesByHash)}))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get artefact diffs: %w", err)
 	}
 
 	moduleSchema, err := loadProtoSchema(moduleConfig, replicas)

--- a/internal/integration/actions.go
+++ b/internal/integration/actions.go
@@ -223,11 +223,16 @@ func ExpectError(action Action, expectedErrorMsg ...string) Action {
 func Deploy(module string) Action {
 	return Chain(
 		func(t testing.TB, ic TestContext) {
-			if ic.kubeClient != nil {
-				Exec("ftl", "deploy", "--build-env", "GOOS=linux", "--build-env", "GOARCH=amd64", "--build-env", "CGO_ENABLED=0", module)(t, ic)
-			} else {
-				Exec("ftl", "deploy", module)(t, ic)
+			args := []string{"deploy"}
+			if ic.Provisioner != nil {
+				args = append(args, "--use-provisioner", "--provisioner-endpoint=http://localhost:8894")
 			}
+			if ic.kubeClient != nil {
+				args = append(args, "--build-env", "GOOS=linux", "--build-env", "GOARCH=amd64", "--build-env", "CGO_ENABLED=0")
+			}
+			args = append(args, module)
+
+			Exec("ftl", args...)(t, ic)
 		},
 		Wait(module),
 	)


### PR DESCRIPTION
runs deployments through the provisioner if requested

This also adds a hidden CLI flags
 `--use-provisioner` to deploy using the provisioner service instead of controller
 `--provisioner-endpoint` to set the provisioner endpoint

Next, I will look how to integrate `ftl-provisioner` better with `ftl serve`