### PR TITLE
fix: pass in bind allocator to build engine

### DIFF
--- a/frontend/cli/cmd_box.go
+++ b/frontend/cli/cmd_box.go
@@ -15,6 +15,7 @@ import (
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/controller/dsn"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
+	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -123,7 +124,16 @@ func (b *boxCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 	if len(b.Build.Dirs) == 0 {
 		return errors.New("no directories specified")
 	}
-	engine, err := buildengine.New(ctx, client, projConfig.Root(), b.Build.Dirs, buildengine.BuildEnv(b.Build.BuildEnv), buildengine.Parallelism(b.Build.Parallelism))
+
+	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
+	// TODO: is this ok?
+	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint)
+	if err != nil {
+		return fmt.Errorf("could not create bind allocator: %w", err)
+	}
+	_ = bindAllocator.Next()
+
+	engine, err := buildengine.New(ctx, client, projConfig.Root(), b.Build.Dirs, bindAllocator, buildengine.BuildEnv(b.Build.BuildEnv), buildengine.Parallelism(b.Build.Parallelism))
 	if err != nil {
 		return err
 	}

--- a/frontend/cli/cmd_box.go
+++ b/frontend/cli/cmd_box.go
@@ -126,7 +126,6 @@ func (b *boxCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 	}
 
 	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-	// TODO: is this ok?
 	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint)
 	if err != nil {
 		return fmt.Errorf("could not create bind allocator: %w", err)

--- a/frontend/cli/cmd_box_run.go
+++ b/frontend/cli/cmd_box_run.go
@@ -75,7 +75,7 @@ func (b *boxRunCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 		return fmt.Errorf("controller failed to start: %w", err)
 	}
 
-	engine, err := buildengine.New(ctx, client, projConfig.Root(), []string{b.Dir})
+	engine, err := buildengine.New(ctx, client, projConfig.Root(), []string{b.Dir}, runnerPortAllocator)
 	if err != nil {
 		return fmt.Errorf("failed to create build engine: %w", err)
 	}

--- a/internal/buildengine/engine.go
+++ b/internal/buildengine/engine.go
@@ -236,7 +236,7 @@ func WithStartTime(startTime time.Time) Option {
 // pull in missing schemas.
 //
 // "dirs" are directories to scan for local modules.
-func New(ctx context.Context, client DeployClient, projectRoot string, moduleDirs []string, options ...Option) (*Engine, error) {
+func New(ctx context.Context, client DeployClient, projectRoot string, moduleDirs []string, bindAllocator *bind.BindAllocator, options ...Option) (*Engine, error) {
 	ctx = rpc.ContextWithClient(ctx, client)
 	e := &Engine{
 		client:           client,
@@ -252,6 +252,7 @@ func New(ctx context.Context, client DeployClient, projectRoot string, moduleDir
 		invalidateDeps:   make(chan invalidateDependenciesEvent, 128),
 		rawEngineUpdates: make(chan rawEngineEvent, 128),
 		EngineUpdates:    pubsub.New[EngineEvent](),
+		bindAllocator:    bindAllocator,
 	}
 	for _, option := range options {
 		option(e)

--- a/internal/buildengine/engine_test.go
+++ b/internal/buildengine/engine_test.go
@@ -2,10 +2,12 @@ package buildengine_test
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
 
+	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/schema"
@@ -13,7 +15,13 @@ import (
 
 func TestGraph(t *testing.T) {
 	ctx := log.ContextWithNewDefaultLogger(context.Background())
-	engine, err := buildengine.New(ctx, nil, t.TempDir(), []string{"testdata/alpha", "testdata/other", "testdata/another"})
+
+	bindURL, err := url.Parse("http://127.0.0.1:8893")
+	assert.NoError(t, err)
+	bindAllocator, err := bind.NewBindAllocator(bindURL)
+	assert.NoError(t, err)
+
+	engine, err := buildengine.New(ctx, nil, t.TempDir(), []string{"testdata/alpha", "testdata/other", "testdata/another"}, bindAllocator)
 	assert.NoError(t, err)
 
 	defer engine.Close()


### PR DESCRIPTION
We already added bind allocator to build engine so that it can launch language plugins but we did not pass in the bind allocator.

Added a task to clean this up here: https://github.com/TBD54566975/ftl/issues/2452