### PR TITLE
chore: attempt to improve integration test output

### DIFF
--- a/internal/integration/harness.go
+++ b/internal/integration/harness.go
@@ -258,7 +258,7 @@ func run(t *testing.T, actionsOrOptions ...ActionOrOption) {
 			assert.NoError(t, err)
 		}
 		if opts.requireJava || slices.Contains(opts.languages, "java") || slices.Contains(opts.languages, "kotlin") {
-			err = ftlexec.Command(ctx, log.Debug, rootDir, "just", "build-java", "-DskipTests", "-B").RunBuffered(ctx)
+			err = ftlexec.Command(ctx, log.Debug, rootDir, "just", "build-java", "-DskipTests", "-B").RunBufferedWithOutputTimeout(ctx, time.Minute*2)
 			assert.NoError(t, err)
 		}
 		if opts.localstack {


### PR DESCRIPTION
There have been lots of failures recently where tests and timing out on the JVM build.

Because the go test runtime panics we don't get any output, and the tests on CI are configured to fully buffer output.

This change will start streaming output after a set time, so if there is a hang we should be able to get more information.