### PR TITLE
fix: reporting call and ingress event errors

### DIFF
--- a/backend/controller/timeline/internal/timeline_test.go
+++ b/backend/controller/timeline/internal/timeline_test.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strconv"
 	"testing"
@@ -129,21 +127,17 @@ func TestTimeline(t *testing.T) {
 
 	t.Run("InsertHTTPIngressEvent", func(t *testing.T) {
 		timeline.EnqueueEvent(ctx, &timeline2.Ingress{
-			DeploymentKey: ingressEvent.DeploymentKey,
-			RequestKey:    ingressEvent.RequestKey.MustGet(),
-			StartTime:     ingressEvent.Time,
-			Verb:          &ingressEvent.Verb,
-			Request: &http.Request{
-				Method: ingressEvent.Method,
-				URL:    &url.URL{Path: ingressEvent.Path},
-				Body:   io.NopCloser(bytes.NewReader(ingressEvent.Request)),
-				Header: http.Header(map[string][]string{"request": {"header"}}),
-			},
-			Response: &http.Response{
-				StatusCode: ingressEvent.StatusCode,
-				Body:       io.NopCloser(bytes.NewReader(ingressEvent.Response)),
-				Header:     http.Header(map[string][]string{"response": {"header"}}),
-			},
+			DeploymentKey:   ingressEvent.DeploymentKey,
+			RequestKey:      ingressEvent.RequestKey.MustGet(),
+			StartTime:       ingressEvent.Time,
+			Verb:            &ingressEvent.Verb,
+			RequestMethod:   ingressEvent.Method,
+			RequestPath:     ingressEvent.Path,
+			RequestHeaders:  http.Header(map[string][]string{"request": {"header"}}),
+			RequestBody:     ingressEvent.Request,
+			ResponseStatus:  ingressEvent.StatusCode,
+			ResponseHeaders: http.Header(map[string][]string{"response": {"header"}}),
+			ResponseBody:    ingressEvent.Response,
 		})
 		time.Sleep(200 * time.Millisecond)
 	})

--- a/frontend/console/src/features/timeline/timeline.utils.ts
+++ b/frontend/console/src/features/timeline/timeline.utils.ts
@@ -10,7 +10,12 @@ const eventBackgroundColorMap: Record<string, string> = {
   '': 'bg-gray-500',
 }
 
-export const eventBackgroundColor = (event: Event) => eventBackgroundColorMap[event.entry.case || '']
+export const eventBackgroundColor = (event: Event) => {
+  if (isError(event)) {
+    return 'bg-red-500'
+  }
+  return eventBackgroundColorMap[event.entry.case || '']
+}
 
 const eventTextColorMap: Record<string, string> = {
   log: 'text-gray-500',
@@ -22,4 +27,19 @@ const eventTextColorMap: Record<string, string> = {
   '': 'text-gray-500',
 }
 
-export const eventTextColor = (event: Event) => eventTextColorMap[event.entry.case || '']
+export const eventTextColor = (event: Event) => {
+  if (isError(event)) {
+    return 'text-red-500'
+  }
+  return eventTextColorMap[event.entry.case || '']
+}
+
+const isError = (event: Event) => {
+  if (event.entry.case === 'call' && event.entry.value.error) {
+    return true
+  }
+  if (event.entry.case === 'ingress' && event.entry.value.error) {
+    return true
+  }
+  return false
+}

--- a/frontend/console/src/features/traces/TraceRequestList.tsx
+++ b/frontend/console/src/features/traces/TraceRequestList.tsx
@@ -13,9 +13,7 @@ export const TraceRequestList = ({ module, verb }: { module: string; verb?: stri
   const [selectedEventId, setSelectedEventId] = useState<bigint | undefined>()
 
   const traceEventsRequest = useModuleTraceEvents(module, verb)
-  const traceEvents = useMemo(() => {
-    return groupEventsByRequestKey(traceEventsRequest.data)
-  }, [traceEventsRequest.data])
+  const traceEvents = useMemo(() => groupEventsByRequestKey(traceEventsRequest.data), [traceEventsRequest.data])
 
   const handleCallClicked = (event: Event) => {
     if (selectedEventId === event.id) {


### PR DESCRIPTION
Fixes #3149

Also fixes:
- ingress request keys were not being added to the database
- ingress events not adding to the db because of request body reading twice resulting in `error:timeline: Failed to insert 1 events, most recent error: failed to read request body: http: invalid Read on closed Body`
- call event errors were not being inserted as events (just logged)
- call not reusing the ingress request key correctly
- TimelineIcon not respecting error fields in responses

![Screenshot 2024-10-18 at 9 55 13 AM](https://github.com/user-attachments/assets/9e5e311d-11d6-44db-89d8-f2ca55985429)
![Screenshot 2024-10-18 at 9 55 35 AM](https://github.com/user-attachments/assets/6e4dc678-4473-4667-96f0-d7df388f3ee1)
