### PR TITLE
fix: replace deprecated `logging` exporter

### DIFF
--- a/otel-local-config.yaml
+++ b/otel-local-config.yaml
@@ -10,19 +10,22 @@ processors:
   batch:
 
 exporters:
-  logging:
+  debug:
+    verbosity: detailed
+    sampling_initial: 5
+    sampling_thereafter: 200
 
 service:
   pipelines:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]
     logs:
       receivers: [otlp]
       processors: [batch]
-      exporters: [logging]
+      exporters: [debug]


### PR DESCRIPTION
# Summary
This PR replaces a deprecated `logging` exporter being used in the local otel collector causing it to bork on startup. replaced with [debug exporter](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/debugexporter/README.md)

closes #3019 

## Before
```
docker compose --profile infra up otel-collector
[+] Running 4/4
 ✔ otel-collector Pulled                                                                                                                               6.0s
   ✔ f269895151d7 Pull complete                                                                                                                        0.4s
   ✔ 5d76f70d74fd Pull complete                                                                                                                        4.3s
   ✔ f5b2992c14e2 Pull complete                                                                                                                        4.3s
[+] Running 1/1
 ✔ Container ftl-otel-collector-1  Recreated                                                                                                           0.3s
Attaching to otel-collector-1
otel-collector-1  | Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
otel-collector-1  |
otel-collector-1  | error decoding 'exporters': the logging exporter has been deprecated, use the debug exporter instead
otel-collector-1  | 2024/10/09 14:20:57 collector server run finished with error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
otel-collector-1  |
otel-collector-1  | error decoding 'exporters': the logging exporter has been deprecated, use the debug exporter instead
otel-collector-1 exited with code 1
```

## After

```
docker compose --profile infra up otel-collector
[+] Running 1/0
 ✔ Container ftl-otel-collector-1  Created                                                                                                             0.0s
Attaching to otel-collector-1
otel-collector-1  | 2024-10-09T14:22:14.184Z	info	service@v0.111.0/service.go:136	Setting up own telemetry...
otel-collector-1  | 2024-10-09T14:22:14.184Z	info	telemetry/metrics.go:70	Serving metrics	{"address": "localhost:8888", "metrics level": "Normal"}
otel-collector-1  | 2024-10-09T14:22:14.184Z	info	builders/builders.go:26	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
otel-collector-1  | 2024-10-09T14:22:14.185Z	info	builders/builders.go:26	Development component. May change in the future.	{"kind": "exporter", "data_type": "traces", "name": "debug"}
otel-collector-1  | 2024-10-09T14:22:14.185Z	info	builders/builders.go:26	Development component. May change in the future.	{"kind": "exporter", "data_type": "logs", "name": "debug"}
otel-collector-1  | 2024-10-09T14:22:14.185Z	info	service@v0.111.0/service.go:208	Starting otelcol-contrib...	{"Version": "0.111.0", "NumCPU": 10}
otel-collector-1  | 2024-10-09T14:22:14.185Z	info	extensions/extensions.go:39	Starting extensions...
otel-collector-1  | 2024-10-09T14:22:14.185Z	warn	internal@v0.111.0/warning.go:40	Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks.	{"kind": "receiver", "name": "otlp", "data_type": "traces", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
otel-collector-1  | 2024-10-09T14:22:14.185Z	info	otlpreceiver@v0.111.0/otlp.go:112	Starting GRPC server	{"kind": "receiver", "name": "otlp", "data_type": "traces", "endpoint": "0.0.0.0:4317"}
otel-collector-1  | 2024-10-09T14:22:14.186Z	warn	internal@v0.111.0/warning.go:40	Using the 0.0.0.0 address exposes this server to every network interface, which may facilitate Denial of Service attacks.	{"kind": "receiver", "name": "otlp", "data_type": "traces", "documentation": "https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks"}
otel-collector-1  | 2024-10-09T14:22:14.186Z	info	otlpreceiver@v0.111.0/otlp.go:169	Starting HTTP server	{"kind": "receiver", "name": "otlp", "data_type": "traces", "endpoint": "0.0.0.0:4318"}
otel-collector-1  | 2024-10-09T14:22:14.186Z	info	service@v0.111.0/service.go:234	Everything is ready. Begin running and processing data.
```