### PR TITLE
fix: increase playwright timeout

### DIFF
--- a/frontend/console/playwright.config.ts
+++ b/frontend/console/playwright.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
+  /* If the test end up needing to pull the postgres docker image this can take a while, give it two minutes */
+  timeout: 120000,
   reporter: 'html',
   use: {
     baseURL: 'http://localhost:8892',


### PR DESCRIPTION
This can be an issue if the test has to pull docker images