### PR TITLE
fix: fail BindAllocator.Next() allocation for required ports

### DIFF
--- a/backend/controller/scaling/localscaling/local_scaling.go
+++ b/backend/controller/scaling/localscaling/local_scaling.go
@@ -161,13 +161,20 @@ func (l *localScaling) startRunner(ctx context.Context, deploymentKey string, in
 	controllerEndpoint := l.controllerAddresses[len(l.runners)%len(l.controllerAddresses)]
 	logger := log.FromContext(ctx)
 
-	bind := l.portAllocator.Next()
+	bind, err := l.portAllocator.Next()
+	if err != nil {
+		return fmt.Errorf("failed to start runner: %w", err)
+	}
 	var debug *localdebug.DebugInfo
 	debugPort := 0
 	if ide, ok := l.ideSupport.Get(); ok {
+		debugBind, err := l.portAllocator.NextPort()
+		if err != nil {
+			return fmt.Errorf("failed to start runner: %w", err)
+		}
 		debug = &localdebug.DebugInfo{
 			Language: info.language,
-			Port:     l.portAllocator.NextPort(),
+			Port:     debugBind,
 		}
 		l.debugPorts[info.module] = debug
 		ide.SyncIDEDebugIntegrations(ctx, l.debugPorts)

--- a/frontend/cli/cmd_box.go
+++ b/frontend/cli/cmd_box.go
@@ -126,11 +126,11 @@ func (b *boxCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 	}
 
 	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint)
+	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint, 0)
 	if err != nil {
 		return fmt.Errorf("could not create bind allocator: %w", err)
 	}
-	_ = bindAllocator.Next()
+	_, _ = bindAllocator.Next() //nolint:errcheck
 
 	engine, err := buildengine.New(ctx, client, projConfig, b.Build.Dirs, bindAllocator, buildengine.BuildEnv(b.Build.BuildEnv), buildengine.Parallelism(b.Build.Parallelism))
 	if err != nil {

--- a/frontend/cli/cmd_box_run.go
+++ b/frontend/cli/cmd_box_run.go
@@ -47,7 +47,7 @@ func (b *boxRunCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 	config.SetDefaults()
 
 	// Start the controller.
-	runnerPortAllocator, err := bind.NewBindAllocator(b.RunnerBase)
+	runnerPortAllocator, err := bind.NewBindAllocator(b.RunnerBase, 0)
 	if err != nil {
 		return fmt.Errorf("failed to create runner port allocator: %w", err)
 	}

--- a/frontend/cli/cmd_build.go
+++ b/frontend/cli/cmd_build.go
@@ -25,11 +25,11 @@ func (b *buildCmd) Run(ctx context.Context, client ftlv1connect.ControllerServic
 		return errors.New("no directories specified")
 	}
 	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint)
+	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint, 0)
 	if err != nil {
 		return fmt.Errorf("could not create bind allocator: %w", err)
 	}
-	_ = bindAllocator.Next()
+	_, _ = bindAllocator.Next() //nolint:errcheck
 
 	engine, err := buildengine.New(ctx, client, projConfig, b.Dirs, bindAllocator, buildengine.BuildEnv(b.BuildEnv), buildengine.Parallelism(b.Parallelism))
 	if err != nil {

--- a/frontend/cli/cmd_deploy.go
+++ b/frontend/cli/cmd_deploy.go
@@ -28,11 +28,11 @@ func (d *deployCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 	}
 
 	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint)
+	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint, 0)
 	if err != nil {
 		return fmt.Errorf("could not create bind allocator: %w", err)
 	}
-	_ = bindAllocator.Next()
+	_, _ = bindAllocator.Next() //nolint:errcheck
 
 	engine, err := buildengine.New(ctx, client, projConfig, d.Build.Dirs, bindAllocator, buildengine.BuildEnv(d.Build.BuildEnv), buildengine.Parallelism(d.Build.Parallelism))
 	if err != nil {

--- a/frontend/cli/cmd_dev.go
+++ b/frontend/cli/cmd_dev.go
@@ -67,7 +67,7 @@ func (d *devCmd) Run(ctx context.Context, k *kong.Kong, projConfig projectconfig
 	sm := terminal.FromContext(ctx)
 	starting := sm.NewStatus("\u001B[92mStarting FTL Server 🚀\u001B[39m")
 
-	bindAllocator, err := bind.NewBindAllocator(d.ServeCmd.Bind)
+	bindAllocator, err := bind.NewBindAllocator(d.ServeCmd.Bind, 1)
 	if err != nil {
 		return fmt.Errorf("could not create bind allocator: %w", err)
 	}
@@ -81,9 +81,6 @@ func (d *devCmd) Run(ctx context.Context, k *kong.Kong, projConfig projectconfig
 				return err
 			}
 			d.ServeCmd.Stop = false
-		}
-		if d.ServeCmd.isRunning(ctx, client) {
-			return errors.New(ftlRunningErrorMsg)
 		}
 
 		g.Go(func() error {

--- a/frontend/cli/cmd_new.go
+++ b/frontend/cli/cmd_new.go
@@ -64,7 +64,7 @@ func prepareNewCmd(ctx context.Context, k *kong.Kong, args []string) (optionalPl
 		return optionalPlugin, fmt.Errorf("could not parse default bind URL: %w", err)
 	}
 	var bindAllocator *bind.BindAllocator
-	bindAllocator, err = bind.NewBindAllocator(pluginBind)
+	bindAllocator, err = bind.NewBindAllocator(pluginBind, 0)
 	if err != nil {
 		return optionalPlugin, fmt.Errorf("could not create bind allocator: %w", err)
 	}

--- a/frontend/cli/cmd_schema_diff.go
+++ b/frontend/cli/cmd_schema_diff.go
@@ -44,11 +44,11 @@ func (d *schemaDiffCmd) Run(ctx context.Context, currentURL *url.URL, projConfig
 
 		// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
 		var bindAllocator *bind.BindAllocator
-		bindAllocator, err = bind.NewBindAllocator(cli.Endpoint)
+		bindAllocator, err = bind.NewBindAllocator(cli.Endpoint, 0)
 		if err != nil {
 			return fmt.Errorf("could not create bind allocator: %w", err)
 		}
-		_ = bindAllocator.Next()
+		_, _ = bindAllocator.Next() //nolint:errcheck
 
 		other, err = localSchema(ctx, projConfig, bindAllocator)
 	} else {

--- a/internal/buildengine/engine_test.go
+++ b/internal/buildengine/engine_test.go
@@ -20,7 +20,7 @@ func TestGraph(t *testing.T) {
 
 	bindURL, err := url.Parse("http://127.0.0.1:8893")
 	assert.NoError(t, err)
-	bindAllocator, err := bind.NewBindAllocator(bindURL)
+	bindAllocator, err := bind.NewBindAllocator(bindURL, 0)
 	assert.NoError(t, err)
 
 	projConfig := projectconfig.Config{

--- a/internal/buildengine/languageplugin/external_integration_test.go
+++ b/internal/buildengine/languageplugin/external_integration_test.go
@@ -15,6 +15,11 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/types/result"
+	"github.com/bmatcuk/doublestar/v4"
+	"golang.org/x/sync/errgroup"
+
 	langpb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/language"
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
 	"github.com/TBD54566975/ftl/internal/bind"
@@ -25,10 +30,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/schema"
 	"github.com/TBD54566975/ftl/internal/slices"
 	"github.com/TBD54566975/ftl/internal/watch"
-	"github.com/alecthomas/assert/v2"
-	"github.com/alecthomas/types/result"
-	"github.com/bmatcuk/doublestar/v4"
-	"golang.org/x/sync/errgroup"
 )
 
 // These integration tests are meant as a test suite for external plugins.
@@ -238,10 +239,11 @@ func startPlugin() in.Action {
 		in.Infof("Starting plugin")
 		baseBind, err := url.Parse("http://127.0.0.1:8893")
 		assert.NoError(t, err)
-		bindAllocator, err := bind.NewBindAllocator(baseBind)
+		bindAllocator, err := bind.NewBindAllocator(baseBind, 0)
 		assert.NoError(t, err)
 
-		bindURL = bindAllocator.Next()
+		bindURL, err = bindAllocator.Next()
+		assert.NoError(t, err)
 		client, err = newExternalPluginImpl(ic.Context, bindURL, ic.Language)
 		assert.NoError(t, err)
 	}

--- a/internal/buildengine/languageplugin/plugin.go
+++ b/internal/buildengine/languageplugin/plugin.go
@@ -141,7 +141,11 @@ func New(ctx context.Context, bindAllocator *bind.BindAllocator, language string
 	case "rust":
 		return newRustPlugin(ctx), nil
 	default:
-		return newExternalPlugin(ctx, bindAllocator.Next(), language)
+		port, err := bindAllocator.Next()
+		if err != nil {
+			return nil, fmt.Errorf("failed to allocate port for external plugin: %w", err)
+		}
+		return newExternalPlugin(ctx, port, language)
 	}
 }
 


### PR DESCRIPTION
The BindAllocator was designed for dynamically allocating ports, and will skip bound ports. This is intentional, but we don't want the initial controller ports (ingress and RPC) to be skipped if those ports are already bound.

Fixes #3190