### PR TITLE
feat: save module schemas to .ftl/schemas

### DIFF
--- a/backend/controller/admin/admin_test.go
+++ b/backend/controller/admin/admin_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/configuration"
 	"github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
@@ -36,7 +35,7 @@ func TestAdminService(t *testing.T) {
 			providers.Inline[configuration.Secrets]{},
 		})
 	assert.NoError(t, err)
-	admin := NewAdminService(cm, sm, &diskSchemaRetriever{}, optional.None[*bind.BindAllocator]())
+	admin := NewAdminService(cm, sm, &diskSchemaRetriever{})
 	assert.NotZero(t, admin)
 
 	expectedEnvarValue, err := json.MarshalIndent(map[string]string{"bar": "barfoo"}, "", "  ")
@@ -200,7 +199,7 @@ var testSchema = schema.MustValidate(&schema.Schema{
 type mockSchemaRetriever struct {
 }
 
-func (d *mockSchemaRetriever) GetActiveSchema(ctx context.Context, bindAllocator optional.Option[*bind.BindAllocator]) (*schema.Schema, error) {
+func (d *mockSchemaRetriever) GetActiveSchema(ctx context.Context) (*schema.Schema, error) {
 	return testSchema, nil
 }
 
@@ -218,7 +217,7 @@ func TestAdminValidation(t *testing.T) {
 			providers.Inline[configuration.Secrets]{},
 		})
 	assert.NoError(t, err)
-	admin := NewAdminService(cm, sm, &mockSchemaRetriever{}, optional.None[*bind.BindAllocator]())
+	admin := NewAdminService(cm, sm, &mockSchemaRetriever{})
 	assert.NotZero(t, admin)
 
 	testSetConfig(t, ctx, admin, "batmobile", "color", "Black", "")

--- a/backend/controller/admin/local_client_test.go
+++ b/backend/controller/admin/local_client_test.go
@@ -4,13 +4,11 @@ package admin
 
 import (
 	"context"
-	"net/url"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/types/optional"
 
-	"github.com/TBD54566975/ftl/internal/bind"
 	cf "github.com/TBD54566975/ftl/internal/configuration"
 	"github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
@@ -22,13 +20,8 @@ import (
 
 func getDiskSchema(t testing.TB, ctx context.Context) (*schema.Schema, error) {
 	t.Helper()
-
-	bindURL, err := url.Parse("http://127.0.0.1:8893")
-	assert.NoError(t, err)
-	bindAllocator, err := bind.NewBindAllocator(bindURL)
-	assert.NoError(t, err)
 	dsr := &diskSchemaRetriever{}
-	return dsr.GetActiveSchema(ctx, optional.Some(bindAllocator))
+	return dsr.GetActiveSchema(ctx)
 }
 
 func TestDiskSchemaRetrieverWithBuildArtefact(t *testing.T) {
@@ -76,10 +69,10 @@ func TestAdminNoValidationWithNoSchema(t *testing.T) {
 	assert.NoError(t, err)
 
 	dsr := &diskSchemaRetriever{deployRoot: optional.Some(string(t.TempDir()))}
-	_, err = dsr.GetActiveSchema(ctx, optional.None[*bind.BindAllocator]())
+	_, err = dsr.GetActiveSchema(ctx)
 	assert.Error(t, err)
 
-	admin := NewAdminService(cm, sm, dsr, optional.None[*bind.BindAllocator]())
+	admin := NewAdminService(cm, sm, dsr)
 	testSetConfig(t, ctx, admin, "batmobile", "color", "Red", "")
 	testSetSecret(t, ctx, admin, "batmobile", "owner", 99, "")
 }

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -57,7 +57,6 @@ import (
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	frontend "github.com/TBD54566975/ftl/frontend/console"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/configuration"
 	cf "github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/configuration/providers"
@@ -164,7 +163,7 @@ func Start(ctx context.Context, config Config, runnerScaling scaling.RunnerScali
 	cm := cf.ConfigFromContext(ctx)
 	sm := cf.SecretsFromContext(ctx)
 
-	admin := admin.NewAdminService(cm, sm, svc.dal, optional.None[*bind.BindAllocator]())
+	admin := admin.NewAdminService(cm, sm, svc.dal)
 	console := console.NewService(svc.dal, svc.timeline)
 
 	ingressHandler := otelhttp.NewHandler(http.Handler(svc), "ftl.ingress")

--- a/backend/controller/dal/dal.go
+++ b/backend/controller/dal/dal.go
@@ -23,7 +23,6 @@ import (
 	"github.com/TBD54566975/ftl/backend/controller/pubsub"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltypes"
 	"github.com/TBD54566975/ftl/backend/libdal"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/maps"
 	"github.com/TBD54566975/ftl/internal/model"
@@ -584,7 +583,7 @@ func (d *DAL) GetActiveDeployments(ctx context.Context) ([]dalmodel.Deployment, 
 }
 
 // GetActiveSchema returns the schema for all active deployments.
-func (d *DAL) GetActiveSchema(ctx context.Context, bindAllocator optional.Option[*bind.BindAllocator]) (*schema.Schema, error) {
+func (d *DAL) GetActiveSchema(ctx context.Context) (*schema.Schema, error) {
 	deployments, err := d.GetActiveDeployments(ctx)
 	if err != nil {
 		return nil, err

--- a/frontend/cli/cmd_box.go
+++ b/frontend/cli/cmd_box.go
@@ -132,7 +132,7 @@ func (b *boxCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 	}
 	_ = bindAllocator.Next()
 
-	engine, err := buildengine.New(ctx, client, projConfig.Root(), b.Build.Dirs, bindAllocator, buildengine.BuildEnv(b.Build.BuildEnv), buildengine.Parallelism(b.Build.Parallelism))
+	engine, err := buildengine.New(ctx, client, projConfig, b.Build.Dirs, bindAllocator, buildengine.BuildEnv(b.Build.BuildEnv), buildengine.Parallelism(b.Build.Parallelism))
 	if err != nil {
 		return err
 	}
@@ -163,7 +163,7 @@ func (b *boxCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 			return err
 		}
 		files = append(files, filepath.Join(config.Dir, "ftl.toml"))
-		files = append(files, config.Schema())
+		files = append(files, projConfig.SchemaPath(config.Module))
 		for _, file := range files {
 			relFile, err := filepath.Rel(config.Dir, file)
 			if err != nil {

--- a/frontend/cli/cmd_box_run.go
+++ b/frontend/cli/cmd_box_run.go
@@ -75,7 +75,7 @@ func (b *boxRunCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 		return fmt.Errorf("controller failed to start: %w", err)
 	}
 
-	engine, err := buildengine.New(ctx, client, projConfig.Root(), []string{b.Dir}, runnerPortAllocator)
+	engine, err := buildengine.New(ctx, client, projConfig, []string{b.Dir}, runnerPortAllocator)
 	if err != nil {
 		return fmt.Errorf("failed to create build engine: %w", err)
 	}
@@ -85,7 +85,7 @@ func (b *boxRunCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 	// Manually import the schema for each module to get the dependency graph.
 	err = engine.Each(func(m buildengine.Module) error {
 		logger.Debugf("Loading schema for module %q", m.Config.Module)
-		mod, err := schema.ModuleFromProtoFile(m.Config.Abs().Schema())
+		mod, err := schema.ModuleFromProtoFile(projConfig.SchemaPath(m.Config.Module))
 		if err != nil {
 			return fmt.Errorf("failed to read schema for module %q: %w", m.Config.Module, err)
 		}

--- a/frontend/cli/cmd_build.go
+++ b/frontend/cli/cmd_build.go
@@ -31,7 +31,7 @@ func (b *buildCmd) Run(ctx context.Context, client ftlv1connect.ControllerServic
 	}
 	_ = bindAllocator.Next()
 
-	engine, err := buildengine.New(ctx, client, projConfig.Root(), b.Dirs, bindAllocator, buildengine.BuildEnv(b.BuildEnv), buildengine.Parallelism(b.Parallelism))
+	engine, err := buildengine.New(ctx, client, projConfig, b.Dirs, bindAllocator, buildengine.BuildEnv(b.BuildEnv), buildengine.Parallelism(b.Parallelism))
 	if err != nil {
 		return err
 	}

--- a/frontend/cli/cmd_config.go
+++ b/frontend/cli/cmd_config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/TBD54566975/ftl/backend/controller/admin"
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/configuration"
 	"github.com/TBD54566975/ftl/internal/configuration/manager"
 	"github.com/TBD54566975/ftl/internal/configuration/routers"
@@ -87,15 +86,7 @@ func setUpAdminClient(ctx context.Context, config projectconfig.Config) (ctxOut 
 			return ctx, client, fmt.Errorf("could not create secrets manager: %w", err)
 		}
 		ctx = manager.ContextWithSecrets(ctx, sm)
-
-		// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-		bindAllocator, err := bind.NewBindAllocator(cli.Endpoint)
-		if err != nil {
-			return ctx, client, fmt.Errorf("could not create bind allocator: %w", err)
-		}
-		_ = bindAllocator.Next()
-
-		return ctx, admin.NewLocalClient(cm, sm, bindAllocator), nil
+		return ctx, admin.NewLocalClient(cm, sm), nil
 	}
 	return ctx, adminServiceClient, nil
 }

--- a/frontend/cli/cmd_deploy.go
+++ b/frontend/cli/cmd_deploy.go
@@ -34,7 +34,7 @@ func (d *deployCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 	}
 	_ = bindAllocator.Next()
 
-	engine, err := buildengine.New(ctx, client, projConfig.Root(), d.Build.Dirs, bindAllocator, buildengine.BuildEnv(d.Build.BuildEnv), buildengine.Parallelism(d.Build.Parallelism))
+	engine, err := buildengine.New(ctx, client, projConfig, d.Build.Dirs, bindAllocator, buildengine.BuildEnv(d.Build.BuildEnv), buildengine.Parallelism(d.Build.Parallelism))
 	if err != nil {
 		return err
 	}

--- a/frontend/cli/cmd_dev.go
+++ b/frontend/cli/cmd_dev.go
@@ -108,7 +108,7 @@ func (d *devCmd) Run(ctx context.Context, k *kong.Kong, projConfig projectconfig
 			})
 		}
 
-		engine, err := buildengine.New(ctx, client, projConfig.Root(), d.Build.Dirs, bindAllocator, opts...)
+		engine, err := buildengine.New(ctx, client, projConfig, d.Build.Dirs, bindAllocator, opts...)
 		if err != nil {
 			return err
 		}

--- a/frontend/cli/cmd_schema_diff.go
+++ b/frontend/cli/cmd_schema_diff.go
@@ -127,7 +127,7 @@ func localSchema(ctx context.Context, projectConfig projectconfig.Config, bindAl
 			if err != nil {
 				moduleSchemas <- either.RightOf[*schema.Module](err)
 			}
-			module, err := schema.ModuleFromProtoFile(config.Abs().Schema())
+			module, err := schema.ModuleFromProtoFile(projectConfig.SchemaPath(config.Module))
 			if err != nil {
 				moduleSchemas <- either.RightOf[*schema.Module](err)
 				return

--- a/internal/buildengine/engine_test.go
+++ b/internal/buildengine/engine_test.go
@@ -3,6 +3,7 @@ package buildengine_test
 import (
 	"context"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/alecthomas/assert/v2"
@@ -10,6 +11,7 @@ import (
 	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine"
 	"github.com/TBD54566975/ftl/internal/log"
+	"github.com/TBD54566975/ftl/internal/projectconfig"
 	"github.com/TBD54566975/ftl/internal/schema"
 )
 
@@ -21,7 +23,11 @@ func TestGraph(t *testing.T) {
 	bindAllocator, err := bind.NewBindAllocator(bindURL)
 	assert.NoError(t, err)
 
-	engine, err := buildengine.New(ctx, nil, t.TempDir(), []string{"testdata/alpha", "testdata/other", "testdata/another"}, bindAllocator)
+	projConfig := projectconfig.Config{
+		Path: filepath.Join(t.TempDir(), "ftl-project.toml"),
+		Name: "test",
+	}
+	engine, err := buildengine.New(ctx, nil, projConfig, []string{"testdata/alpha", "testdata/other", "testdata/another"}, bindAllocator)
 	assert.NoError(t, err)
 
 	defer engine.Close()

--- a/internal/buildengine/languageplugin/java_plugin.go
+++ b/internal/buildengine/languageplugin/java_plugin.go
@@ -281,7 +281,7 @@ func buildJava(ctx context.Context, projectRoot, stubsRoot string, bctx BuildCon
 		return result, nil
 	}
 
-	moduleSchema, err := schema.ModuleFromProtoFile(config.Schema())
+	moduleSchema, err := schema.ModuleFromProtoFile(filepath.Join(config.DeployDir, "schema.pb"))
 	if err != nil {
 		return BuildResult{}, fmt.Errorf("failed to read schema for module: %w", err)
 	}

--- a/internal/buildengine/languageplugin/rust_plugin.go
+++ b/internal/buildengine/languageplugin/rust_plugin.go
@@ -3,6 +3,7 @@ package languageplugin
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/alecthomas/kong"
 	"github.com/alecthomas/types/optional"
@@ -69,7 +70,7 @@ func buildRust(ctx context.Context, projectRoot, stubsRoot string, bctx BuildCon
 		return result, nil
 	}
 
-	moduleSchema, err := schema.ModuleFromProtoFile(config.Schema())
+	moduleSchema, err := schema.ModuleFromProtoFile(filepath.Join(config.DeployDir, "schema.pb"))
 	if err != nil {
 		return BuildResult{}, fmt.Errorf("failed to read schema for module: %w", err)
 	}

--- a/internal/moduleconfig/moduleconfig.go
+++ b/internal/moduleconfig/moduleconfig.go
@@ -191,11 +191,3 @@ func isBeneath(moduleDir, path string) bool {
 	resolved := filepath.Clean(filepath.Join(moduleDir, path))
 	return strings.HasPrefix(resolved, strings.TrimSuffix(moduleDir, "/")+"/")
 }
-
-func (c ModuleConfig) Schema() string {
-	return "schema.pb"
-}
-
-func (c AbsModuleConfig) Schema() string {
-	return filepath.Join(c.DeployDir, "schema.pb")
-}

--- a/internal/projectconfig/projectconfig.go
+++ b/internal/projectconfig/projectconfig.go
@@ -199,3 +199,8 @@ func Save(config Config) error {
 	}
 	return os.Rename(w.Name(), config.Path)
 }
+
+// SchemaPath returns the path to the schema file for the given module.
+func (c Config) SchemaPath(module string) string {
+	return filepath.Join(c.Root(), ".ftl", "schemas", module+".pb")
+}


### PR DESCRIPTION
This removes the need for some cli commands to have a bind allocator, as they no longer need a language plugin to declare where the deploy dir is.