### PR TITLE
feat: Add env var to prevent dbmate from dumping the schema

### DIFF
--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,5 +1,6 @@
 env = {
   "DBMATE_MIGRATIONS_DIR": "${HERMIT_ENV}/backend/controller/sql/schema",
+  "DBMATE_NO_DUMP_SCHEMA": "true",
   "FTL_ENDPOINT": "http://localhost:8892",
   "FTL_INIT_GO_REPLACE": "github.com/TBD54566975/ftl=${HERMIT_ENV}",
   "FTL_SOURCE": "${HERMIT_ENV}",


### PR DESCRIPTION
# Summary
This PR adds an env var to hermit, `DBMATE_NO_DUMP_SCHEMA`, as a catch-all way to prevent creation of `db/schema.sql`

# Rationale
ran `dbmate up` from the command-line and noticed the pesky `db/schema.sql` crop up again because i forgot the `--no-dump-schema` flag. Added the env var incase anyone else makes the same mistake.

<img width="997" alt="image" src="https://github.com/user-attachments/assets/fc9b3e27-7b91-4f91-a15e-267ed8728859">


