### PR TITLE
fix: typealias case issues in icons and urls

### DIFF
--- a/frontend/console/src/features/command-pallete/CommandPalette.tsx
+++ b/frontend/console/src/features/command-pallete/CommandPalette.tsx
@@ -25,20 +25,23 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
     }
   }, [schemaData])
 
-  const fuse = useMemo(() => {
-    return new Fuse(items, {
-      keys: ['title', { name: 'subtitle', weight: 1 }],
-      minMatchCharLength: 2,
-      fieldNormWeight: 2,
-    })
-  }, [items])
+  const fuseOptions = {
+    keys: ['title', { name: 'subtitle', weight: 1 }],
+    minMatchCharLength: 2,
+    fieldNormWeight: 2,
+  }
+
+  const fuseIndex = useMemo(() => Fuse.createIndex(fuseOptions.keys, items), [items])
+  const fuse = useMemo(() => new Fuse(items, fuseOptions, fuseIndex), [items, fuseIndex])
 
   useEffect(() => {
     if (query === '') {
       setFilteredItems([])
     } else {
       const results = fuse.search(query).map((result) => result.item)
-      setFilteredItems(results)
+
+      // only show first 25 results
+      setFilteredItems(results.slice(0, 25))
     }
   }, [query, fuse])
 

--- a/frontend/console/src/features/command-pallete/command-palette.utils.ts
+++ b/frontend/console/src/features/command-pallete/command-palette.utils.ts
@@ -1,6 +1,6 @@
 import { CellsIcon, type HugeiconsProps } from 'hugeicons-react'
 import type { PullSchemaResponse } from '../../protos/xyz/block/ftl/v1/ftl_pb'
-import { declIcons, declUrl } from '../modules/module.utils'
+import { declIcon, declUrl } from '../modules/module.utils'
 
 export interface PaletteItem {
   id: string
@@ -29,7 +29,7 @@ export const paletteItems = (schema: PullSchemaResponse[]): PaletteItem[] => {
 
       items.push({
         id: `${module.moduleName}-${decl.value.value.name}`,
-        icon: declIcons[decl.value.case],
+        icon: declIcon(decl.value.case),
         title: decl.value.value.name,
         subtitle: `${module.moduleName}.${decl.value.value.name}`,
         url: declUrl(module.moduleName, decl),
@@ -39,7 +39,7 @@ export const paletteItems = (schema: PullSchemaResponse[]): PaletteItem[] => {
         for (const field of decl.value.value.fields) {
           items.push({
             id: `${module.moduleName}-${decl.value.value.name}-${field.name}`,
-            icon: declIcons[decl.value.case],
+            icon: declIcon(decl.value.case),
             title: field.name,
             subtitle: `${module.moduleName}.${decl.value.value.name}.${field.name}`,
             url: declUrl(module.moduleName, decl),

--- a/frontend/console/src/features/modules/ModulesTree.tsx
+++ b/frontend/console/src/features/modules/ModulesTree.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight01Icon, ArrowShrink02Icon, CircleArrowRight02Icon, CodeIcon, FileExportIcon, PackageIcon } from 'hugeicons-react'
+import { ArrowRight01Icon, ArrowShrink02Icon, CircleArrowRight02Icon, FileExportIcon, PackageIcon } from 'hugeicons-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { Multiselect, sortMultiselectOpts } from '../../components/Multiselect'
@@ -9,7 +9,7 @@ import {
   type DeclInfo,
   addModuleToLocalStorageIfMissing,
   collapseAllModulesInLocalStorage,
-  declIcons,
+  declIcon,
   declSumTypeIsExported,
   declUrlFromInfo,
   listExpandedModulesFromLocalStorage,
@@ -38,7 +38,7 @@ const DeclNode = ({ decl, href, isSelected }: { decl: DeclInfo; href: string; is
     }
   }, [isSelected])
 
-  const Icon = useMemo(() => declIcons[decl.declType || ''] || CodeIcon, [decl.declType])
+  const Icon = useMemo(() => declIcon(decl.declType), [decl.declType])
   return (
     <li className='my-1'>
       <div

--- a/frontend/console/src/features/modules/module.utils.ts
+++ b/frontend/console/src/features/modules/module.utils.ts
@@ -75,6 +75,7 @@ export type DeclSumType = Config | Data | Database | Enum | FSM | Topic | TypeAl
 export interface DeclInfo {
   declType: string
   value: DeclSumType
+  decl: Decl
 }
 
 export interface ModuleTreeItem {
@@ -92,7 +93,7 @@ export const moduleTreeFromStream = (modules: Module[]) => {
         deploymentKey: module.deploymentKey,
         isBuiltin: module.name === 'builtin',
         decls: [
-          ...module.configs.map((d) => ({ declType: 'config', value: d.config })),
+          ...module.configs.map((d) => ({ declType: 'config', value: d.config, decl: d })),
           ...module.secrets.map((d) => ({ declType: 'secret', value: d.secret })),
           ...module.databases.map((d) => ({ declType: 'database', value: d.database })),
           ...module.topics.map((d) => ({ declType: 'topic', value: d.topic })),
@@ -167,21 +168,30 @@ export const addModuleToLocalStorageIfMissing = (moduleName?: string) => {
 
 export const collapseAllModulesInLocalStorage = () => localStorage.setItem('tree_m', '')
 
-type IconMap = Record<string, React.FC<Omit<HugeiconsProps, 'ref'> & React.RefAttributes<SVGSVGElement>>>
-export const declIcons: IconMap = {
-  config: Settings02Icon,
-  data: CodeIcon,
-  database: DatabaseIcon,
-  enum: LeftToRightListNumberIcon,
-  fsm: FlowIcon,
-  topic: BubbleChatIcon,
-  typealias: AnonymousIcon,
-  secret: SquareLock02Icon,
-  subscription: MessageIncoming02Icon,
-  verb: FunctionIcon,
+export const declIcon = (declCase?: string) => {
+  const declIcons: Record<string, React.FC<Omit<HugeiconsProps, 'ref'> & React.RefAttributes<SVGSVGElement>>> = {
+    config: Settings02Icon,
+    data: CodeIcon,
+    database: DatabaseIcon,
+    enum: LeftToRightListNumberIcon,
+    fsm: FlowIcon,
+    topic: BubbleChatIcon,
+    typealias: AnonymousIcon,
+    secret: SquareLock02Icon,
+    subscription: MessageIncoming02Icon,
+    verb: FunctionIcon,
+  }
+
+  const normalizedDeclCase = declCase?.toLowerCase()
+  if (!normalizedDeclCase || !declIcons[normalizedDeclCase]) {
+    console.warn(`No icon for decl case: ${declCase}`)
+    return CodeIcon
+  }
+
+  return declIcons[normalizedDeclCase]
 }
 
-export const declUrl = (moduleName: string, decl: Decl) => `/modules/${moduleName}/${decl.value.case}/${decl.value.value?.name}`
+export const declUrl = (moduleName: string, decl: Decl) => `/modules/${moduleName}/${decl.value.case?.toLowerCase()}/${decl.value.value?.name}`
 
 export const declUrlFromInfo = (moduleName: string, decl: DeclInfo) => `/modules/${moduleName}/${decl.declType}/${decl.value.name}`
 


### PR DESCRIPTION
- Fixes issues with `CommandPallete` erroring when `typeAlias` is used since we had `typealias` in the icons list
- Fixes issues with urls that have `module/typealias/declName` in them vs. `module/typeAlias/declName`
- Performance improvements on `CommandPallete` searching/filtering.

See also #3146