### PR TITLE
feat: add DD trace id to the logs

### DIFF
--- a/backend/controller/observability/calls.go
+++ b/backend/controller/observability/calls.go
@@ -60,7 +60,7 @@ func (m *CallMetrics) BeginSpan(ctx context.Context, verb *schemapb.Ref) (contex
 	attrs := []attribute.KeyValue{
 		attribute.String(callVerbRefAttr, schema.RefFromProto(verb).String()),
 	}
-	return m.callTracer.Start(ctx, callMeterName, trace.WithAttributes(attrs...))
+	return observability.AddSpanToLogger(m.callTracer.Start(ctx, callMeterName, trace.WithAttributes(attrs...)))
 }
 func (m *CallMetrics) Request(ctx context.Context, verb *schemapb.Ref, startTime time.Time, maybeFailureMode optional.Option[string]) {
 	attrs := []attribute.KeyValue{

--- a/backend/controller/observability/controller.go
+++ b/backend/controller/observability/controller.go
@@ -6,6 +6,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/TBD54566975/ftl/internal/observability"
 )
 
 const (
@@ -30,5 +32,5 @@ func (m *ControllerTracing) BeginSpan(ctx context.Context, name string) (context
 	attrs := []attribute.KeyValue{
 		attribute.String(operation, name),
 	}
-	return m.polling.Start(ctx, controllerPollingOperation, trace.WithAttributes(attrs...))
+	return observability.AddSpanToLogger(m.polling.Start(ctx, controllerPollingOperation, trace.WithAttributes(attrs...)))
 }

--- a/backend/runner/runner.go
+++ b/backend/runner/runner.go
@@ -35,6 +35,7 @@ import (
 	"github.com/TBD54566975/ftl/internal/identity"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/model"
+	ftlobservability "github.com/TBD54566975/ftl/internal/observability"
 	"github.com/TBD54566975/ftl/internal/rpc"
 	"github.com/TBD54566975/ftl/internal/schema"
 	"github.com/TBD54566975/ftl/internal/slices"
@@ -516,6 +517,7 @@ func (s *Service) getDeploymentLogger(ctx context.Context, deploymentKey model.D
 	if requestKey, _ := rpc.RequestKeyFromContext(ctx); requestKey.Ok() { //nolint:errcheck // best effort
 		attrs["request"] = requestKey.MustGet().String()
 	}
+	ctx = ftlobservability.AddSpanContextToLogger(ctx)
 
 	sink := newDeploymentLogsSink(s.deploymentLogQueue)
 	return log.FromContext(ctx).AddSink(sink).Attrs(attrs)

--- a/go-runtime/server/server.go
+++ b/go-runtime/server/server.go
@@ -79,6 +79,7 @@ func HandleCall[Req, Resp any](verb any) Handler {
 			if err != nil {
 				return nil, fmt.Errorf("invalid request to verb %s: %w", ref, err)
 			}
+			ctx = observability.AddSpanContextToLogger(ctx)
 
 			// Call Verb.
 			resp, err := Call[Req, Resp](ref)(ctx, req)

--- a/internal/observability/logger.go
+++ b/internal/observability/logger.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/go-logr/logr"
-
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/TBD54566975/ftl/internal/log"


### PR DESCRIPTION
Only works for the go runtime at the moment, as the JVM logging needs to be cleaned up to match the go format.

fixes: #3105