### PR TITLE
fix: add config to prevent red squigglies when opening `.proto` files in vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .hermit/
 .vscode/*
+!/.vscode/extensions.json
 !/.vscode/settings.json
 !/.vscode/launch.json
 .idea/*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "zxh404.vscode-proto3"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "protoc": {
+      "path": "${workspaceRoot}/bin/protoc",
+      "options": [
+          "--proto_path=${workspaceRoot}/backend/protos"
+      ]
+  }
+}


### PR DESCRIPTION
# Summary
This PR introduces workspace configuration for the [vscode-proto3](https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3) extension that specifies the path to the `protos` dir. This prevents all the red squigglies from showing up whenever a `.proto` file is opened.

> [!NOTE]
Also added [vscode-proto3](https://marketplace.visualstudio.com/items?itemName=zxh404.vscode-proto3) as a recommended extension by including it in `.vscode/extensions.json`


## Before

![image](https://github.com/user-attachments/assets/7edfc001-2732-4dda-aca9-8a00c2d45181)


## After
![image](https://github.com/user-attachments/assets/6bd7ccb2-09cb-4075-9066-1983a5413d0d)


> [!NOTE]
> there's a newer protobuf vscode extension that pbkit.dev made called: [Protobuf](https://marketplace.visualstudio.com/items?itemName=pbkit.vscode-pbkit). might be worth trying