### PR TITLE
fix: optional handling in the JVM

### DIFF
--- a/internal/integration/actions.go
+++ b/internal/integration/actions.go
@@ -417,6 +417,32 @@ func VerifySchema(check func(ctx context.Context, t testing.TB, sch *schemapb.Sc
 	}
 }
 
+// VerifySchemaVerb lets you test the current schema for a specific verb
+func VerifySchemaVerb(module string, verb string, check func(ctx context.Context, t testing.TB, sch *schemapb.Verb)) Action {
+	return func(t testing.TB, ic TestContext) {
+		sch, err := ic.Controller.GetSchema(ic, connect.NewRequest(&ftlv1.GetSchemaRequest{}))
+		if err != nil {
+			t.Errorf("failed to get schema: %v", err)
+			return
+		}
+		if err != nil {
+			t.Errorf("failed to deserialize schema: %v", err)
+			return
+		}
+		for _, m := range sch.Msg.GetSchema().Modules {
+			if m.Name == module {
+				for _, v := range m.Decls {
+					if v.GetVerb() != nil && v.GetVerb().Name == verb {
+						check(ic.Context, t, v.GetVerb())
+						return
+					}
+				}
+			}
+
+		}
+	}
+}
+
 // Fail expects the next action to Fail.
 func Fail(next Action, msg string, args ...any) Action {
 	return func(t testing.TB, ic TestContext) {

--- a/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/DefaultOptionalBuildItem.java
+++ b/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/DefaultOptionalBuildItem.java
@@ -1,0 +1,20 @@
+package xyz.block.ftl.deployment;
+
+import io.quarkus.builder.item.SimpleBuildItem;
+
+/**
+ * Build item that indicates if a type with no nullability information should default to optional.
+ *
+ * This is different between Kotlin and Java
+ */
+public final class DefaultOptionalBuildItem extends SimpleBuildItem {
+    final boolean defaultToOptional;
+
+    public DefaultOptionalBuildItem(boolean defaultToOptional) {
+        this.defaultToOptional = defaultToOptional;
+    }
+
+    public boolean isDefaultToOptional() {
+        return defaultToOptional;
+    }
+}

--- a/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/HTTPProcessor.java
+++ b/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/HTTPProcessor.java
@@ -157,8 +157,9 @@ public class HTTPProcessor {
                             .setIngress(ingressBuilder
                                     .build())
                             .build();
-                    Type requestTypeParam = moduleBuilder.buildType(bodyParamType, true);
-                    Type responseTypeParam = moduleBuilder.buildType(endpoint.getMethodInfo().returnType(), true);
+                    Type requestTypeParam = moduleBuilder.buildType(bodyParamType, true, Nullability.NOT_NULL);
+                    Type responseTypeParam = moduleBuilder.buildType(endpoint.getMethodInfo().returnType(), true,
+                            Nullability.NOT_NULL);
                     Type stringType = Type.newBuilder().setString(xyz.block.ftl.v1.schema.String.newBuilder().build()).build();
                     Type pathParamType = Type.newBuilder()
                             .setMap(xyz.block.ftl.v1.schema.Map.newBuilder().setKey(stringType)

--- a/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/ModuleProcessor.java
+++ b/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/ModuleProcessor.java
@@ -112,6 +112,7 @@ public class ModuleProcessor {
             TopicsBuildItem topicsBuildItem,
             VerbClientBuildItem verbClientBuildItem,
             List<TypeAliasBuildItem> typeAliasBuildItems,
+            DefaultOptionalBuildItem defaultOptionalBuildItem,
             List<SchemaContributorBuildItem> schemaContributorBuildItems) throws Exception {
         String moduleName = moduleNameBuildItem.getModuleName();
         Map<String, Iterable<String>> comments = readComments();
@@ -133,7 +134,8 @@ public class ModuleProcessor {
         }
 
         ModuleBuilder moduleBuilder = new ModuleBuilder(index.getComputingIndex(), moduleName, topicsBuildItem.getTopics(),
-                verbClientBuildItem.getVerbClients(), recorder, comments, existingRefs);
+                verbClientBuildItem.getVerbClients(), recorder, comments, existingRefs,
+                defaultOptionalBuildItem.isDefaultToOptional());
 
         for (var i : schemaContributorBuildItems) {
             i.getSchemaContributor().accept(moduleBuilder);

--- a/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/Nullability.java
+++ b/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/Nullability.java
@@ -1,0 +1,7 @@
+package xyz.block.ftl.deployment;
+
+public enum Nullability {
+    MISSING,
+    NULLABLE,
+    NOT_NULL
+}

--- a/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/TopicsProcessor.java
+++ b/jvm-runtime/ftl-runtime/common/deployment/src/main/java/xyz/block/ftl/deployment/TopicsProcessor.java
@@ -90,7 +90,8 @@ public class TopicsProcessor {
                     moduleBuilder.addDecls(Decl.newBuilder().setTopic(xyz.block.ftl.v1.schema.Topic.newBuilder()
                             .setExport(topic.exported())
                             .setName(topic.topicName())
-                            .setEvent(moduleBuilder.buildType(topic.eventType(), topic.exported())).build()).build());
+                            .setEvent(moduleBuilder.buildType(topic.eventType(), topic.exported(), Nullability.NOT_NULL))
+                            .build()).build());
                 }
             }
         });

--- a/jvm-runtime/ftl-runtime/common/runtime/src/main/java/xyz/block/ftl/runtime/config/FTLConfigSource.java
+++ b/jvm-runtime/ftl-runtime/common/runtime/src/main/java/xyz/block/ftl/runtime/config/FTLConfigSource.java
@@ -96,7 +96,6 @@ public class FTLConfigSource implements ConfigSource {
             }
         }
         if (s.startsWith("quarkus.datasource")) {
-            System.out.println("prop: " + s);
             switch (s) {
                 case DEFAULT_USER -> {
                     return Optional.ofNullable(controller.getDatasource("default")).map(FTLController.Datasource::username)
@@ -115,19 +114,16 @@ public class FTLConfigSource implements ConfigSource {
             }
             Matcher m = USER_PATTERN.matcher(s);
             if (m.matches()) {
-                System.out.println("match: " + s);
                 return Optional.ofNullable(controller.getDatasource(m.group(1))).map(FTLController.Datasource::username)
                         .orElse(null);
             }
             m = PASSWORD_PATTERN.matcher(s);
             if (m.matches()) {
-                System.out.println("match: " + s);
                 return Optional.ofNullable(controller.getDatasource(m.group(1))).map(FTLController.Datasource::password)
                         .orElse(null);
             }
             m = URL_PATTERN.matcher(s);
             if (m.matches()) {
-                System.out.println("match: " + s);
                 return Optional.ofNullable(controller.getDatasource(m.group(1))).map(FTLController.Datasource::connectionString)
                         .orElse(null);
             }

--- a/jvm-runtime/ftl-runtime/java/deployment/src/main/java/xyz/block/ftl/javalang/deployment/FTLJavaProcessor.java
+++ b/jvm-runtime/ftl-runtime/java/deployment/src/main/java/xyz/block/ftl/javalang/deployment/FTLJavaProcessor.java
@@ -1,0 +1,11 @@
+package xyz.block.ftl.javalang.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import xyz.block.ftl.deployment.DefaultOptionalBuildItem;
+
+public class FTLJavaProcessor {
+    @BuildStep
+    public DefaultOptionalBuildItem defaultOptional() {
+        return new DefaultOptionalBuildItem(false);
+    }
+}

--- a/jvm-runtime/ftl-runtime/kotlin/deployment/src/main/java/xyz/block/ftl/kotlin/deployment/FTLKotlinProcessor.java
+++ b/jvm-runtime/ftl-runtime/kotlin/deployment/src/main/java/xyz/block/ftl/kotlin/deployment/FTLKotlinProcessor.java
@@ -1,0 +1,11 @@
+package xyz.block.ftl.kotlin.deployment;
+
+import io.quarkus.deployment.annotations.BuildStep;
+import xyz.block.ftl.deployment.DefaultOptionalBuildItem;
+
+public class FTLKotlinProcessor {
+    @BuildStep
+    public DefaultOptionalBuildItem defaultOptional() {
+        return new DefaultOptionalBuildItem(true);
+    }
+}

--- a/jvm-runtime/ftl-runtime/kotlin/deployment/src/main/java/xyz/block/ftl/kotlin/deployment/KotlinCodeGenerator.java
+++ b/jvm-runtime/ftl-runtime/kotlin/deployment/src/main/java/xyz/block/ftl/kotlin/deployment/KotlinCodeGenerator.java
@@ -210,8 +210,7 @@ public class KotlinCodeGenerator extends JVMCodeGenerator {
         } else if (type.hasString()) {
             return new ClassName("kotlin", "String");
         } else if (type.hasOptional()) {
-            // Always box for optional, as normal primities can't be null
-            return toKotlinTypeName(type.getOptional().getType(), typeAliasMap, nativeTypeAliasMap);
+            return toKotlinTypeName(type.getOptional().getType(), typeAliasMap, nativeTypeAliasMap).copy(true, List.of());
         } else if (type.hasRef()) {
             if (type.getRef().getModule().isEmpty()) {
                 return TypeVariableName.get(type.getRef().getName());

--- a/jvm-runtime/testdata/java/javamodule/src/main/java/xyz/block/ftl/test/TestInvokeGoFromJava.java
+++ b/jvm-runtime/testdata/java/javamodule/src/main/java/xyz/block/ftl/test/TestInvokeGoFromJava.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import ftl.gomodule.BoolVerbClient;
 import ftl.gomodule.BytesVerbClient;
@@ -43,6 +44,9 @@ import xyz.block.ftl.Verb;
 
 public class TestInvokeGoFromJava {
 
+    /**
+     * JAVA COMMENT
+     */
     @Export
     @Verb
     public void emptyVerb(EmptyVerbClient emptyVerbClient) {
@@ -61,9 +65,6 @@ public class TestInvokeGoFromJava {
         return sourceVerbClient.call();
     }
 
-    /**
-     * JAVA COMMENT
-     */
     @Export
     @Verb
     public void errorEmptyVerb(ErrorEmptyVerbClient client) {
@@ -166,43 +167,43 @@ public class TestInvokeGoFromJava {
 
     @Export
     @Verb
-    public String optionalStringVerb(String val, OptionalStringVerbClient client) {
+    public @Nullable String optionalStringVerb(@Nullable String val, OptionalStringVerbClient client) {
         return client.call(val);
     }
 
     @Export
     @Verb
-    public byte[] optionalBytesVerb(byte[] val, OptionalBytesVerbClient client) {
+    public byte @Nullable [] optionalBytesVerb(byte @Nullable [] val, OptionalBytesVerbClient client) {
         return client.call(val);
     }
 
     @Export
     @Verb
-    public boolean optionalBoolVerb(boolean val, OptionalBoolVerbClient client) {
+    public Boolean optionalBoolVerb(Boolean val, OptionalBoolVerbClient client) {
         return client.call(val);
     }
 
     @Export
     @Verb
-    public List<String> optionalStringArrayVerb(List<String> val, OptionalStringArrayVerbClient client) {
+    public @Nullable List<String> optionalStringArrayVerb(@Nullable List<String> val, OptionalStringArrayVerbClient client) {
         return client.call(val);
     }
 
     @Export
     @Verb
-    public Map<String, String> optionalStringMapVerb(Map<String, String> val, OptionalStringMapVerbClient client) {
+    public @Nullable Map<String, String> optionalStringMapVerb(@Nullable Map<String, String> val, OptionalStringMapVerbClient client) {
         return client.call(val);
     }
 
     @Export
     @Verb
-    public ZonedDateTime optionalTimeVerb(ZonedDateTime instant, OptionalTimeVerbClient client) {
+    public @Nullable ZonedDateTime optionalTimeVerb(@Nullable ZonedDateTime instant, OptionalTimeVerbClient client) {
         return client.call(instant);
     }
 
     @Export
     @Verb
-    public TestObject optionalTestObjectVerb(TestObject val, OptionalTestObjectVerbClient client) {
+    public @Nullable TestObject optionalTestObjectVerb(@Nullable TestObject val, OptionalTestObjectVerbClient client) {
         return client.call(val);
     }
 

--- a/jvm-runtime/testdata/kotlin/kotlinmodule/src/main/kotlin/xyz/block/ftl/test/TestInvokeGoFromKotlin.kt
+++ b/jvm-runtime/testdata/kotlin/kotlinmodule/src/main/kotlin/xyz/block/ftl/test/TestInvokeGoFromKotlin.kt
@@ -120,55 +120,55 @@ fun testObjectOptionalFieldsVerb(
 // now the same again but with option return / input types
 @Export
 @Verb
-fun optionalIntVerb(payload: Long, client: OptionalIntVerbClient): Long {
+fun optionalIntVerb(payload: Long?, client: OptionalIntVerbClient): Long? {
   return client.call(payload)
 }
 
 @Export
 @Verb
-fun optionalFloatVerb(payload: Double, client: OptionalFloatVerbClient): Double {
+fun optionalFloatVerb(payload: Double?, client: OptionalFloatVerbClient): Double? {
   return client.call(payload)
 }
 
 @Export
 @Verb
-fun optionalStringVerb(payload: String, client: OptionalStringVerbClient): String {
+fun optionalStringVerb(payload: String?, client: OptionalStringVerbClient): String? {
   return client.call(payload)
 }
 
 @Export
 @Verb
-fun optionalBytesVerb(payload: ByteArray?, client: OptionalBytesVerbClient): ByteArray {
+fun optionalBytesVerb(payload: ByteArray?, client: OptionalBytesVerbClient): ByteArray? {
   return client.call(payload!!)
 }
 
 @Export
 @Verb
-fun optionalBoolVerb(payload: Boolean, client: OptionalBoolVerbClient): Boolean {
+fun optionalBoolVerb(payload: Boolean?, client: OptionalBoolVerbClient): Boolean? {
   return client.call(payload)
 }
 
 @Export
 @Verb
-fun optionalStringArrayVerb(payload: List<String>, client: OptionalStringArrayVerbClient): List<String> {
+fun optionalStringArrayVerb(payload: List<String>?, client: OptionalStringArrayVerbClient): List<String>? {
   return client.call(payload)
 }
 
 @Export
 @Verb
-fun optionalStringMapVerb(payload: Map<String, String>, client: OptionalStringMapVerbClient): Map<String, String> {
+fun optionalStringMapVerb(payload: Map<String, String>?, client: OptionalStringMapVerbClient): Map<String, String>? {
   return client.call(payload)
 }
 
 @Export
 @Verb
-fun optionalTimeVerb(instant: ZonedDateTime?, client: OptionalTimeVerbClient): ZonedDateTime {
+fun optionalTimeVerb(instant: ZonedDateTime?, client: OptionalTimeVerbClient): ZonedDateTime? {
   return client.call(instant!!)
 }
 
 @Export
 @Verb
-fun optionalTestObjectVerb(payload: TestObject?, client: OptionalTestObjectVerbClient): TestObject {
+fun optionalTestObjectVerb(payload: TestObject?, client: OptionalTestObjectVerbClient): TestObject? {
   return client.call(payload!!)
 }
 
@@ -177,7 +177,7 @@ fun optionalTestObjectVerb(payload: TestObject?, client: OptionalTestObjectVerbC
 fun optionalTestObjectOptionalFieldsVerb(
   payload: TestObjectOptionalFields?,
   client: OptionalTestObjectOptionalFieldsVerbClient
-): TestObjectOptionalFields {
+): TestObjectOptionalFields? {
   return client.call(payload!!)
 }
 


### PR DESCRIPTION
For Kotlin this should exactly match the language semantics. For Java types are not considered Optional unless they are wrapped in a java.util.Optional, or annotated with @Nullable.

The exception to this are the boxed primitive types, which are always considered nullable.

fixes: #2356