### PR TITLE
fix: cron and pubsub verb forms and test

### DIFF
--- a/frontend/console/e2e/cron.spec.ts
+++ b/frontend/console/e2e/cron.spec.ts
@@ -1,23 +1,19 @@
 import { expect, test } from '@playwright/test'
 import { navigateToDecl } from './helpers'
 
-test('shows echo verb form', async ({ page }) => {
-  await navigateToDecl(page, 'echo', 'echo')
+test('shows cron verb form', async ({ page }) => {
+  await navigateToDecl(page, 'cron', 'thirtySeconds')
 
-  await expect(page.getByText('CALL', { exact: true })).toBeVisible()
-  await expect(page.locator('input#request-path')).toHaveValue('echo.echo')
+  await expect(page.getByText('CRON', { exact: true })).toBeVisible()
+  await expect(page.locator('input#request-path')).toHaveValue('cron.thirtySeconds')
 
   await expect(page.getByText('Body', { exact: true })).toBeVisible()
   await expect(page.getByText('Verb Schema', { exact: true })).toBeVisible()
   await expect(page.getByText('JSONSchema', { exact: true })).toBeVisible()
 })
 
-test('send echo request', async ({ page }) => {
-  await navigateToDecl(page, 'echo', 'echo')
-
-  const bodyEditor = page.locator('#body-editor .cm-content[contenteditable="true"]')
-  await expect(bodyEditor).toBeVisible()
-  await bodyEditor.fill('{\n  "name": "wicket"\n}')
+test('send cron request', async ({ page }) => {
+  await navigateToDecl(page, 'cron', 'thirtySeconds')
 
   await page.getByRole('button', { name: 'Send' }).click()
 
@@ -27,6 +23,5 @@ test('send echo request', async ({ page }) => {
   const responseText = await responseEditor.textContent()
   const responseJson = JSON.parse(responseText?.trim() || '{}')
 
-  const expectedStart = 'Hello, wicket!!! It is '
-  expect(responseJson.message.startsWith(expectedStart)).toBe(true)
+  expect(responseJson).toEqual({})
 })

--- a/frontend/console/e2e/pubsub.spec.ts
+++ b/frontend/console/e2e/pubsub.spec.ts
@@ -1,23 +1,23 @@
 import { expect, test } from '@playwright/test'
 import { navigateToDecl } from './helpers'
 
-test('shows echo verb form', async ({ page }) => {
-  await navigateToDecl(page, 'echo', 'echo')
+test('shows pubsub verb form', async ({ page }) => {
+  await navigateToDecl(page, 'pubsub', 'cookPizza')
 
-  await expect(page.getByText('CALL', { exact: true })).toBeVisible()
-  await expect(page.locator('input#request-path')).toHaveValue('echo.echo')
+  await expect(page.getByText('SUB', { exact: true })).toBeVisible()
+  await expect(page.locator('input#request-path')).toHaveValue('pubsub.cookPizza')
 
   await expect(page.getByText('Body', { exact: true })).toBeVisible()
   await expect(page.getByText('Verb Schema', { exact: true })).toBeVisible()
   await expect(page.getByText('JSONSchema', { exact: true })).toBeVisible()
 })
 
-test('send echo request', async ({ page }) => {
-  await navigateToDecl(page, 'echo', 'echo')
+test('send pubsub request', async ({ page }) => {
+  await navigateToDecl(page, 'pubsub', 'cookPizza')
 
   const bodyEditor = page.locator('#body-editor .cm-content[contenteditable="true"]')
   await expect(bodyEditor).toBeVisible()
-  await bodyEditor.fill('{\n  "name": "wicket"\n}')
+  await bodyEditor.fill('{\n  "customer": "wicket",\n"id":123,\n  "type":"cheese"\n}')
 
   await page.getByRole('button', { name: 'Send' }).click()
 
@@ -27,6 +27,5 @@ test('send echo request', async ({ page }) => {
   const responseText = await responseEditor.textContent()
   const responseJson = JSON.parse(responseText?.trim() || '{}')
 
-  const expectedStart = 'Hello, wicket!!! It is '
-  expect(responseJson.message.startsWith(expectedStart)).toBe(true)
+  expect(responseJson).toEqual({})
 })


### PR DESCRIPTION
Sending on the `cron` and `pubsub` verbs was broken due to invalid "path" in the form. This fixes it and adds a quick test to make sure it stays working.

![Screenshot 2024-10-15 at 1 40 21 PM](https://github.com/user-attachments/assets/8ccfccd5-5041-48a4-be7f-a8e030daaa84)
![Screenshot 2024-10-15 at 1 40 38 PM](https://github.com/user-attachments/assets/3504595d-c56e-4498-851d-6c57e03702ac)
