### PR TITLE
feat: use "scratch" base image for ftl-controller

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -10,12 +10,17 @@ WORKDIR /src
 
 # Seed some of the most common tools - this will be cached
 RUN go version
-RUN mvn -B --version
 RUN node --version
 
 # Download Go dependencies separately so Docker will cache them
 COPY go.mod go.sum ./
 RUN go mod download -x
+
+# Download PNPM dependencies separately so Docker will cache them
+COPY frontend/console/package.json ./frontend/console/
+COPY frontend/vscode/package.json ./frontend/vscode/
+COPY pnpm-workspace.yaml pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
 
 # Build
 COPY . /src/
@@ -23,21 +28,15 @@ RUN just errtrace
 # Reset timestamps so that the build state is reset
 RUN git ls-files -z | xargs -0 touch -r go.mod
 RUN just build ftl-controller
-RUN just build ftl-initdb
-RUN just build ftl
 
 # Finally create the runtime image.
-FROM ubuntu:24.04
+FROM scratch
 
-RUN apt-get update
-RUN apt-get install -y curl postgresql-client iputils-ping vim
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-WORKDIR /root/
+WORKDIR /service/
 
 COPY --from=builder /src/build/release/ftl-controller .
-COPY --from=builder /src/build/release/ftl-initdb .
-COPY --from=builder /src/build/release/ftl .
-RUN mkdir deployments
 
 EXPOSE 8891
 EXPOSE 8892
@@ -47,4 +46,4 @@ ENV FTL_CONTROLLER_ADVERTISE="http://127.0.0.1:8892"
 ENV FTL_CONTROLLER_CONSOLE_URL="*"
 ENV FTL_CONTROLLER_DSN="postgres://host.docker.internal/ftl?sslmode=disable&user=postgres&password=secret"
 
-CMD ["/root/ftl-controller"]
+CMD ["/service/ftl-controller"]

--- a/Justfile
+++ b/Justfile
@@ -55,6 +55,8 @@ build +tools: build-protos build-zips build-frontend
   #!/bin/bash
   shopt -s extglob
 
+  export CGO_ENABLED=0
+
   for tool in $@; do
     path="cmd/$tool"
     test "$tool" = "ftl" && path="frontend/cli"
@@ -123,7 +125,7 @@ format-frontend:
 
 # Install Node dependencies using pnpm
 pnpm-install:
-  @for i in {1..3}; do mk frontend/**/node_modules : frontend/**/package.json -- "pnpm install" && break || sleep 5; done
+  @for i in {1..3}; do mk frontend/**/node_modules : frontend/**/package.json -- "pnpm install --frozen-lockfile" && break || sleep 5; done
 
 # Regenerate protos
 build-protos: pnpm-install
@@ -255,4 +257,8 @@ storybook:
 
 # Build an FTL Docker image.
 build-docker name:
-  docker build --platform linux/amd64 -t ftl0/ftl-{{name}}:"${GITHUB_SHA:-$(git rev-parse HEAD)}" -t ftl0/ftl-{{name}}:latest -f Dockerfile.{{name}} .
+  docker build \
+    --platform linux/amd64 \
+    -t ftl0/ftl-{{name}}:"${GITHUB_SHA:-$(git rev-parse HEAD)}" \
+    -t ftl0/ftl-{{name}}:latest \
+    -f Dockerfile.{{name}} .


### PR DESCRIPTION
Reduces the image size from 381MB to 94MB:

```
ftl0/ftl-controller                    latest                                     37007a93754e   2 minutes ago       93.9MB
ftl0/ftl-controller                    <none>                                     66ae6a69737d   3 months ago        381MB
```