### PR TITLE
refactor: move verb export check to before req body validation

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -1018,12 +1018,13 @@ func (s *Service) callWithRequest(
 		return nil, err
 	}
 
-	var currentCaller *schema.Ref
+	var currentCaller *schema.Ref // might be nil but that's fine. just means that it's not a cal from another verb
 	if len(callers) > 0 {
 		currentCaller = callers[len(callers)-1]
 	}
 
 	module := verbRef.Module
+
 	if currentCaller.Module != module && !verb.IsExported() {
 		observability.Calls.Request(ctx, req.Msg.Verb, start, optional.Some("invalid request: verb not exported"))
 		return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("verb %q is not exported", verbRef))

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -1025,7 +1025,7 @@ func (s *Service) callWithRequest(
 
 	module := verbRef.Module
 
-	if currentCaller.Module != module && !verb.IsExported() {
+	if currentCaller != nil && currentCaller.Module != module && !verb.IsExported() {
 		observability.Calls.Request(ctx, req.Msg.Verb, start, optional.Some("invalid request: verb not exported"))
 		return nil, connect.NewError(connect.CodePermissionDenied, fmt.Errorf("verb %q is not exported", verbRef))
 	}


### PR DESCRIPTION
# Summary
This smol PR includes a micro optimization by ensuring that a verb is callable (a.k.a exported OR a call within the same module) _before_ validating the request body. 


# Rationale
This change is not necessary by any means. Just something that crossed my mindwhile looking at controller logic with @wesbillman. 

# Changes
* moves `!verb.IsExported` check to before validating request body
* use the current caller to see if the call is intra-module instead of looping over all callers. 

> [!NOTE]
> there may have been a reason why all callers are being looped over instead of checking the current caller, but i couldn't think of a good one. if someone knows definitely let me know!