### PR TITLE
fix: regex match to show decl schema string

### DIFF
--- a/frontend/console/src/features/modules/decls/DeclPanel.tsx
+++ b/frontend/console/src/features/modules/decls/DeclPanel.tsx
@@ -52,7 +52,7 @@ export const DeclPanel = () => {
       return <SubscriptionPanel {...commonProps} value={decl as Subscription} />
     case 'topic':
       return <TopicPanel {...commonProps} value={decl as Topic} />
-    case 'typeAlias':
+    case 'typealias':
       return <TypeAliasPanel {...commonProps} value={decl as TypeAlias} />
     case 'verb':
       return <VerbPage {...nameProps} />

--- a/frontend/console/src/features/modules/schema/schema.utils.ts
+++ b/frontend/console/src/features/modules/schema/schema.utils.ts
@@ -163,7 +163,7 @@ export function declFromModuleSchemaString(declName: string, schema: string) {
 }
 
 function findDeclLinkIdx(declName: string, lines: string[]) {
-  const regex = new RegExp(`^  (export )?\\w+ ${declName}`)
+  const regex = new RegExp(`^  (export )?\\w+ ${declName}[ (<:]`)
   const foundIdx = lines.findIndex((line) => line.match(regex))
   if (foundIdx !== -1) {
     return foundIdx


### PR DESCRIPTION
This fixes the 2 issues we saw this morning:
* `compliance.Case` showed the schema for `compliance.CaseToken` instead of its own
* `typealias` decl pages don't show the schema at all