### PR TITLE
feat: Default to "new" command handler for options

### DIFF
--- a/frontend/cli/cmd_new.go
+++ b/frontend/cli/cmd_new.go
@@ -39,7 +39,8 @@ func prepareNewCmd(ctx context.Context, k *kong.Kong, args []string) error {
 		return nil
 	}
 	language := args[1]
-	if len(language) == 0 {
+	// Default to `new` command handler if no language is provided, or option is specified on `new` command.
+	if len(language) == 0 || language[0] == '-' {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes #3040
If the specified "language" to the new command starts with '-', assume it's an option to the new command. Shortcircuit the following logic and handle the option.