### PR TITLE
fix: don't cache SNAPSHOT versions

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -26,7 +26,9 @@ runs:
       id: cache-maven
       uses: actions/cache/restore@v4
       with:
-        path: ~/.m2/repository
+        path: |
+          ~/.m2/repository
+          **SNAPSHOT**
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
I am not 100% sure this will work, but the docs seem to imply it will.