### PR TITLE
feat: language plugins require a bind allocator to be provided

### DIFF
--- a/backend/controller/admin/admin.go
+++ b/backend/controller/admin/admin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"connectrpc.com/connect"
+	"github.com/alecthomas/types/optional"
 
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
@@ -16,7 +17,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/schema"
-	"github.com/alecthomas/types/optional"
 )
 
 type AdminService struct {

--- a/backend/controller/admin/admin.go
+++ b/backend/controller/admin/admin.go
@@ -30,9 +30,12 @@ type AdminService struct {
 var _ ftlv1connect.AdminServiceHandler = (*AdminService)(nil)
 
 type SchemaRetriever interface {
+	// BindAllocator is required if the schema is retrieved from disk using language plugins
 	GetActiveSchema(ctx context.Context, bindAllocator optional.Option[*bind.BindAllocator]) (*schema.Schema, error)
 }
 
+// NewAdminService creates a new AdminService.
+// bindAllocator is optional and should be set if a local client is to be used that accesses schema from disk using language plugins.
 func NewAdminService(cm *manager.Manager[configuration.Configuration], sm *manager.Manager[configuration.Secrets], schr SchemaRetriever, bindAllocator optional.Option[*bind.BindAllocator]) *AdminService {
 	return &AdminService{
 		schr:          schr,

--- a/backend/controller/admin/admin_test.go
+++ b/backend/controller/admin/admin_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/configuration"
 	"github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
@@ -35,7 +36,7 @@ func TestAdminService(t *testing.T) {
 			providers.Inline[configuration.Secrets]{},
 		})
 	assert.NoError(t, err)
-	admin := NewAdminService(cm, sm, &diskSchemaRetriever{})
+	admin := NewAdminService(cm, sm, &diskSchemaRetriever{}, optional.None[*bind.BindAllocator]())
 	assert.NotZero(t, admin)
 
 	expectedEnvarValue, err := json.MarshalIndent(map[string]string{"bar": "barfoo"}, "", "  ")
@@ -199,7 +200,7 @@ var testSchema = schema.MustValidate(&schema.Schema{
 type mockSchemaRetriever struct {
 }
 
-func (d *mockSchemaRetriever) GetActiveSchema(ctx context.Context) (*schema.Schema, error) {
+func (d *mockSchemaRetriever) GetActiveSchema(ctx context.Context, bindAllocator optional.Option[*bind.BindAllocator]) (*schema.Schema, error) {
 	return testSchema, nil
 }
 
@@ -217,7 +218,7 @@ func TestAdminValidation(t *testing.T) {
 			providers.Inline[configuration.Secrets]{},
 		})
 	assert.NoError(t, err)
-	admin := NewAdminService(cm, sm, &mockSchemaRetriever{})
+	admin := NewAdminService(cm, sm, &mockSchemaRetriever{}, optional.None[*bind.BindAllocator]())
 	assert.NotZero(t, admin)
 
 	testSetConfig(t, ctx, admin, "batmobile", "color", "Black", "")

--- a/backend/controller/admin/local_client_test.go
+++ b/backend/controller/admin/local_client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/types/optional"
 
+	"github.com/TBD54566975/ftl/internal/bind"
 	cf "github.com/TBD54566975/ftl/internal/configuration"
 	"github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
@@ -25,7 +26,7 @@ func TestDiskSchemaRetrieverWithBuildArtefact(t *testing.T) {
 		in.Build("dischema"),
 		func(t testing.TB, ic in.TestContext) {
 			dsr := &diskSchemaRetriever{deployRoot: optional.Some[string](ic.WorkingDir())}
-			sch, err := dsr.GetActiveSchema(ic.Context)
+			sch, err := dsr.GetActiveSchema(ic.Context, optional.None[*bind.BindAllocator]())
 			assert.NoError(t, err)
 
 			module, ok := sch.Module("dischema").Get()
@@ -42,7 +43,7 @@ func TestDiskSchemaRetrieverWithNoSchema(t *testing.T) {
 		in.CopyModule("dischema"),
 		func(t testing.TB, ic in.TestContext) {
 			dsr := &diskSchemaRetriever{}
-			_, err := dsr.GetActiveSchema(ic.Context)
+			_, err := dsr.GetActiveSchema(ic.Context, optional.None[*bind.BindAllocator]())
 			assert.Error(t, err)
 		},
 	)
@@ -64,10 +65,10 @@ func TestAdminNoValidationWithNoSchema(t *testing.T) {
 	assert.NoError(t, err)
 
 	dsr := &diskSchemaRetriever{deployRoot: optional.Some(string(t.TempDir()))}
-	_, err = dsr.GetActiveSchema(ctx)
+	_, err = dsr.GetActiveSchema(ctx, optional.None[*bind.BindAllocator]())
 	assert.Error(t, err)
 
-	admin := NewAdminService(cm, sm, dsr)
+	admin := NewAdminService(cm, sm, dsr, optional.None[*bind.BindAllocator]())
 	testSetConfig(t, ctx, admin, "batmobile", "color", "Red", "")
 	testSetSecret(t, ctx, admin, "batmobile", "owner", 99, "")
 }

--- a/backend/controller/admin/local_client_test.go
+++ b/backend/controller/admin/local_client_test.go
@@ -4,6 +4,7 @@ package admin
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -16,7 +17,19 @@ import (
 	"github.com/TBD54566975/ftl/internal/configuration/routers"
 	in "github.com/TBD54566975/ftl/internal/integration"
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/schema"
 )
+
+func getDiskSchema(t testing.TB, ctx context.Context) (*schema.Schema, error) {
+	t.Helper()
+
+	bindURL, err := url.Parse("http://127.0.0.1:8893")
+	assert.NoError(t, err)
+	bindAllocator, err := bind.NewBindAllocator(bindURL)
+	assert.NoError(t, err)
+	dsr := &diskSchemaRetriever{}
+	return dsr.GetActiveSchema(ctx, optional.Some(bindAllocator))
+}
 
 func TestDiskSchemaRetrieverWithBuildArtefact(t *testing.T) {
 	in.Run(t,
@@ -25,8 +38,7 @@ func TestDiskSchemaRetrieverWithBuildArtefact(t *testing.T) {
 		in.CopyModule("dischema"),
 		in.Build("dischema"),
 		func(t testing.TB, ic in.TestContext) {
-			dsr := &diskSchemaRetriever{deployRoot: optional.Some[string](ic.WorkingDir())}
-			sch, err := dsr.GetActiveSchema(ic.Context, optional.None[*bind.BindAllocator]())
+			sch, err := getDiskSchema(t, ic.Context)
 			assert.NoError(t, err)
 
 			module, ok := sch.Module("dischema").Get()
@@ -42,8 +54,7 @@ func TestDiskSchemaRetrieverWithNoSchema(t *testing.T) {
 		in.WithoutController(),
 		in.CopyModule("dischema"),
 		func(t testing.TB, ic in.TestContext) {
-			dsr := &diskSchemaRetriever{}
-			_, err := dsr.GetActiveSchema(ic.Context, optional.None[*bind.BindAllocator]())
+			_, err := getDiskSchema(t, ic.Context)
 			assert.Error(t, err)
 		},
 	)

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -57,6 +57,7 @@ import (
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	frontend "github.com/TBD54566975/ftl/frontend/console"
+	"github.com/TBD54566975/ftl/internal/bind"
 	cf "github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/cors"
 	ftlhttp "github.com/TBD54566975/ftl/internal/http"
@@ -161,7 +162,7 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 	cm := cf.ConfigFromContext(ctx)
 	sm := cf.SecretsFromContext(ctx)
 
-	admin := admin.NewAdminService(cm, sm, svc.dal)
+	admin := admin.NewAdminService(cm, sm, svc.dal, optional.None[*bind.BindAllocator]())
 	console := console.NewService(svc.dal, svc.timeline)
 
 	ingressHandler := otelhttp.NewHandler(http.Handler(svc), "ftl.ingress")

--- a/backend/controller/dal/dal.go
+++ b/backend/controller/dal/dal.go
@@ -22,6 +22,7 @@ import (
 	"github.com/TBD54566975/ftl/backend/controller/pubsub"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltypes"
 	"github.com/TBD54566975/ftl/backend/libdal"
+	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/maps"
 	"github.com/TBD54566975/ftl/internal/model"
@@ -573,7 +574,7 @@ func (d *DAL) GetActiveDeployments(ctx context.Context) ([]dalmodel.Deployment, 
 }
 
 // GetActiveSchema returns the schema for all active deployments.
-func (d *DAL) GetActiveSchema(ctx context.Context) (*schema.Schema, error) {
+func (d *DAL) GetActiveSchema(ctx context.Context, bindAllocator optional.Option[*bind.BindAllocator]) (*schema.Schema, error) {
 	deployments, err := d.GetActiveDeployments(ctx)
 	if err != nil {
 		return nil, err

--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,7 +1,7 @@
 env = {
   "DBMATE_MIGRATIONS_DIR": "${HERMIT_ENV}/backend/controller/sql/schema",
   "DBMATE_NO_DUMP_SCHEMA": "true",
-  "FTL_ENDPOINT": "http://localhost:8892",
+  "FTL_ENDPOINT": "http://127.0.0.1:8892",
   "FTL_INIT_GO_REPLACE": "github.com/TBD54566975/ftl=${HERMIT_ENV}",
   "FTL_SOURCE": "${HERMIT_ENV}",
   "OTEL_GRPC_PORT": "4317",

--- a/frontend/cli/cmd_new.go
+++ b/frontend/cli/cmd_new.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"go/token"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -54,14 +53,13 @@ func prepareNewCmd(ctx context.Context, k *kong.Kong, args []string) (optionalPl
 		return optionalPlugin, fmt.Errorf("could not find new command")
 	}
 
-	bindURL, err := url.Parse("http://127.0.0.1:8892")
-	if err != nil {
-		return optionalPlugin, fmt.Errorf("could not parse port to bind on: %w", err)
-	}
-	bindAllocator, err := bind.NewBindAllocator(bindURL)
+	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
+	var bindAllocator *bind.BindAllocator
+	bindAllocator, err = bind.NewBindAllocator(cli.Endpoint)
 	if err != nil {
 		return optionalPlugin, fmt.Errorf("could not create bind allocator: %w", err)
 	}
+	_ = bindAllocator.Next()
 
 	plugin, err := languageplugin.New(ctx, bindAllocator, language)
 	if err != nil {

--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -40,8 +40,7 @@ import (
 )
 
 type serveCmd struct {
-	// TODO: update comment
-	Bind                *url.URL             `help:"Starting endpoint to bind to and advertise to. Each controller, ingress and runner will increment the port by 1" default:"http://127.0.0.1:8891"`
+	Bind                *url.URL             `help:"Starting endpoint to bind to and advertise to. Each controller, ingress, runner and language plugin will increment the port by 1" default:"http://127.0.0.1:8891"`
 	DBPort              int                  `help:"Port to use for the database." default:"15432"`
 	Recreate            bool                 `help:"Recreate the database even if it already exists." default:"false"`
 	Controllers         int                  `short:"c" help:"Number of controllers to start." default:"1"`

--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -40,6 +40,7 @@ import (
 )
 
 type serveCmd struct {
+	// TODO: update comment
 	Bind                *url.URL             `help:"Starting endpoint to bind to and advertise to. Each controller, ingress and runner will increment the port by 1" default:"http://127.0.0.1:8891"`
 	DBPort              int                  `help:"Port to use for the database." default:"15432"`
 	Recreate            bool                 `help:"Recreate the database even if it already exists." default:"false"`

--- a/frontend/cli/main.go
+++ b/frontend/cli/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner/provisionerconnect"
 	"github.com/TBD54566975/ftl/internal"
 	_ "github.com/TBD54566975/ftl/internal/automaxprocs" // Set GOMAXPROCS to match Linux container CPU quota.
+	"github.com/TBD54566975/ftl/internal/buildengine/languageplugin"
 	"github.com/TBD54566975/ftl/internal/configuration"
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -82,10 +83,18 @@ var cli CLI
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	csm := &currentStatusManager{}
+
 	app := createKongApplication(&cli, csm)
-	app.FatalIfErrorf(prepareNewCmd(ctx, app, os.Args[1:]))
+	languagePlugin, err := prepareNewCmd(ctx, app, os.Args[1:])
+	app.FatalIfErrorf(err)
+
 	kctx, err := app.Parse(os.Args[1:])
 	app.FatalIfErrorf(err)
+
+	if plugin, ok := languagePlugin.Get(); ok {
+		// for "ftl new" command, we only need to create the language plugin once
+		kctx.BindTo(plugin, (*languageplugin.LanguagePlugin)(nil))
+	}
 
 	if !cli.Plain {
 		sm := terminal.NewStatusManager(ctx)

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine/languageplugin"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/moduleconfig"
@@ -82,6 +83,7 @@ type Listener interface {
 // Engine for building a set of modules.
 type Engine struct {
 	client           DeployClient
+	bindAllocator    *bind.BindAllocator
 	moduleMetas      *xsync.MapOf[string, moduleMeta]
 	projectRoot      string
 	moduleDirs       []string
@@ -863,7 +865,7 @@ func (e *Engine) gatherSchemas(
 }
 
 func (e *Engine) newModuleMeta(ctx context.Context, config moduleconfig.UnvalidatedModuleConfig) (moduleMeta, error) {
-	plugin, err := languageplugin.New(ctx, config.Language)
+	plugin, err := languageplugin.New(ctx, e.bindAllocator, config.Language)
 	if err != nil {
 		return moduleMeta{}, fmt.Errorf("could not create plugin for %s: %w", config.Module, err)
 	}

--- a/internal/buildengine/languageplugin/go_plugin_test.go
+++ b/internal/buildengine/languageplugin/go_plugin_test.go
@@ -32,7 +32,7 @@ func TestExtractModuleDepsGo(t *testing.T) {
 	uncheckedConfig, err := moduleconfig.LoadConfig(dir)
 	assert.NoError(t, err)
 
-	plugin, err := New(ctx, uncheckedConfig.Language)
+	plugin, err := New(ctx, nil, uncheckedConfig.Language)
 	assert.NoError(t, err)
 
 	customDefaults, err := plugin.ModuleConfigDefaults(ctx, uncheckedConfig.Dir)
@@ -85,7 +85,7 @@ func TestGoConfigDefaults(t *testing.T) {
 			dir, err := filepath.Abs(tt.dir)
 			assert.NoError(t, err)
 
-			plugin, err := New(ctx, "go")
+			plugin, err := New(ctx, nil, "go")
 			assert.NoError(t, err)
 
 			defaults, err := plugin.ModuleConfigDefaults(ctx, dir)

--- a/internal/buildengine/languageplugin/java_plugin_test.go
+++ b/internal/buildengine/languageplugin/java_plugin_test.go
@@ -62,7 +62,7 @@ func TestJavaConfigDefaults(t *testing.T) {
 			dir, err := filepath.Abs(tt.dir)
 			assert.NoError(t, err)
 
-			plugin, err := New(ctx, "java")
+			plugin, err := New(ctx, nil, "java")
 			assert.NoError(t, err)
 
 			defaults, err := plugin.ModuleConfigDefaults(ctx, dir)

--- a/internal/buildengine/languageplugin/plugin.go
+++ b/internal/buildengine/languageplugin/plugin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/alecthomas/types/either"
 	"github.com/alecthomas/types/pubsub"
 
+	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/builderrors"
 	"github.com/TBD54566975/ftl/internal/flock"
 	"github.com/TBD54566975/ftl/internal/moduleconfig"
@@ -90,7 +91,7 @@ type LanguagePlugin interface {
 }
 
 // PluginFromConfig creates a new language plugin from the given config.
-func New(ctx context.Context, language string) (p LanguagePlugin, err error) {
+func New(ctx context.Context, bindAllocator *bind.BindAllocator, language string) (p LanguagePlugin, err error) {
 	switch language {
 	case "go":
 		return newGoPlugin(ctx), nil


### PR DESCRIPTION
This is a prerequisite for external language plugins. This PR makes sure `languageplugin.New()` is called with a bind allocator so that external plugins will soon able to able to acquire a bind url.