### PR TITLE
fix: emty replace flag is allowed in `ftl new go`

### DIFF
--- a/internal/buildengine/plugin_go.go
+++ b/internal/buildengine/plugin_go.go
@@ -79,7 +79,7 @@ func (p *goPlugin) CreateModule(ctx context.Context, projConfig projectconfig.Co
 		GoVersion: runtime.Version()[2:],
 		Replace:   map[string]string{},
 	}
-	if replaceStr, ok := flags["replace"]; ok {
+	if replaceStr, ok := flags["replace"]; ok && replaceStr != "" {
 		for _, replace := range strings.Split(replaceStr, ",") {
 			parts := strings.Split(replace, "=")
 			if len(parts) != 2 {


### PR DESCRIPTION
fixes #3006
This was due to FTL trying to parse `""` as the format `A=B,C=D` and failing when it didn't have any pairs.