### PR TITLE
chore: configurable provisioners in ftl-provisioner

### DIFF
--- a/backend/provisioner/deployment/deployment.go
+++ b/backend/provisioner/deployment/deployment.go
@@ -106,8 +106,13 @@ func (d *Deployment) Progress(ctx context.Context) (bool, error) {
 			return true, err
 		}
 	}
-	err := next.Progress(ctx)
-	return d.next().Ok(), err
+	if next.state != TaskStateDone {
+		err := next.Progress(ctx)
+		if err != nil {
+			return true, err
+		}
+	}
+	return d.next().Ok(), nil
 }
 
 type DeploymentState struct {

--- a/backend/provisioner/deployment/noop_provisioner.go
+++ b/backend/provisioner/deployment/noop_provisioner.go
@@ -1,0 +1,19 @@
+package deployment
+
+import (
+	"context"
+
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner"
+)
+
+type NoopProvisioner struct{}
+
+func (n *NoopProvisioner) Provision(ctx context.Context, module string, desired []*provisioner.ResourceContext, existing []*provisioner.Resource) (string, error) {
+	return "", nil
+}
+
+func (n *NoopProvisioner) State(ctx context.Context, token string, desired []*provisioner.Resource) (TaskState, []*provisioner.Resource, error) {
+	return TaskStateDone, desired, nil
+}
+
+var _ Provisioner = (*NoopProvisioner)(nil)

--- a/backend/provisioner/deployment/plugin_provisioner.go
+++ b/backend/provisioner/deployment/plugin_provisioner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner/provisionerconnect"
 	"github.com/TBD54566975/ftl/common/plugin"

--- a/backend/provisioner/deployment/plugin_provisioner.go
+++ b/backend/provisioner/deployment/plugin_provisioner.go
@@ -1,0 +1,70 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"connectrpc.com/connect"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner/provisionerconnect"
+	"github.com/TBD54566975/ftl/common/plugin"
+	"github.com/TBD54566975/ftl/internal/log"
+)
+
+// PluginProvisioner delegates provisioning to an external plugin
+type PluginProvisioner struct {
+	cmdCtx context.Context
+	client *plugin.Plugin[provisionerconnect.ProvisionerPluginServiceClient]
+}
+
+var _ Provisioner = (*PluginProvisioner)(nil)
+
+func NewPluginProvisioner(ctx context.Context, name string) (*PluginProvisioner, error) {
+	client, cmdCtx, err := plugin.Spawn(
+		ctx,
+		log.Debug,
+		"ftl-provisioner-"+name,
+		".",
+		"ftl-provisioner-"+name,
+		provisionerconnect.NewProvisionerPluginServiceClient,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("error spawning plugin: %w", err)
+	}
+
+	return &PluginProvisioner{
+		cmdCtx: cmdCtx,
+		client: client,
+	}, nil
+}
+
+func (p *PluginProvisioner) Provision(ctx context.Context, module string, desired []*provisioner.ResourceContext, existing []*provisioner.Resource) (string, error) {
+	resp, err := p.client.Client.Provision(ctx, connect.NewRequest(&provisioner.ProvisionRequest{
+		DesiredResources:  desired,
+		ExistingResources: existing,
+		FtlClusterId:      "ftl",
+		Module:            module,
+	}))
+	if err != nil {
+		return "", fmt.Errorf("error calling plugin: %w", err)
+	}
+	if resp.Msg.Status != provisioner.ProvisionResponse_SUBMITTED {
+		return resp.Msg.ProvisioningToken, nil
+	}
+	return "", nil
+}
+
+func (p *PluginProvisioner) State(ctx context.Context, token string, desired []*provisioner.Resource) (TaskState, []*provisioner.Resource, error) {
+	resp, err := p.client.Client.Status(ctx, connect.NewRequest(&provisioner.StatusRequest{
+		ProvisioningToken: token,
+	}))
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting status from plugin: %w", err)
+	}
+	if failed, ok := resp.Msg.Status.(*provisioner.StatusResponse_Failed); ok {
+		return TaskStateFailed, nil, fmt.Errorf("provisioning failed: %s", failed.Failed.ErrorMessage)
+	} else if success, ok := resp.Msg.Status.(*provisioner.StatusResponse_Success); ok {
+		return TaskStateDone, success.Success.UpdatedResources, nil
+	}
+	return TaskStateRunning, nil, nil
+}

--- a/backend/provisioner/provisioner_integration_test.go
+++ b/backend/provisioner/provisioner_integration_test.go
@@ -9,9 +9,14 @@ import (
 	"github.com/alecthomas/assert/v2"
 )
 
-func TestDeploymentThroughProvisioner(t *testing.T) {
+func TestDeploymentThroughNoopProvisioner(t *testing.T) {
 	in.Run(t,
-		in.WithProvisioner(),
+		in.WithProvisioner(`
+			default = "noop"
+			plugins = [
+				{ name = "noop", resources = ["postgres"] },
+			]
+		`),
 		in.CopyModule("echo"),
 		in.Deploy("echo"),
 		in.Call("echo", "echo", "Bob", func(t testing.TB, response string) {

--- a/backend/provisioner/testdata/go/echo/echo.go
+++ b/backend/provisioner/testdata/go/echo/echo.go
@@ -4,7 +4,11 @@ package echo
 import (
 	"context"
 	"fmt"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl"
 )
+
+var db = ftl.PostgresDatabase("echodb")
 
 // Echo returns a greeting with the current time.
 //

--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -52,6 +52,7 @@ type serveCmd struct {
 	ObservabilityConfig observability.Config `embed:"" prefix:"o11y-"`
 	DatabaseImage       string               `help:"The container image to start for the database" default:"postgres:15.8" env:"FTL_DATABASE_IMAGE" hidden:""`
 	controller.CommonConfig
+	provisioner.CommonProvisionerConfig
 }
 
 const ftlContainerName = "ftl-db-1"
@@ -191,8 +192,9 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 
 	for i := range s.Provisioners {
 		config := provisioner.Config{
-			Bind:               provisionerAddresses[i],
-			ControllerEndpoint: controllerAddresses[i%len(controllerAddresses)],
+			Bind:                    provisionerAddresses[i],
+			ControllerEndpoint:      controllerAddresses[i%len(controllerAddresses)],
+			CommonProvisionerConfig: s.CommonProvisionerConfig,
 		}
 
 		config.SetDefaults()


### PR DESCRIPTION
Adds a TOML config file for configuring which provisioner plugin to use for which resource. 

There is a hard coded `noop` provisioner doing nothing. Otherwise a binary with name `ftl-provisioner-<name>` is used as plugin.

Next, I will use Localstack to test that the Cloudformation plugin actually creates a DB.