### PR TITLE
fix: `ftl diff` no longer needs language plugins for schemas

### DIFF
--- a/frontend/cli/cmd_schema_diff.go
+++ b/frontend/cli/cmd_schema_diff.go
@@ -18,8 +18,6 @@ import (
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	schemapb "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/schema"
-	"github.com/TBD54566975/ftl/internal/bind"
-	"github.com/TBD54566975/ftl/internal/buildengine/languageplugin"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/projectconfig"
 	"github.com/TBD54566975/ftl/internal/rpc"
@@ -42,15 +40,7 @@ func (d *schemaDiffCmd) Run(ctx context.Context, currentURL *url.URL, projConfig
 		otherEndpoint = "Local Changes"
 		sameModulesOnly = true
 
-		// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-		var bindAllocator *bind.BindAllocator
-		bindAllocator, err = bind.NewBindAllocator(cli.Endpoint, 0)
-		if err != nil {
-			return fmt.Errorf("could not create bind allocator: %w", err)
-		}
-		_, _ = bindAllocator.Next() //nolint:errcheck
-
-		other, err = localSchema(ctx, projConfig, bindAllocator)
+		other, err = localSchema(ctx, projConfig)
 	} else {
 		other, err = schemaForURL(ctx, d.OtherEndpoint)
 	}
@@ -99,7 +89,7 @@ func (d *schemaDiffCmd) Run(ctx context.Context, currentURL *url.URL, projConfig
 	return nil
 }
 
-func localSchema(ctx context.Context, projectConfig projectconfig.Config, bindAllocator *bind.BindAllocator) (*schema.Schema, error) {
+func localSchema(ctx context.Context, projectConfig projectconfig.Config) (*schema.Schema, error) {
 	errs := []error{}
 	modules, err := watch.DiscoverModules(ctx, projectConfig.AbsModuleDirs())
 	if err != nil {
@@ -111,23 +101,7 @@ func localSchema(ctx context.Context, projectConfig projectconfig.Config, bindAl
 
 	for _, m := range modules {
 		go func() {
-			// Loading a plugin can be expensive. Is there a better way?
-			plugin, err := languageplugin.New(ctx, bindAllocator, m.Language)
-			if err != nil {
-				moduleSchemas <- either.RightOf[*schema.Module](err)
-			}
-			defer plugin.Kill() // nolint:errcheck
-
-			customDefaults, err := plugin.ModuleConfigDefaults(ctx, m.Dir)
-			if err != nil {
-				moduleSchemas <- either.RightOf[*schema.Module](err)
-			}
-
-			config, err := m.FillDefaultsAndValidate(customDefaults)
-			if err != nil {
-				moduleSchemas <- either.RightOf[*schema.Module](err)
-			}
-			module, err := schema.ModuleFromProtoFile(projectConfig.SchemaPath(config.Module))
+			module, err := schema.ModuleFromProtoFile(projectConfig.SchemaPath(m.Module))
 			if err != nil {
 				moduleSchemas <- either.RightOf[*schema.Module](err)
 				return


### PR DESCRIPTION
This was slow and required a bind allocator.
Now that we have `$(projectroot)/.ftl/schemas`, `ftl diff` can use that to find module schemas.