### PR TITLE
feat: support ftl.Map on injected resources

### DIFF
--- a/backend/controller/sql/database_integration_test.go
+++ b/backend/controller/sql/database_integration_test.go
@@ -27,6 +27,20 @@ func TestDatabase(t *testing.T) {
 	)
 }
 
+func TestMappedDatabase(t *testing.T) {
+	in.Run(t,
+		// only run this for the Go module, testing the ftl.MappedHandle feature
+		in.WithLanguages("go"),
+		in.WithFTLConfig("database/ftl-project.toml"),
+		// deploy real module against "testdb"
+		in.CopyModule("database"),
+		in.CreateDBAction("database", "testdb", false),
+		in.Deploy("database"),
+		in.Call[in.Obj, in.Obj]("database", "mapped", in.Obj{"data": "hello"}, nil),
+		in.QueryRow("testdb", "SELECT data FROM requests", "hello"),
+	)
+}
+
 func TestMigrate(t *testing.T) {
 	dbName := "ftl_test"
 	dbUri := dsn.DSN(dbName)

--- a/backend/controller/sql/testdata/go/database/types.ftl.go
+++ b/backend/controller/sql/testdata/go/database/types.ftl.go
@@ -9,12 +9,18 @@ import (
 
 type InsertClient func(context.Context, InsertRequest) (InsertResponse, error)
 
+type MappedClient func(context.Context, InsertRequest) (InsertResponse, error)
+
 func init() {
 	reflection.Register(
-		reflection.Database[MyDbConfig](server.InitPostgres),
+		reflection.Database[MyDBConfig]("testdb", server.InitPostgres),
 		reflection.ProvideResourcesForVerb(
 			Insert,
-			server.PostgresDatabaseHandle[MyDbConfig](),
+			server.PostgresDatabaseHandle[MyDBConfig](),
+		),
+		reflection.ProvideResourcesForVerb(
+			Mapped,
+			server.MappedHandle[MyDBMapper](server.PostgresDatabaseHandle[MyDBConfig]()),
 		),
 	)
 }

--- a/go-runtime/compile/build-template/.ftl.tmpl/go/main/main.go.tmpl
+++ b/go-runtime/compile/build-template/.ftl.tmpl/go/main/main.go.tmpl
@@ -34,22 +34,7 @@ func init() {
 		reflection.ProvideResourcesForVerb(
             {{.TypeName}},
             {{- range .Resources}}
-                {{- with getVerbClient . }}
-            	{{- if and (eq .Request.TypeName "ftl.Unit") (eq .Response.TypeName "ftl.Unit") }}
-            server.EmptyClient[{{.TypeName}}](),
-            	{{- else if eq .Request.TypeName "ftl.Unit" }}
-            server.SourceClient[{{.TypeName}}, {{.Response.TypeName}}](),
-            	{{- else if eq .Response.TypeName "ftl.Unit" }}
-            server.SinkClient[{{.TypeName}}, {{.Request.TypeName}}](),
-            	{{- else }}
-            server.VerbClient[{{.TypeName}}, {{.Request.TypeName}}, {{.Response.TypeName}}](),
-            	{{- end -}}
-                {{- end }}
-                {{- with getDatabaseHandle . }}
-                	{{- if eq .Type "postgres" }}
-			server.PostgresDatabaseHandle[{{.TypeName}}](),
-                	{{- end }}
-                {{- end }}
+            {{ getResourceProvider "" . false }},
 			{{- end}}
 		),
 {{- end}}

--- a/go-runtime/compile/build-template/types.ftl.go.tmpl
+++ b/go-runtime/compile/build-template/types.ftl.go.tmpl
@@ -52,24 +52,7 @@ func init() {
 		reflection.ProvideResourcesForVerb(
             {{ trimModuleQualifier $moduleName .TypeName }},
             {{- range .Resources}}
-                {{- with getVerbClient . }}
-            	{{- $verb := trimModuleQualifier $moduleName .TypeName -}}
-
-            	{{ if and (eq .Request.TypeName "ftl.Unit") (eq .Response.TypeName "ftl.Unit")}}
-            server.EmptyClient[{{$verb}}](),
-            	{{- else if eq .Request.TypeName "ftl.Unit" }}
-            server.SourceClient[{{$verb}}, {{.Response.LocalTypeName}}](),
-            	{{- else if eq .Response.TypeName "ftl.Unit" }}
-            server.SinkClient[{{$verb}}, {{.Request.LocalTypeName}}](),
-            	{{- else }}
-            server.VerbClient[{{$verb}}, {{.Request.LocalTypeName}}, {{.Response.LocalTypeName}}](),
-            	{{- end }}
-                {{- end }}
-                {{- with getDatabaseHandle . }}
-                	{{- if eq .Type "postgres" }}
-			server.PostgresDatabaseHandle[{{ trimModuleQualifier $moduleName .TypeName }}](),
-                	{{- end }}
-                {{- end }}
+            {{ getResourceProvider $moduleName . true }},
 			{{- end}}
 		),
 {{- end}}

--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/TBD54566975/ftl/go-runtime/schema/common"
 	"github.com/TBD54566975/scaffolder"
 	"github.com/alecthomas/types/optional"
 	sets "github.com/deckarep/golang-set/v2"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/TBD54566975/ftl"
 	extract "github.com/TBD54566975/ftl/go-runtime/schema"
+	"github.com/TBD54566975/ftl/go-runtime/schema/common"
 	"github.com/TBD54566975/ftl/internal"
 	"github.com/TBD54566975/ftl/internal/builderrors"
 	"github.com/TBD54566975/ftl/internal/exec"

--- a/go-runtime/ftl/ftltest/fake.go
+++ b/go-runtime/ftl/ftltest/fake.go
@@ -147,7 +147,7 @@ func makeMapKey(mapper any) uintptr {
 		panic("fakeFTL received object that was not a pointer, expected *MapHandle")
 	}
 	underlying := v.Elem().Type().Name()
-	if !strings.HasPrefix(underlying, "MapHandle[") {
+	if !(strings.HasPrefix(underlying, "MapHandle[") || strings.HasPrefix(underlying, "MappedHandle[")) {
 		panic(fmt.Sprintf("fakeFTL received *%s, expected *MapHandle", underlying))
 	}
 	return v.Pointer()

--- a/go-runtime/ftl/map.go
+++ b/go-runtime/ftl/map.go
@@ -32,3 +32,51 @@ func Map[T, U any](getter Handle[T], fn func(context.Context, T) (U, error)) *Ma
 		handle: getter,
 	}
 }
+
+// ResourceMapper is an interface that can be implemented to map a resource of type `From` to a new type `To`.
+//
+// A ResourceMapper struct should embed the Handle type that it is mapping from and define a `Map` method that
+// returns the new type.
+//
+// e.g.
+//
+//	 type DBMapper struct {
+//	   ftl.DatabaseHandle[MyConfig]
+//	 }
+//
+//		func (DBMapper) Map(ctx context.Context, conn *sql.DB) (NewType, error) {
+//		  ...
+//		}
+type ResourceMapper[From, To any] interface {
+	Handle[From]
+	Map(ctx context.Context, f From) (To, error)
+}
+
+// MappedHandle can be used to provide the mapped value of a resource in a verb signature.
+//
+// e.g.
+// //ftl:verb
+//
+//	func MyVerb(ctx context.Context, req Request, handle ftl.MappedHandle[DBMapper, *sql.DB, NewType]) (Response, error) {
+//	  db := handle.Get(ctx)
+//	  ...
+//	}
+type MappedHandle[R ResourceMapper[From, To], From, To any] struct {
+	mapper R
+}
+
+func (mh *MappedHandle[H, From, To]) Get(ctx context.Context) To {
+	value := mh.mapper.Get(ctx)
+	out := internal.FromContext(ctx).CallMap(ctx, mh, value, func(ctx context.Context) (any, error) {
+		return mh.mapper.Map(ctx, value)
+	})
+	u, ok := out.(To)
+	if !ok {
+		panic(fmt.Sprintf("output object %v is not compatible with expected type %T", out, *new(To)))
+	}
+	return u
+}
+
+func NewMappedHandle[H ResourceMapper[From, To], From, To any](mapper H) MappedHandle[H, From, To] {
+	return MappedHandle[H, From, To]{mapper}
+}

--- a/go-runtime/schema/common/fact.go
+++ b/go-runtime/schema/common/fact.go
@@ -149,6 +149,25 @@ type DatabaseConfig struct {
 
 func (*DatabaseConfig) schemaFactValue() {}
 
+// VerbResourceParamOrder is a fact for marking the order of resource parameters used by a verb, where the signature
+// is (context.Context, <request>, <resource1>, <resource2>, ...).
+//
+// This is used in the generated code that registers verb resources. The order of parameters is important because it
+// will determine the order in which resources are passed to the verb when the call is constructed via reflection at
+// runtime.
+type VerbResourceParamOrder struct {
+	Resources []VerbResourceParam
+}
+
+type VerbResourceParam struct {
+	Ref  *schema.Ref
+	Type schema.Metadata
+	// The mapper specifying an object that the resource is mapped to, if applicable.
+	Mapper optional.Option[types.Object]
+}
+
+func (*VerbResourceParamOrder) schemaFactValue() {}
+
 // MarkSchemaDecl marks the given object as having been extracted to the given schema decl.
 func MarkSchemaDecl(pass *analysis.Pass, obj types.Object, decl schema.Decl) {
 	fact := newFact(pass, obj)
@@ -217,6 +236,13 @@ func MarkDatabaseConfig(pass *analysis.Pass, obj types.Object, dbType DatabaseTy
 	method DatabaseConfigMethod, value any) {
 	fact := newFact(pass, obj)
 	fact.Add(&DatabaseConfig{Type: dbType, Method: method, Value: value})
+	pass.ExportObjectFact(obj, fact)
+}
+
+// MarkVerbResourceParamOrder marks the given verb object with the order of its parameters.
+func MarkVerbResourceParamOrder(pass *analysis.Pass, obj types.Object, resources []VerbResourceParam) {
+	fact := newFact(pass, obj)
+	fact.Add(&VerbResourceParamOrder{Resources: resources})
 	pass.ExportObjectFact(obj, fact)
 }
 

--- a/go-runtime/schema/database/analyzer.go
+++ b/go-runtime/schema/database/analyzer.go
@@ -51,11 +51,15 @@ func extractDatabase(
 				common.Errorf(pass, node, "invalid database name %q", name)
 				return optional.None[*schema.Database]()
 			}
+			if name == "" {
+				common.Errorf(pass, node.Type, "database config must provide a name")
+				return optional.None[*schema.Database]()
+			}
 			db.Name = name
 		}
 	}
+	// not a DB config
 	if db.Name == "" {
-		common.Errorf(pass, node.Type, "database config must provide a name")
 		return optional.None[*schema.Database]()
 	}
 

--- a/go-runtime/schema/extract.go
+++ b/go-runtime/schema/extract.go
@@ -89,6 +89,8 @@ type Result struct {
 	Module *schema.Module
 	// NativeNames maps schema nodes to their native Go names.
 	NativeNames NativeNames
+	// VerbResourceParamOrder contains the order of resource parameters for each verb.
+	VerbResourceParamOrder map[*schema.Verb][]common.VerbResourceParam
 	// Errors is a list of errors encountered during schema extraction.
 	Errors []builderrors.Error
 }
@@ -146,12 +148,13 @@ type combinedData struct {
 	module *schema.Module
 	errs   []builderrors.Error
 
-	nativeNames         NativeNames
-	functionCalls       map[schema.Position]finalize.FunctionCall
-	verbs               map[types.Object]*schema.Verb
-	refResults          map[schema.RefKey]refResult
-	extractedDecls      map[schema.Decl]types.Object
-	externalTypeAliases sets.Set[*schema.TypeAlias]
+	nativeNames            NativeNames
+	functionCalls          map[schema.Position]finalize.FunctionCall
+	verbs                  map[types.Object]*schema.Verb
+	verbResourceParamOrder map[*schema.Verb][]common.VerbResourceParam
+	refResults             map[schema.RefKey]refResult
+	extractedDecls         map[schema.Decl]types.Object
+	externalTypeAliases    sets.Set[*schema.TypeAlias]
 	// for detecting duplicates
 	typeUniqueness   map[string]tuple.Pair[types.Object, schema.Position]
 	globalUniqueness map[string]tuple.Pair[types.Object, schema.Position]
@@ -159,15 +162,16 @@ type combinedData struct {
 
 func newCombinedData(diagnostics []analysis.SimpleDiagnostic) *combinedData {
 	return &combinedData{
-		errs:                diagnosticsToSchemaErrors(diagnostics),
-		nativeNames:         make(NativeNames),
-		functionCalls:       make(map[schema.Position]finalize.FunctionCall),
-		verbs:               make(map[types.Object]*schema.Verb),
-		refResults:          make(map[schema.RefKey]refResult),
-		extractedDecls:      make(map[schema.Decl]types.Object),
-		externalTypeAliases: sets.NewSet[*schema.TypeAlias](),
-		typeUniqueness:      make(map[string]tuple.Pair[types.Object, schema.Position]),
-		globalUniqueness:    make(map[string]tuple.Pair[types.Object, schema.Position]),
+		errs:                   diagnosticsToSchemaErrors(diagnostics),
+		nativeNames:            make(NativeNames),
+		functionCalls:          make(map[schema.Position]finalize.FunctionCall),
+		verbs:                  make(map[types.Object]*schema.Verb),
+		verbResourceParamOrder: make(map[*schema.Verb][]common.VerbResourceParam),
+		refResults:             make(map[schema.RefKey]refResult),
+		extractedDecls:         make(map[schema.Decl]types.Object),
+		externalTypeAliases:    sets.NewSet[*schema.TypeAlias](),
+		typeUniqueness:         make(map[string]tuple.Pair[types.Object, schema.Position]),
+		globalUniqueness:       make(map[string]tuple.Pair[types.Object, schema.Position]),
 	}
 }
 
@@ -183,6 +187,7 @@ func (cd *combinedData) update(fr finalize.Result) {
 	copyFailedRefs(cd.refResults, fr.Failed)
 	maps.Copy(cd.nativeNames, fr.NativeNames)
 	maps.Copy(cd.functionCalls, fr.FunctionCalls)
+	maps.Copy(cd.verbResourceParamOrder, fr.VerbResourceParamOrder)
 }
 
 func (cd *combinedData) toResult() Result {
@@ -192,9 +197,10 @@ func (cd *combinedData) toResult() Result {
 	cd.errorDirectVerbInvocations()
 	builderrors.SortErrorsByPosition(cd.errs)
 	return Result{
-		Module:      cd.module,
-		NativeNames: cd.nativeNames,
-		Errors:      cd.errs,
+		Module:                 cd.module,
+		NativeNames:            cd.nativeNames,
+		VerbResourceParamOrder: cd.verbResourceParamOrder,
+		Errors:                 cd.errs,
 	}
 }
 

--- a/go-runtime/schema/finalize/analyzer.go
+++ b/go-runtime/schema/finalize/analyzer.go
@@ -37,6 +37,8 @@ type Result struct {
 	NativeNames map[schema.Node]string
 	// FunctionCalls contains all function calls; key is the parent function, value is the called functions.
 	FunctionCalls map[schema.Position]FunctionCall
+	// VerbResourceParamOrder contains the order of resource parameters for each verb.
+	VerbResourceParamOrder map[*schema.Verb][]common.VerbResourceParam
 }
 
 type FunctionCall struct {
@@ -54,6 +56,7 @@ func Run(pass *analysis.Pass) (interface{}, error) {
 	// for identifying duplicates
 	declKeys := make(map[string]types.Object)
 	nativeNames := make(map[schema.Node]string)
+	verbParamOrder := make(map[*schema.Verb][]common.VerbResourceParam)
 	for obj, fact := range common.GetAllFactsExtractionStatus(pass) {
 		switch f := fact.(type) {
 		case *common.ExtractedDecl:
@@ -66,6 +69,14 @@ func Run(pass *analysis.Pass) (interface{}, error) {
 				extracted[f.Decl] = obj
 				declKeys[f.Decl.String()] = obj
 				nativeNames[f.Decl] = common.GetNativeName(obj)
+
+				if v, ok := f.Decl.(*schema.Verb); ok {
+					paramOrder, ok := common.GetFactForObject[*common.VerbResourceParamOrder](pass, obj).Get()
+					if !ok {
+						common.NoEndColumnErrorf(pass, obj.Pos(), "failed to extract verb schema")
+					}
+					verbParamOrder[v] = paramOrder.Resources
+				}
 			}
 		case *common.FailedExtraction:
 			failed[schema.RefKey{Module: moduleName, Name: strcase.ToUpperCamel(obj.Name())}] = obj
@@ -82,12 +93,13 @@ func Run(pass *analysis.Pass) (interface{}, error) {
 		}
 	}
 	return Result{
-		ModuleName:     moduleName,
-		ModuleComments: extractModuleComments(pass),
-		Extracted:      extracted,
-		Failed:         failed,
-		NativeNames:    nativeNames,
-		FunctionCalls:  getFunctionCalls(pass),
+		ModuleName:             moduleName,
+		ModuleComments:         extractModuleComments(pass),
+		Extracted:              extracted,
+		Failed:                 failed,
+		NativeNames:            nativeNames,
+		FunctionCalls:          getFunctionCalls(pass),
+		VerbResourceParamOrder: verbParamOrder,
 	}, nil
 }
 

--- a/go-runtime/schema/schema_integration_test.go
+++ b/go-runtime/schema/schema_integration_test.go
@@ -292,12 +292,13 @@ func testExtractModuleSchemaTwo(t *testing.T) {
 				+calls two.two, two.three
 
 			export verb ingress(builtin.HttpRequest<two.PostRequest, Unit, Unit>) builtin.HttpResponse<two.PostResponse, String>
-				+ingress http POST /users
 				+encoding json lenient
+				+ingress http POST /users
 
 			export verb returnsUser(Unit) two.UserResponse
 
 			export verb three(two.Payload<String>) two.Payload<String>
+				+database calls two.foo
 
 			export verb two(two.Payload<String>) two.Payload<String>
 				+database calls two.foo
@@ -424,8 +425,8 @@ func testExtractModulePubSub(t *testing.T) {
         verb payin(Unit) Unit
 
         verb processBroadcast(pubsub.PayinEvent) Unit
-        	+subscribe broadcastSubscription
 			+retry 10 1s
+        	+subscribe broadcastSubscription
 
         verb processPayin(pubsub.PayinEvent) Unit
         	+subscribe paymentProcessing

--- a/go-runtime/schema/testdata/two/two.go
+++ b/go-runtime/schema/testdata/two/two.go
@@ -2,6 +2,7 @@ package two
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	lib "github.com/TBD54566975/ftl/go-runtime/schema/testdata"
@@ -10,11 +11,23 @@ import (
 	"ftl/builtin"
 )
 
+type NewType struct {
+	*sql.DB
+}
+
 type FooConfig struct {
 	ftl.DefaultPostgresDatabaseConfig
 }
 
 func (FooConfig) Name() string { return "foo" }
+
+type DBMapper struct {
+	ftl.DatabaseHandle[FooConfig]
+}
+
+func (h DBMapper) Map(ctx context.Context, db *sql.DB) (NewType, error) {
+	return NewType{db}, nil
+}
 
 //ftl:enum export
 type TwoEnum string
@@ -64,7 +77,7 @@ func Two(ctx context.Context, req Payload[string], handle ftl.DatabaseHandle[Foo
 }
 
 //ftl:verb export
-func Three(ctx context.Context, req Payload[string]) (Payload[string], error) {
+func Three(ctx context.Context, req Payload[string], mapped ftl.MappedHandle[DBMapper, *sql.DB, NewType]) (Payload[string], error) {
 	return Payload[string]{}, nil
 }
 

--- a/go-runtime/schema/testdata/two/types.ftl.go
+++ b/go-runtime/schema/testdata/two/types.ftl.go
@@ -49,6 +49,7 @@ func init() {
 		),
 		reflection.ProvideResourcesForVerb(
 			Three,
+			server.MappedHandle[DBMapper](server.PostgresDatabaseHandle[FooConfig]()),
 		),
 		reflection.ProvideResourcesForVerb(
 			Ingress,

--- a/go-runtime/server/map.go
+++ b/go-runtime/server/map.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/TBD54566975/ftl/go-runtime/ftl"
+	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+)
+
+func MappedHandle[R ftl.ResourceMapper[From, To], From, To any](resource reflection.VerbResource) reflection.VerbResource {
+	return func() reflect.Value {
+		handle := resource()
+		var instance R
+		var wasSet bool
+		val := reflect.ValueOf(&instance).Elem()
+		for i := range val.NumField() {
+			field := val.Field(i)
+			if handle.Type().AssignableTo(field.Type()) {
+				if field.CanSet() {
+					handleValue := handle.Convert(field.Type())
+					field.Set(handleValue)
+					wasSet = true
+					break
+				}
+				panic(fmt.Sprintf("mapper must contain a field of type %s that is settable", handle.Type().String()))
+			}
+		}
+		if !wasSet {
+			panic(fmt.Sprintf("mapper must contain a field of type %s", handle.Type().String()))
+		}
+		db := ftl.NewMappedHandle(instance)
+		return reflect.ValueOf(db)
+	}
+}

--- a/go-runtime/server/server.go
+++ b/go-runtime/server/server.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 
 	"connectrpc.com/connect"
+
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/common/plugin"

--- a/go-runtime/server/server.go
+++ b/go-runtime/server/server.go
@@ -6,15 +6,11 @@ import (
 	"net/url"
 	"reflect"
 	"runtime/debug"
-	"strings"
 
 	"connectrpc.com/connect"
-	"github.com/alecthomas/types/optional"
-
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/common/plugin"
-	"github.com/TBD54566975/ftl/go-runtime/encoding"
 	"github.com/TBD54566975/ftl/go-runtime/ftl"
 	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
 	"github.com/TBD54566975/ftl/go-runtime/internal"
@@ -23,7 +19,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/modulecontext"
 	"github.com/TBD54566975/ftl/internal/observability"
 	"github.com/TBD54566975/ftl/internal/rpc"
-	"github.com/TBD54566975/ftl/internal/schema"
 )
 
 type UserVerbConfig struct {
@@ -57,173 +52,6 @@ func NewUserVerbServer(projectName string, moduleName string, handlers ...Handle
 		}
 		hmap := maps.FromSlice(handlers, func(h Handler) (reflection.Ref, Handler) { return h.ref, h })
 		return ctx, &moduleServer{handlers: hmap}, nil
-	}
-}
-
-// Handler for a Verb.
-type Handler struct {
-	ref reflection.Ref
-	fn  func(ctx context.Context, req []byte, metadata map[internal.MetadataKey]string) ([]byte, error)
-}
-
-func HandleCall[Req, Resp any](verb any) Handler {
-	ref := reflection.FuncRef(verb)
-	return Handler{
-		ref: ref,
-		fn: func(ctx context.Context, reqdata []byte, metadata map[internal.MetadataKey]string) ([]byte, error) {
-			ctx = internal.ContextWithCallMetadata(ctx, metadata)
-
-			// Decode request.
-			var req Req
-			err := encoding.Unmarshal(reqdata, &req)
-			if err != nil {
-				return nil, fmt.Errorf("invalid request to verb %s: %w", ref, err)
-			}
-			ctx = observability.AddSpanContextToLogger(ctx)
-
-			// InvokeVerb Verb.
-			resp, err := InvokeVerb[Req, Resp](ref)(ctx, req)
-			if err != nil {
-				return nil, fmt.Errorf("call to verb %s failed: %w", ref, err)
-			}
-
-			respdata, err := encoding.Marshal(resp)
-			if err != nil {
-				return nil, err
-			}
-
-			return respdata, nil
-		},
-	}
-}
-
-func HandleSink[Req any](verb any) Handler {
-	return HandleCall[Req, ftl.Unit](verb)
-}
-
-func HandleSource[Resp any](verb any) Handler {
-	return HandleCall[ftl.Unit, Resp](verb)
-}
-
-func HandleEmpty(verb any) Handler {
-	return HandleCall[ftl.Unit, ftl.Unit](verb)
-}
-
-func InvokeVerb[Req, Resp any](ref reflection.Ref) func(ctx context.Context, req Req) (resp Resp, err error) {
-	return func(ctx context.Context, req Req) (resp Resp, err error) {
-		request := optional.Some[any](req)
-		if reflect.TypeFor[Req]() == reflect.TypeFor[ftl.Unit]() {
-			request = optional.None[any]()
-		}
-
-		out, err := reflection.CallVerb(reflection.Ref{Module: ref.Module, Name: ref.Name})(ctx, request)
-		if err != nil {
-			return resp, err
-		}
-
-		var respValue any
-		if r, ok := out.Get(); ok {
-			respValue = r
-		} else {
-			respValue = ftl.Unit{}
-		}
-		resp, ok := respValue.(Resp)
-		if !ok {
-			return resp, fmt.Errorf("unexpected response type from verb %s: %T", ref, resp)
-		}
-		return resp, err
-	}
-}
-
-func VerbClient[Verb, Req, Resp any]() reflection.VerbResource {
-	fnCall := call[Verb, Req, Resp]()
-	return func() reflect.Value {
-		return reflect.ValueOf(fnCall)
-	}
-}
-
-func SinkClient[Verb, Req any]() reflection.VerbResource {
-	fnCall := call[Verb, Req, ftl.Unit]()
-	sink := func(ctx context.Context, req Req) error {
-		_, err := fnCall(ctx, req)
-		return err
-	}
-	return func() reflect.Value {
-		return reflect.ValueOf(sink)
-	}
-}
-
-func SourceClient[Verb, Resp any]() reflection.VerbResource {
-	fnCall := call[Verb, ftl.Unit, Resp]()
-	source := func(ctx context.Context) (Resp, error) {
-		return fnCall(ctx, ftl.Unit{})
-	}
-	return func() reflect.Value {
-		return reflect.ValueOf(source)
-	}
-}
-
-func EmptyClient[Verb any]() reflection.VerbResource {
-	fnCall := call[Verb, ftl.Unit, ftl.Unit]()
-	source := func(ctx context.Context) error {
-		_, err := fnCall(ctx, ftl.Unit{})
-		return err
-	}
-	return func() reflect.Value {
-		return reflect.ValueOf(source)
-	}
-}
-
-func call[Verb, Req, Resp any]() func(ctx context.Context, req Req) (resp Resp, err error) {
-	typ := reflect.TypeFor[Verb]()
-	if typ.Kind() != reflect.Func {
-		panic(fmt.Sprintf("Cannot register %s: expected function, got %s", typ, typ.Kind()))
-	}
-	callee := reflection.TypeRef[Verb]()
-	callee.Name = strings.TrimSuffix(callee.Name, "Client")
-	return func(ctx context.Context, req Req) (resp Resp, err error) {
-		ref := reflection.Ref{Module: callee.Module, Name: callee.Name}
-		moduleCtx := modulecontext.FromContext(ctx).CurrentContext()
-		override, err := moduleCtx.BehaviorForVerb(schema.Ref{Module: ref.Module, Name: ref.Name})
-		if err != nil {
-			return resp, fmt.Errorf("%s: %w", ref, err)
-		}
-		if behavior, ok := override.Get(); ok {
-			uncheckedResp, err := behavior.Call(ctx, modulecontext.Verb(widenVerb(InvokeVerb[Req, Resp](ref))), req)
-			if err != nil {
-				return resp, fmt.Errorf("%s: %w", ref, err)
-			}
-			if r, ok := uncheckedResp.(Resp); ok {
-				return r, nil
-			}
-			return resp, fmt.Errorf("%s: overridden verb had invalid response type %T, expected %v", ref,
-				uncheckedResp, reflect.TypeFor[Resp]())
-		}
-
-		reqData, err := encoding.Marshal(req)
-		if err != nil {
-			return resp, fmt.Errorf("%s: failed to marshal request: %w", callee, err)
-		}
-
-		client := rpc.ClientFromContext[ftlv1connect.VerbServiceClient](ctx)
-		cresp, err := client.Call(ctx, connect.NewRequest(&ftlv1.CallRequest{Verb: callee.ToProto(), Body: reqData}))
-		if err != nil {
-			return resp, fmt.Errorf("%s: failed to call Verb: %w", callee, err)
-		}
-		switch cresp := cresp.Msg.Response.(type) {
-		case *ftlv1.CallResponse_Error_:
-			return resp, fmt.Errorf("%s: %s", callee, cresp.Error.Message)
-
-		case *ftlv1.CallResponse_Body:
-			err = encoding.Unmarshal(cresp.Body, &resp)
-			if err != nil {
-				return resp, fmt.Errorf("%s: failed to decode response: %w", callee, err)
-			}
-			return resp, nil
-
-		default:
-			panic(fmt.Sprintf("%s: invalid response type %T", callee, cresp))
-		}
 	}
 }
 

--- a/go-runtime/server/verb.go
+++ b/go-runtime/server/verb.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"connectrpc.com/connect"
+	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
+	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/go-runtime/encoding"
+	"github.com/TBD54566975/ftl/go-runtime/ftl"
+	"github.com/TBD54566975/ftl/go-runtime/ftl/reflection"
+	"github.com/TBD54566975/ftl/go-runtime/internal"
+	"github.com/TBD54566975/ftl/internal/modulecontext"
+	"github.com/TBD54566975/ftl/internal/observability"
+	"github.com/TBD54566975/ftl/internal/rpc"
+	"github.com/TBD54566975/ftl/internal/schema"
+	"github.com/alecthomas/types/optional"
+)
+
+// Handler for a Verb.
+type Handler struct {
+	ref reflection.Ref
+	fn  func(ctx context.Context, req []byte, metadata map[internal.MetadataKey]string) ([]byte, error)
+}
+
+func HandleCall[Req, Resp any](verb any) Handler {
+	ref := reflection.FuncRef(verb)
+	return Handler{
+		ref: ref,
+		fn: func(ctx context.Context, reqdata []byte, metadata map[internal.MetadataKey]string) ([]byte, error) {
+			ctx = internal.ContextWithCallMetadata(ctx, metadata)
+
+			// Decode request.
+			var req Req
+			err := encoding.Unmarshal(reqdata, &req)
+			if err != nil {
+				return nil, fmt.Errorf("invalid request to verb %s: %w", ref, err)
+			}
+			ctx = observability.AddSpanContextToLogger(ctx)
+
+			// InvokeVerb Verb.
+			resp, err := InvokeVerb[Req, Resp](ref)(ctx, req)
+			if err != nil {
+				return nil, fmt.Errorf("call to verb %s failed: %w", ref, err)
+			}
+
+			respdata, err := encoding.Marshal(resp)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal response from verb %s: %w", ref, err)
+			}
+
+			return respdata, nil
+		},
+	}
+}
+
+func HandleSink[Req any](verb any) Handler {
+	return HandleCall[Req, ftl.Unit](verb)
+}
+
+func HandleSource[Resp any](verb any) Handler {
+	return HandleCall[ftl.Unit, Resp](verb)
+}
+
+func HandleEmpty(verb any) Handler {
+	return HandleCall[ftl.Unit, ftl.Unit](verb)
+}
+
+func InvokeVerb[Req, Resp any](ref reflection.Ref) func(ctx context.Context, req Req) (resp Resp, err error) {
+	return func(ctx context.Context, req Req) (resp Resp, err error) {
+		request := optional.Some[any](req)
+		if reflect.TypeFor[Req]() == reflect.TypeFor[ftl.Unit]() {
+			request = optional.None[any]()
+		}
+
+		out, err := reflection.CallVerb(reflection.Ref{Module: ref.Module, Name: ref.Name})(ctx, request)
+		if err != nil {
+			return resp, err
+		}
+
+		var respValue any
+		if r, ok := out.Get(); ok {
+			respValue = r
+		} else {
+			respValue = ftl.Unit{}
+		}
+		resp, ok := respValue.(Resp)
+		if !ok {
+			return resp, fmt.Errorf("unexpected response type from verb %s: %T", ref, resp)
+		}
+		return resp, err
+	}
+}
+
+func VerbClient[Verb, Req, Resp any]() reflection.VerbResource {
+	fnCall := call[Verb, Req, Resp]()
+	return func() reflect.Value {
+		return reflect.ValueOf(fnCall)
+	}
+}
+
+func SinkClient[Verb, Req any]() reflection.VerbResource {
+	fnCall := call[Verb, Req, ftl.Unit]()
+	sink := func(ctx context.Context, req Req) error {
+		_, err := fnCall(ctx, req)
+		return err
+	}
+	return func() reflect.Value {
+		return reflect.ValueOf(sink)
+	}
+}
+
+func SourceClient[Verb, Resp any]() reflection.VerbResource {
+	fnCall := call[Verb, ftl.Unit, Resp]()
+	source := func(ctx context.Context) (Resp, error) {
+		return fnCall(ctx, ftl.Unit{})
+	}
+	return func() reflect.Value {
+		return reflect.ValueOf(source)
+	}
+}
+
+func EmptyClient[Verb any]() reflection.VerbResource {
+	fnCall := call[Verb, ftl.Unit, ftl.Unit]()
+	source := func(ctx context.Context) error {
+		_, err := fnCall(ctx, ftl.Unit{})
+		return err
+	}
+	return func() reflect.Value {
+		return reflect.ValueOf(source)
+	}
+}
+
+func call[Verb, Req, Resp any]() func(ctx context.Context, req Req) (resp Resp, err error) {
+	typ := reflect.TypeFor[Verb]()
+	if typ.Kind() != reflect.Func {
+		panic(fmt.Sprintf("Cannot register %s: expected function, got %s", typ, typ.Kind()))
+	}
+	callee := reflection.TypeRef[Verb]()
+	callee.Name = strings.TrimSuffix(callee.Name, "Client")
+	return func(ctx context.Context, req Req) (resp Resp, err error) {
+		ref := reflection.Ref{Module: callee.Module, Name: callee.Name}
+		moduleCtx := modulecontext.FromContext(ctx).CurrentContext()
+		override, err := moduleCtx.BehaviorForVerb(schema.Ref{Module: ref.Module, Name: ref.Name})
+		if err != nil {
+			return resp, fmt.Errorf("%s: %w", ref, err)
+		}
+		if behavior, ok := override.Get(); ok {
+			uncheckedResp, err := behavior.Call(ctx, modulecontext.Verb(widenVerb(InvokeVerb[Req, Resp](ref))), req)
+			if err != nil {
+				return resp, fmt.Errorf("%s: %w", ref, err)
+			}
+			if r, ok := uncheckedResp.(Resp); ok {
+				return r, nil
+			}
+			return resp, fmt.Errorf("%s: overridden verb had invalid response type %T, expected %v", ref,
+				uncheckedResp, reflect.TypeFor[Resp]())
+		}
+
+		reqData, err := encoding.Marshal(req)
+		if err != nil {
+			return resp, fmt.Errorf("%s: failed to marshal request: %w", callee, err)
+		}
+
+		client := rpc.ClientFromContext[ftlv1connect.VerbServiceClient](ctx)
+		cresp, err := client.Call(ctx, connect.NewRequest(&ftlv1.CallRequest{Verb: callee.ToProto(), Body: reqData}))
+		if err != nil {
+			return resp, fmt.Errorf("%s: failed to call Verb: %w", callee, err)
+		}
+		switch cresp := cresp.Msg.Response.(type) {
+		case *ftlv1.CallResponse_Error_:
+			return resp, fmt.Errorf("%s: %s", callee, cresp.Error.Message)
+
+		case *ftlv1.CallResponse_Body:
+			err = encoding.Unmarshal(cresp.Body, &resp)
+			if err != nil {
+				return resp, fmt.Errorf("%s: failed to decode response: %w", callee, err)
+			}
+			return resp, nil
+
+		default:
+			panic(fmt.Sprintf("%s: invalid response type %T", callee, cresp))
+		}
+	}
+}

--- a/go-runtime/server/verb.go
+++ b/go-runtime/server/verb.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/alecthomas/types/optional"
+
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/go-runtime/encoding"
@@ -17,7 +19,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/observability"
 	"github.com/TBD54566975/ftl/internal/rpc"
 	"github.com/TBD54566975/ftl/internal/schema"
-	"github.com/alecthomas/types/optional"
 )
 
 // Handler for a Verb.

--- a/internal/schema/validate.go
+++ b/internal/schema/validate.go
@@ -378,6 +378,54 @@ func SortModuleDecls(module *Module) {
 	})
 }
 
+func sortMetadata(md []Metadata) {
+	sort.SliceStable(md, func(i, j int) bool {
+		iMd := md[i]
+		jMd := md[j]
+		sortMetadataType(iMd)
+		sortMetadataType(jMd)
+		iPriority := getMetadataSortingPriority(iMd)
+		jPriority := getMetadataSortingPriority(jMd)
+		return iPriority < jPriority
+	})
+}
+
+func sortMetadataType(md Metadata) {
+	sortRefs := func(refs []*Ref) {
+		sort.SliceStable(refs, func(i, j int) bool {
+			if refs[i].Module == refs[j].Module {
+				return refs[i].Name < refs[j].Name
+			}
+			return refs[i].Module < refs[j].Module
+		})
+	}
+
+	switch m := md.(type) {
+	case *MetadataAlias:
+		return
+	case *MetadataCalls:
+		sortRefs(m.Calls)
+	case *MetadataConfig:
+		sortRefs(m.Config)
+	case *MetadataCronJob:
+		return
+	case *MetadataDatabases:
+		sortRefs(m.Calls)
+	case *MetadataEncoding:
+		return
+	case *MetadataIngress:
+		return
+	case *MetadataRetry:
+		return
+	case *MetadataSecrets:
+		sortRefs(m.Secrets)
+	case *MetadataSubscriber:
+		return
+	case *MetadataTypeMap:
+		return
+	}
+}
+
 // getDeclSortingPriority (used for schema sorting) is pulled out into it's own switch so the Go sumtype check will fail
 // if a new Decl is added but not explicitly prioritized
 func getDeclSortingPriority(decl Decl) int {
@@ -401,6 +449,35 @@ func getDeclSortingPriority(decl Decl) int {
 		priority = 8
 	case *Verb:
 		priority = 9
+	}
+	return priority
+}
+
+func getMetadataSortingPriority(metadata Metadata) int {
+	priority := 0
+	switch metadata.(type) {
+	case *MetadataAlias:
+		priority = 1
+	case *MetadataCalls:
+		priority = 2
+	case *MetadataConfig:
+		priority = 3
+	case *MetadataCronJob:
+		priority = 4
+	case *MetadataDatabases:
+		priority = 5
+	case *MetadataEncoding:
+		priority = 6
+	case *MetadataIngress:
+		priority = 7
+	case *MetadataRetry:
+		priority = 8
+	case *MetadataSecrets:
+		priority = 9
+	case *MetadataSubscriber:
+		priority = 10
+	case *MetadataTypeMap:
+		priority = 11
 	}
 	return priority
 }

--- a/internal/schema/verb.go
+++ b/internal/schema/verb.go
@@ -135,6 +135,10 @@ func (v *Verb) AddDatabase(db *Ref) {
 	v.Metadata = append(v.Metadata, &MetadataDatabases{Calls: []*Ref{db}})
 }
 
+func (v *Verb) SortMetadata() {
+	sortMetadata(v.Metadata)
+}
+
 func (v *Verb) GetMetadataIngress() optional.Option[*MetadataIngress] {
 	if m, ok := slices.FindVariant[*MetadataIngress](v.Metadata); ok {
 		return optional.Some(m)


### PR DESCRIPTION
embed the FTL handle that needs mapping in a new mapper type, e.g.:
```
type DBMapper struct {
     ftl.DatabaseHandle[MyConfig]
}
```
then implement a map function on it:
```
func (DBMapper) Map(ctx context.Context, conn *sql.DB) (NewType, error) {
     return NewType{db}, nil
}
```

such that your new type implements this FTL interface:
```
type ResourceMapper[From, To any] interface {
     Handle[From]
     Map(ctx context.Context, f From) (To, error)
}
```

Then, you can plug your mapper into a verb signature via `ftl.MappedHandle`, e.g.:
```
//ftl:verb
func Insert(ctx context.Context, req Request, db ftl.MappedHandle[DBMapper, *sql.DB, NewType]) (Response, error) {
     ...
}
```

also fixes #2941 