### PR TITLE
fix: ftltest.Call always allows direct initial verb

### DIFF
--- a/go-runtime/ftl/ftltest/testdata/go/verbtypes/verbtypes_test.go
+++ b/go-runtime/ftl/ftltest/testdata/go/verbtypes/verbtypes_test.go
@@ -100,7 +100,6 @@ func TestVerbErrors(t *testing.T) {
 
 func TestTransitiveVerbMock(t *testing.T) {
 	ctx := ftltest.Context(
-		ftltest.WithCallsAllowedWithinModule(),
 		ftltest.WhenVerb[CalleeVerbClient](func(ctx context.Context, req Request) (Response, error) {
 			return Response{Output: fmt.Sprintf("mocked: %s", req.Input)}, nil
 		}),

--- a/go-runtime/ftl/ftltest/testdata/go/wrapped/wrapped_test.go
+++ b/go-runtime/ftl/ftltest/testdata/go/wrapped/wrapped_test.go
@@ -76,7 +76,7 @@ func TestWrapped(t *testing.T) {
 			},
 			configValue:   "helloworld",
 			secretValue:   "shhhhh",
-			expectedError: ftl.Some("test harness failed to retrieve behavior for verb wrapped.outer: no mock found: provide a mock with ftltest.WhenVerb(Outer, ...) or enable all calls within the module with ftltest.WithCallsAllowedWithinModule()"),
+			expectedError: ftl.Some("test harness failed to call verb wrapped.outer: wrapped.inner: no mock found: provide a mock with ftltest.WhenVerb(Inner, ...) or enable all calls within the module with ftltest.WithCallsAllowedWithinModule()"),
 		},
 		{
 			name: "AllowCallsWithinModule",

--- a/internal/modulecontext/module_context.go
+++ b/internal/modulecontext/module_context.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
 	"github.com/alecthomas/atomic"
 	"github.com/alecthomas/types/optional"
 	_ "github.com/jackc/pgx/v5/stdlib" // SQL driver
@@ -19,6 +18,7 @@ import (
 
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
 	"github.com/TBD54566975/ftl/internal/reflect"
 	"github.com/TBD54566975/ftl/internal/rpc"
 	"github.com/TBD54566975/ftl/internal/schema"


### PR DESCRIPTION
when using ftltest.Call, you don't need to mock the verb directly invoked. only downstream verbs must be mocked (or overridden by setting WithCallsAllowedWithinModule globally)

https://sq-tbd.slack.com/archives/C04PEQERFM0/p1727995042643089

fixes #2984