### PR TITLE
chore: remove java from the kube tests

### DIFF
--- a/deployment/Dockerfile.runner.test
+++ b/deployment/Dockerfile.runner.test
@@ -5,8 +5,6 @@ WORKDIR /src
 
 # Finally create the runtime image.
 FROM ubuntu:24.04
-RUN apt-get update
-RUN apt-get install -y ca-certificates openjdk-17-jdk
 
 WORKDIR /root/
 


### PR DESCRIPTION
This seems to possible be the root cause of the out of disk space errors.