### PR TITLE
chore: allow "pnpm install" to be run as a post-upgrade command

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   labels: ["run-all"],
+  allowedPostUpgradeCommands: ["pnpm install"],
   extends: [
     "config:recommended",
     ":semanticCommits",


### PR DESCRIPTION
Fixes:

```
Post-upgrade command 'pnpm install' has not been added to the allowed list in allowedPostUpgradeCommands
```