### PR TITLE
fix: allow running the local scripts outside of the main FTL directory.

### DIFF
--- a/frontend/console/local.go
+++ b/frontend/console/local.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"time"
@@ -24,7 +25,7 @@ var proxyURL, _ = url.Parse("http://localhost:5173") //nolint:errcheck
 var proxy = httputil.NewSingleHostReverseProxy(proxyURL)
 
 func Server(ctx context.Context, timestamp time.Time, publicURL *url.URL, allowOrigin *url.URL) (http.Handler, error) {
-	gitRoot, ok := internal.GitRoot("").Get()
+	gitRoot, ok := internal.GitRoot(os.Getenv("FTL_DIR")).Get()
 	if !ok {
 		return nil, fmt.Errorf("failed to find Git root")
 	}

--- a/scripts/ftl
+++ b/scripts/ftl
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -euo pipefail
-ftldir="$(dirname "$(readlink -f "$0")")/.."
+export FTL_DIR="$(dirname "$(readlink -f "$0")")/.."
+if [ ! "${HERMIT_ENV}" -ef ${FTL_DIR} ]; then
+  . "${FTL_DIR}/bin/activate-hermit"
+fi
+
 name="$(basename "$0")"
-dest="${ftldir}/build/devel"
+dest="${FTL_DIR}/build/devel"
 src="./cmd/${name}"
 if [ "${name}" = "ftl" ]; then
   src="./frontend/cli"
 fi
 mkdir -p "$dest"
-(cd "${ftldir}/${src}" && "${ftldir}/bin/go" build -ldflags="-s -w -buildid=" -o "$dest/${name}" .) && exec "$dest/${name}" "$@"
+(cd "${FTL_DIR}/${src}" && "${FTL_DIR}/bin/go" build -ldflags="-s -w -buildid=" -o "$dest/${name}" .) && exec "$dest/${name}" "$@"


### PR DESCRIPTION
Previously, trying to run `~/Development/ftl/scripts/ftl dev` from a separate project failed with
```
error:controller0: error: No justfile found
```

After this, `scripts/ftl dev` builds the console correctly, though the console UI still does not load correctly, due to
```
http: proxy error: dial tcp [::1]:5173: connect: connection refused
```