### PR TITLE
fix: module tree expansion state when closing the module of the selected decl

### DIFF
--- a/frontend/console/src/features/modules/ModulesTree.tsx
+++ b/frontend/console/src/features/modules/ModulesTree.tsx
@@ -127,13 +127,6 @@ const ModuleSection = ({
   )
 }
 
-function getInitialExpandedModules(moduleName?: string, declName?: string): string[] {
-  if (moduleName && declName) {
-    addModuleToLocalStorageIfMissing(moduleName)
-  }
-  return listExpandedModulesFromLocalStorage()
-}
-
 const declTypesSearchParamKey = 'dt'
 
 export const ModulesTree = ({ modules }: { modules: ModuleTreeItem[] }) => {
@@ -144,10 +137,13 @@ export const ModulesTree = ({ modules }: { modules: ModuleTreeItem[] }) => {
   const declTypesFromUrl = declTypeMultiselectOpts.filter((o) => declTypeKeysFromUrl.includes(o.key))
   const [selectedDeclTypes, setSelectedDeclTypes] = useState(declTypesFromUrl.length === 0 ? declTypeMultiselectOpts : declTypesFromUrl)
 
-  const initialExpanded = getInitialExpandedModules(moduleName, declName)
+  const initialExpanded = listExpandedModulesFromLocalStorage()
   const [expandedModules, setExpandedModules] = useState(initialExpanded)
   useEffect(() => {
-    setExpandedModules(getInitialExpandedModules(moduleName, declName))
+    if (moduleName && declName) {
+      addModuleToLocalStorageIfMissing(moduleName)
+    }
+    setExpandedModules(listExpandedModulesFromLocalStorage())
   }, [moduleName, declName])
 
   function msOnChange(opts: MultiselectOpt[]) {
@@ -161,22 +157,11 @@ export const ModulesTree = ({ modules }: { modules: ModuleTreeItem[] }) => {
     setSelectedDeclTypes(opts)
   }
 
+  // ['didweb'] -> toggle: [] => didweb removed from ls + state, component reinits WITHOUT adding didweb back in, but when component inits otherwise, didweb does get added in
+
   function toggle(toggledModule: string) {
-    const beforeFromLS = listExpandedModulesFromLocalStorage()
-    if (toggledModule === moduleName && beforeFromLS.includes(toggledModule) && !expandedModules.includes(toggledModule)) {
-      // Local storage is out of sync from the state because user closed the
-      // module for the selected decl, which un-syncs the state from the saved
-      // state. Re-opening the selected module lets us re-sync those.
-      // The reason they go out of sync is getInitialExpandedModules gets called
-      // while the decl is still selected, so the module gets added back to the
-      // saved state despite being hence removed from the component state.
-      //setExpandedModules(listExpandedModulesFromLocalStorage())
-      //return
-    }
-    console.log('asdf', listExpandedModulesFromLocalStorage(), expandedModules)
     toggleModuleExpansionInLocalStorage(toggledModule)
     setExpandedModules(listExpandedModulesFromLocalStorage())
-    console.log('asdf2', listExpandedModulesFromLocalStorage(), expandedModules)
   }
 
   function collapseAll() {

--- a/frontend/console/src/features/modules/ModulesTree.tsx
+++ b/frontend/console/src/features/modules/ModulesTree.tsx
@@ -157,8 +157,6 @@ export const ModulesTree = ({ modules }: { modules: ModuleTreeItem[] }) => {
     setSelectedDeclTypes(opts)
   }
 
-  // ['didweb'] -> toggle: [] => didweb removed from ls + state, component reinits WITHOUT adding didweb back in, but when component inits otherwise, didweb does get added in
-
   function toggle(toggledModule: string) {
     toggleModuleExpansionInLocalStorage(toggledModule)
     setExpandedModules(listExpandedModulesFromLocalStorage())

--- a/frontend/console/src/features/modules/module.utils.ts
+++ b/frontend/console/src/features/modules/module.utils.ts
@@ -99,6 +99,7 @@ export const declFromSchema = (moduleName: string, declName: string, schema: Pul
 export const listExpandedModulesFromLocalStorage = () => (localStorage.getItem('tree_m') || '').split(',').filter((s) => s !== '')
 
 export const toggleModuleExpansionInLocalStorage = (moduleName: string) => {
+  console.log('toggle')
   const expanded = listExpandedModulesFromLocalStorage()
   const i = expanded.indexOf(moduleName)
   if (i === -1) {
@@ -110,6 +111,7 @@ export const toggleModuleExpansionInLocalStorage = (moduleName: string) => {
 }
 
 export const addModuleToLocalStorageIfMissing = (moduleName?: string) => {
+  console.log('add')
   const expanded = listExpandedModulesFromLocalStorage()
   if (moduleName && !expanded.includes(moduleName)) {
     localStorage.setItem('tree_m', [...expanded, moduleName].join(','))

--- a/frontend/console/src/features/modules/module.utils.ts
+++ b/frontend/console/src/features/modules/module.utils.ts
@@ -99,7 +99,6 @@ export const declFromSchema = (moduleName: string, declName: string, schema: Pul
 export const listExpandedModulesFromLocalStorage = () => (localStorage.getItem('tree_m') || '').split(',').filter((s) => s !== '')
 
 export const toggleModuleExpansionInLocalStorage = (moduleName: string) => {
-  console.log('toggle')
   const expanded = listExpandedModulesFromLocalStorage()
   const i = expanded.indexOf(moduleName)
   if (i === -1) {
@@ -111,7 +110,6 @@ export const toggleModuleExpansionInLocalStorage = (moduleName: string) => {
 }
 
 export const addModuleToLocalStorageIfMissing = (moduleName?: string) => {
-  console.log('add')
   const expanded = listExpandedModulesFromLocalStorage()
   if (moduleName && !expanded.includes(moduleName)) {
     localStorage.setItem('tree_m', [...expanded, moduleName].join(','))


### PR DESCRIPTION
Fixes: https://github.com/TBD54566975/ftl/issues/2982

This fix delves into the nuance of component re-rendering lifecycle a bit. Basically, before, we would add the selected module to local storage AND update the component state on every single re-render of the component (at `const [expandedModules, setExpandedModules] = useState(...)`. The problem with that was that when we toggled the selected module to close it, the re-render would cause the selected module to still be added back to local storage, but the component state would be out of sync. Then when you went to expand that module again, because the states got unsynced, it would stay stuck in the visibly-closed state. Now, we only add the selected module to local storage in the effect, which doesn't get triggered on toggle a module's expansion state. As a result, the state doesn't de-sync.

So now, you can do the following:
1. Select a decl
2. Close the module of the selected decl in the module tree
3. Re-expand that same module in the module tree. It works.

While the following still works correctly:
1. Close all the modules (i.e. to-be-selected module will not be cached as expanded)
2. Go to a decl page (e.g. paste a link into the browser)
3. The selected module should be expanded in the tree.