### PR TITLE
fix: prevent topic_events being deleted if there is a subscription referencing it

### DIFF
--- a/backend/controller/sql/schema/20241029015638_subscription_cursor.sql
+++ b/backend/controller/sql/schema/20241029015638_subscription_cursor.sql
@@ -1,0 +1,11 @@
+-- migrate:up
+
+ALTER TABLE topic_subscriptions
+DROP CONSTRAINT topic_subscriptions_cursor_fkey,
+ADD CONSTRAINT topic_subscriptions_cursor_fkey
+FOREIGN KEY (cursor)
+REFERENCES topic_events (id)
+ON DELETE RESTRICT;
+
+-- migrate:down
+


### PR DESCRIPTION
This is because the subscription will lose it’s place if this happens. If we set it to null, the subscription will start from scratch (unexpected). If we cascade then we accidentally delete the subscription. We only delete topic events when trying to fix issues in a cluster, so restricting seems like the safest option to avoid accidental knock on effects.