### PR TITLE
fix: missing types in genned files

### DIFF
--- a/internal/buildengine/testdata/alpha/types.ftl.go
+++ b/internal/buildengine/testdata/alpha/types.ftl.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	ftlother "ftl/other"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+	lib "github.com/TBD54566975/ftl/go-runtime/schema/testdata"
 	"github.com/TBD54566975/ftl/go-runtime/server"
 )
 
@@ -12,6 +13,7 @@ type EchoClient func(context.Context, EchoRequest) (EchoResponse, error)
 
 func init() {
 	reflection.Register(
+		reflection.ExternalType(*new(lib.AnotherNonFTLType)),
 		reflection.ProvideResourcesForVerb(
 			Echo,
 			server.VerbClient[ftlother.EchoClient, ftlother.EchoRequest, ftlother.EchoResponse](),

--- a/internal/buildengine/testdata/type_registry_main.go
+++ b/internal/buildengine/testdata/type_registry_main.go
@@ -14,6 +14,10 @@ import (
 
 func init() {
 	reflection.Register(
+		reflection.SumType[ftlanother.SecondTypeEnum](
+			*new(ftlanother.One),
+			*new(ftlanother.Two),
+		),
 		reflection.SumType[ftlanother.TypeEnum](
 			*new(ftlanother.A),
 			*new(ftlanother.B),


### PR DESCRIPTION
visit all children of resolved refs rather than just the resolved decl itself so we don't miss any types referenced by the main module