### PR TITLE
feat: remove Error and Deploy from ModuleConfig

### DIFF
--- a/frontend/cli/cmd_box.go
+++ b/frontend/cli/cmd_box.go
@@ -148,7 +148,7 @@ func (b *boxCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 		destDir := filepath.Join(workDir, "modules", config.Module)
 
 		// Copy deployment artefacts.
-		files, err := buildengine.FindFilesToDeploy(config)
+		files, err := buildengine.FindFilesToDeploy(config, m.Deploy)
 		if err != nil {
 			return err
 		}

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -20,12 +20,8 @@ import (
 	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/TBD54566975/ftl"
-	languagepb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/language"
-	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	extract "github.com/TBD54566975/ftl/go-runtime/schema"
 	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/builderrors"
@@ -262,9 +258,9 @@ func buildDir(moduleDir string) string {
 }
 
 // Build the given module.
-func Build(ctx context.Context, projectRootDir, moduleDir string, config moduleconfig.AbsModuleConfig, sch *schema.Schema, filesTransaction ModifyFilesTransaction, buildEnv []string, devMode bool) (err error) {
+func Build(ctx context.Context, projectRootDir, moduleDir string, config moduleconfig.AbsModuleConfig, sch *schema.Schema, filesTransaction ModifyFilesTransaction, buildEnv []string, devMode bool) (moduleSch *schema.Module, buildErrors []builderrors.Error, err error) {
 	if err := filesTransaction.Begin(); err != nil {
-		return err
+		return nil, nil, err
 	}
 	defer func() {
 		if terr := filesTransaction.End(); terr != nil {
@@ -274,12 +270,12 @@ func Build(ctx context.Context, projectRootDir, moduleDir string, config modulec
 
 	replacements, goModVersion, err := updateGoModule(filepath.Join(moduleDir, "go.mod"))
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	goVersion := runtime.Version()[2:]
 	if semver.Compare("v"+goVersion, "v"+goModVersion) < 0 {
-		return fmt.Errorf("go version %q is not recent enough for this module, needs minimum version %q", goVersion, goModVersion)
+		return nil, nil, fmt.Errorf("go version %q is not recent enough for this module, needs minimum version %q", goVersion, goModVersion)
 	}
 
 	ftlVersion := ""
@@ -291,7 +287,7 @@ func Build(ctx context.Context, projectRootDir, moduleDir string, config modulec
 	if pcpath, ok := projectconfig.DefaultConfigPath().Get(); ok {
 		pc, err := projectconfig.Load(ctx, pcpath)
 		if err != nil {
-			return fmt.Errorf("failed to load project config: %w", err)
+			return nil, nil, fmt.Errorf("failed to load project config: %w", err)
 		}
 		projectName = pc.Name
 	}
@@ -302,7 +298,7 @@ func Build(ctx context.Context, projectRootDir, moduleDir string, config modulec
 	buildDir := buildDir(moduleDir)
 	err = os.MkdirAll(buildDir, 0750)
 	if err != nil {
-		return fmt.Errorf("failed to create build directory: %w", err)
+		return nil, nil, fmt.Errorf("failed to create build directory: %w", err)
 	}
 
 	var sharedModulesPaths []string
@@ -317,36 +313,30 @@ func Build(ctx context.Context, projectRootDir, moduleDir string, config modulec
 		GoVersion:          goModVersion,
 		SharedModulesPaths: sharedModulesPaths,
 	}, scaffolder.Exclude("^go.mod$"), scaffolder.Functions(funcs)); err != nil {
-		return fmt.Errorf("failed to scaffold zip: %w", err)
+		return nil, nil, fmt.Errorf("failed to scaffold zip: %w", err)
 	}
 
 	logger.Debugf("Extracting schema")
 	result, err := extract.Extract(config.Dir)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
-	if err = writeSchemaErrors(config, result.Errors); err != nil {
-		return fmt.Errorf("failed to write schema errors: %w", err)
-	}
 	if builderrors.ContainsTerminalError(result.Errors) {
 		// Only bail if schema errors contain elements at level ERROR.
 		// If errors are only at levels below ERROR (e.g. INFO, WARN), the schema can still be used.
-		return nil
-	}
-	if err = writeSchema(config, result.Module); err != nil {
-		return fmt.Errorf("failed to write schema: %w", err)
+		return nil, result.Errors, nil
 	}
 
 	logger.Debugf("Generating main module")
 	mctx, err := buildMainModuleContext(sch, result, goModVersion, ftlVersion, projectName, sharedModulesPaths,
 		replacements)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err := internal.ScaffoldZip(buildTemplateFiles(), moduleDir, mctx, scaffolder.Exclude("^go.mod$"),
 		scaffolder.Functions(funcs)); err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	logger.Debugf("Tidying go.mod files")
@@ -374,7 +364,7 @@ func Build(ctx context.Context, projectRootDir, moduleDir string, config modulec
 		return filesTransaction.ModifiedFiles(filepath.Join(mainDir, "go.mod"), filepath.Join(moduleDir, "go.sum"))
 	})
 	if err := wg.Wait(); err != nil {
-		return err
+		return nil, nil, err
 	}
 
 	logger.Debugf("Compiling")
@@ -387,7 +377,7 @@ func Build(ctx context.Context, projectRootDir, moduleDir string, config modulec
 	buildEnv = append(buildEnv, "GODEBUG=http2client=0")
 	err = exec.CommandWithEnv(ctx, log.Debug, mainDir, buildEnv, "go", args...).RunBuffered(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to compile: %w", err)
+		return nil, nil, fmt.Errorf("failed to compile: %w", err)
 	}
 	err = os.WriteFile(filepath.Join(mainDir, "../../launch"), []byte(`#!/bin/bash
 	if [ -n "$FTL_DEBUG_PORT" ] && command -v dlv &> /dev/null ; then
@@ -397,9 +387,9 @@ func Build(ctx context.Context, projectRootDir, moduleDir string, config modulec
 	fi
 	`), 0770) // #nosec
 	if err != nil {
-		return fmt.Errorf("failed to write launch script: %w", err)
+		return nil, nil, fmt.Errorf("failed to write launch script: %w", err)
 	}
-	return nil
+	return result.Module, result.Errors, nil
 }
 
 // CleanStubs removes all generated stubs.
@@ -1152,47 +1142,6 @@ func shouldUpdateVersion(goModfile *modfile.File) bool {
 		}
 	}
 	return true
-}
-
-func writeSchema(config moduleconfig.AbsModuleConfig, module *schema.Module) error {
-	modulepb := module.ToProto().(*schemapb.Module) //nolint:forcetypeassert
-	// If user has overridden GOOS and GOARCH we want to use those values.
-	goos, ok := os.LookupEnv("GOOS")
-	if !ok {
-		goos = runtime.GOOS
-	}
-	goarch, ok := os.LookupEnv("GOARCH")
-	if !ok {
-		goarch = runtime.GOARCH
-	}
-
-	modulepb.Runtime = &schemapb.ModuleRuntime{
-		CreateTime: timestamppb.Now(),
-		Language:   "go",
-		Os:         &goos,
-		Arch:       &goarch,
-	}
-	schemaBytes, err := proto.Marshal(module.ToProto())
-	if err != nil {
-		return fmt.Errorf("failed to marshal schema: %w", err)
-	}
-	err = os.WriteFile(config.Schema(), schemaBytes, 0600)
-	if err != nil {
-		return fmt.Errorf("could not write schema: %w", err)
-	}
-	return nil
-}
-
-func writeSchemaErrors(config moduleconfig.AbsModuleConfig, errors []builderrors.Error) error {
-	elBytes, err := proto.Marshal(languagepb.ErrorsToProto(errors))
-	if err != nil {
-		return fmt.Errorf("failed to marshal errors: %w", err)
-	}
-	err = os.WriteFile(config.Errors, elBytes, 0600)
-	if err != nil {
-		return fmt.Errorf("could not write build errors: %w", err)
-	}
-	return nil
 }
 
 // returns the import path and directory name for a Go type

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -817,7 +817,7 @@ func (e *Engine) build(ctx context.Context, moduleName string, builtModules map[
 		return err
 	}
 	// update files to deploy
-	e.moduleMetas.Compute(moduleName, func(meta moduleMeta, exists bool) (new moduleMeta, delete bool) {
+	e.moduleMetas.Compute(moduleName, func(meta moduleMeta, exists bool) (out moduleMeta, shouldDelete bool) {
 		if !exists {
 			return moduleMeta{}, true
 		}

--- a/internal/buildengine/languageplugin/go_plugin_test.go
+++ b/internal/buildengine/languageplugin/go_plugin_test.go
@@ -55,10 +55,6 @@ func TestGoConfigDefaults(t *testing.T) {
 		{
 			dir: "../testdata/alpha",
 			expected: moduleconfig.CustomDefaults{
-				Deploy: []string{
-					"main",
-					"launch",
-				},
 				DeployDir: ".ftl",
 				Watch: []string{
 					"**/*.go",
@@ -71,10 +67,6 @@ func TestGoConfigDefaults(t *testing.T) {
 		{
 			dir: "../testdata/another",
 			expected: moduleconfig.CustomDefaults{
-				Deploy: []string{
-					"main",
-					"launch",
-				},
 				DeployDir: ".ftl",
 				Watch: []string{
 					"**/*.go",

--- a/internal/buildengine/languageplugin/java_plugin.go
+++ b/internal/buildengine/languageplugin/java_plugin.go
@@ -12,7 +12,6 @@ import (
 	"sort"
 	"strings"
 
-	languagepb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/language"
 	"github.com/TBD54566975/scaffolder"
 	"github.com/alecthomas/kong"
 	"github.com/beevik/etree"
@@ -21,6 +20,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/TBD54566975/ftl"
+	languagepb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/language"
 	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/builderrors"
 	"github.com/TBD54566975/ftl/internal/errors"

--- a/internal/buildengine/languageplugin/java_plugin.go
+++ b/internal/buildengine/languageplugin/java_plugin.go
@@ -12,14 +12,18 @@ import (
 	"sort"
 	"strings"
 
+	languagepb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/language"
 	"github.com/TBD54566975/scaffolder"
 	"github.com/alecthomas/kong"
 	"github.com/beevik/etree"
 	"github.com/go-viper/mapstructure/v2"
 	"golang.org/x/exp/maps"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/internal"
+	"github.com/TBD54566975/ftl/internal/builderrors"
+	"github.com/TBD54566975/ftl/internal/errors"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/moduleconfig"
@@ -63,7 +67,6 @@ func newJavaPlugin(ctx context.Context, language string) *javaPlugin {
 func (p *javaPlugin) ModuleConfigDefaults(ctx context.Context, dir string) (moduleconfig.CustomDefaults, error) {
 	defaults := moduleconfig.CustomDefaults{
 		GeneratedSchemaDir: "src/main/ftl-module-schema",
-		Deploy:             []string{"launch", "quarkus-app"},
 		// Watch defaults to files related to maven and gradle
 		Watch: []string{"pom.xml", "src/**", "build/generated", "target/generated-sources"},
 	}
@@ -244,11 +247,13 @@ func extractKotlinFTLImports(self, dir string) ([]string, error) {
 	return modules, nil
 }
 
-func buildJava(ctx context.Context, projectRoot string, config moduleconfig.AbsModuleConfig, sch *schema.Schema, buildEnv []string, devMode bool, transaction watch.ModifyFilesTransaction) error {
+func buildJava(ctx context.Context, projectRoot string, config moduleconfig.AbsModuleConfig, sch *schema.Schema, buildEnv []string, devMode bool, transaction watch.ModifyFilesTransaction) (BuildResult, error) {
+	// TODO: add back
+	// Deploy:
 	logger := log.FromContext(ctx)
 	javaConfig, err := loadJavaConfig(config.LanguageConfig, config.Language)
 	if err != nil {
-		return fmt.Errorf("failed to build module %q: %w", config.Module, err)
+		return BuildResult{}, fmt.Errorf("failed to build module %q: %w", config.Module, err)
 	}
 	if javaConfig.BuildTool == JavaBuildToolMaven {
 		if err := setPOMProperties(ctx, config.Dir); err != nil {
@@ -261,9 +266,29 @@ func buildJava(ctx context.Context, projectRoot string, config moduleconfig.AbsM
 	command := exec.Command(ctx, log.Debug, config.Dir, "bash", "-c", config.Build)
 	err = command.RunBuffered(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to build module %q: %w", config.Module, err)
+		return BuildResult{}, fmt.Errorf("failed to build module %q: %w", config.Module, err)
 	}
-	return nil
+
+	buildErrs, err := loadProtoErrors(config)
+	if err != nil {
+		return BuildResult{}, fmt.Errorf("failed to load build errors: %w", err)
+	}
+	result := BuildResult{
+		Errors: buildErrs,
+	}
+	if builderrors.ContainsTerminalError(buildErrs) {
+		// skip reading schema
+		return result, nil
+	}
+
+	moduleSchema, err := schema.ModuleFromProtoFile(config.Schema())
+	if err != nil {
+		return BuildResult{}, fmt.Errorf("failed to read schema for module: %w", err)
+	}
+
+	result.Schema = moduleSchema
+	result.Deploy = []string{"launch", "quarkus-app"}
+	return result, nil
 }
 
 // setPOMProperties updates the ftl.version properties in the
@@ -325,4 +350,23 @@ func updatePomProperties(root *etree.Element, pomFile string, ftlVersion string)
 	}
 	version.SetText(ftlVersion)
 	return nil
+}
+
+func loadProtoErrors(config moduleconfig.AbsModuleConfig) ([]builderrors.Error, error) {
+	errorsPath := filepath.Join(config.DeployDir, "errors.pb")
+	if _, err := os.Stat(errorsPath); errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	content, err := os.ReadFile(errorsPath)
+	if err != nil {
+		return nil, fmt.Errorf("could not load build errors file: %w", err)
+	}
+
+	errorspb := &languagepb.ErrorList{}
+	err = proto.Unmarshal(content, errorspb)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal build errors %w", err)
+	}
+	return languagepb.ErrorsFromProto(errorspb), nil
 }

--- a/internal/buildengine/languageplugin/java_plugin_test.go
+++ b/internal/buildengine/languageplugin/java_plugin_test.go
@@ -32,11 +32,7 @@ func TestJavaConfigDefaults(t *testing.T) {
 			language: "kotlin",
 			dir:      "testdata/echokotlin",
 			expected: moduleconfig.CustomDefaults{
-				Build: "mvn -B package",
-				Deploy: []string{
-					"launch",
-					"quarkus-app",
-				},
+				Build:              "mvn -B package",
 				DeployDir:          "target",
 				GeneratedSchemaDir: "src/main/ftl-module-schema",
 				Watch:              watch,
@@ -49,11 +45,7 @@ func TestJavaConfigDefaults(t *testing.T) {
 			language: "kotlin",
 			dir:      "testdata/externalkotlin",
 			expected: moduleconfig.CustomDefaults{
-				Build: "mvn -B package",
-				Deploy: []string{
-					"launch",
-					"quarkus-app",
-				},
+				Build:              "mvn -B package",
 				DeployDir:          "target",
 				GeneratedSchemaDir: "src/main/ftl-module-schema",
 				Watch:              watch,

--- a/internal/buildengine/module.go
+++ b/internal/buildengine/module.go
@@ -9,10 +9,18 @@ import (
 type Module struct {
 	Config       moduleconfig.ModuleConfig
 	Dependencies []string
+	// paths to deploy, relative to ModuleConfig.DeployDir
+	Deploy []string
 }
 
 func (m Module) CopyWithDependencies(dependencies []string) Module {
 	module := reflect.DeepCopy(m)
 	module.Dependencies = dependencies
+	return module
+}
+
+func (m Module) CopyWithDeploy(files []string) Module {
+	module := reflect.DeepCopy(m)
+	module.Deploy = files
 	return module
 }

--- a/internal/moduleconfig/moduleconfig_test.go
+++ b/internal/moduleconfig/moduleconfig_test.go
@@ -118,17 +118,6 @@ func TestDefaulting(t *testing.T) {
 		{
 			config: UnvalidatedModuleConfig{
 				Dir:      "b",
-				Module:   "nodeploy",
-				Language: "test",
-			},
-			defaults: CustomDefaults{
-				DeployDir: "deploydir",
-			},
-			error: "no deploy files configured",
-		},
-		{
-			config: UnvalidatedModuleConfig{
-				Dir:      "b",
 				Module:   "nodeploydir",
 				Language: "test",
 			},
@@ -141,7 +130,7 @@ func TestDefaulting(t *testing.T) {
 
 			config, err := tt.config.FillDefaultsAndValidate(tt.defaults)
 			if tt.error != "" {
-				assert.Contains(t, err.Error(), tt.error)
+				assert.EqualError(t, err, tt.error)
 				return
 			}
 			assert.NoError(t, err)

--- a/internal/moduleconfig/moduleconfig_test.go
+++ b/internal/moduleconfig/moduleconfig_test.go
@@ -22,10 +22,8 @@ func TestDefaulting(t *testing.T) {
 			},
 			defaults: CustomDefaults{
 				Build:              "build",
-				Deploy:             []string{"deploy"},
 				DeployDir:          "deploydir",
 				GeneratedSchemaDir: "generatedschemadir",
-				Errors:             "errors.pb",
 				Watch:              []string{"a", "b", "c"},
 			},
 			expected: ModuleConfig{
@@ -34,10 +32,8 @@ func TestDefaulting(t *testing.T) {
 				Module:             "nothingset",
 				Language:           "test",
 				Build:              "build",
-				Deploy:             []string{"deploy"},
 				DeployDir:          "deploydir",
 				GeneratedSchemaDir: "generatedschemadir",
-				Errors:             "errors.pb",
 				Watch:              []string{"a", "b", "c"},
 			},
 		},
@@ -47,10 +43,8 @@ func TestDefaulting(t *testing.T) {
 				Module:             "allset",
 				Language:           "test",
 				Build:              "custombuild",
-				Deploy:             []string{"customdeploy"},
 				DeployDir:          "customdeploydir",
 				GeneratedSchemaDir: "customgeneratedschemadir",
-				Errors:             "customerrors.pb",
 				Watch:              []string{"custom1"},
 				LanguageConfig: map[string]any{
 					"build-tool": "maven",
@@ -59,10 +53,8 @@ func TestDefaulting(t *testing.T) {
 			},
 			defaults: CustomDefaults{
 				Build:              "build",
-				Deploy:             []string{"deploy"},
 				DeployDir:          "deploydir",
 				GeneratedSchemaDir: "generatedschemadir",
-				Errors:             "errors.pb",
 				Watch:              []string{"a", "b", "c"},
 			},
 			expected: ModuleConfig{
@@ -71,10 +63,8 @@ func TestDefaulting(t *testing.T) {
 				Module:             "allset",
 				Language:           "test",
 				Build:              "custombuild",
-				Deploy:             []string{"customdeploy"},
 				DeployDir:          "customdeploydir",
 				GeneratedSchemaDir: "customgeneratedschemadir",
-				Errors:             "customerrors.pb",
 				Watch:              []string{"custom1"},
 				LanguageConfig: map[string]any{
 					"build-tool": "maven",
@@ -97,7 +87,6 @@ func TestDefaulting(t *testing.T) {
 				},
 			},
 			defaults: CustomDefaults{
-				Deploy:    []string{"example"},
 				DeployDir: "deploydir",
 				LanguageConfig: map[string]any{
 					"alreadyset": "incorrect",
@@ -109,9 +98,7 @@ func TestDefaulting(t *testing.T) {
 				},
 			},
 			expected: ModuleConfig{
-				Deploy:    []string{"example"},
 				DeployDir: "deploydir",
-				Errors:    "errors.pb",
 				Realm:     "home",
 				Dir:       "b",
 				Module:    "languageconfig",
@@ -145,22 +132,8 @@ func TestDefaulting(t *testing.T) {
 				Module:   "nodeploydir",
 				Language: "test",
 			},
-			defaults: CustomDefaults{
-				Deploy: []string{"example"},
-			},
-			error: "no deploy directory configured",
-		},
-		{
-			config: UnvalidatedModuleConfig{
-				Dir:      "b",
-				Module:   "deploynotindir",
-				Language: "test",
-			},
-			defaults: CustomDefaults{
-				Deploy:    []string{"example"},
-				DeployDir: "../../deploydir",
-			},
-			error: "must be relative to the module directory",
+			defaults: CustomDefaults{},
+			error:    "no deploy directory configured",
 		},
 	} {
 		t.Run(tt.config.Module, func(t *testing.T) {


### PR DESCRIPTION
Remove things from ModuleConfig in preparation for language plugins:
- `ModuleConfig.Errors`
    - Removed logic to ever write errors to disk (except Java plugin, which just hardcodes `errors.pb` until it moves to being an external plugin)
- `ModuleConfig.Deploy`
    - This has been refactored to being part of a build result. This also allows language plugins to dynamically include files to deploy.