### PR TITLE
chore: clean up bind allocator without controller port

### DIFF
--- a/frontend/cli/bind.go
+++ b/frontend/cli/bind.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/TBD54566975/ftl/internal/bind"
+)
+
+// Create a bind allocator that skips the reserved port for the controller.
+//
+// The bind allocator will use cli.Endpoint if it is a local URL with a port. Otherwise a default port is used.
+func bindAllocatorWithoutController() (*bind.BindAllocator, error) {
+	var url *url.URL
+	var err error
+	// use cli.Endpoint if it is a local URL with a port
+	if cli.Endpoint != nil && cli.Endpoint.Port() != "" {
+		h := cli.Endpoint.Hostname()
+		ips, err := net.LookupIP(h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to look up IP: %w", err)
+		}
+		for _, netip := range ips {
+			if netip.IsLoopback() {
+				url = cli.Endpoint
+				break
+			}
+		}
+	}
+	// fallback to default
+	if url == nil {
+		url, err = url.Parse("http://127.0.0.1:8892")
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse default URL: %w", err)
+		}
+	}
+	bindAllocator, err := bind.NewBindAllocator(url, 0)
+	if err != nil {
+		return nil, fmt.Errorf("could not create bind allocator: %w", err)
+	}
+	// Skip initial port as it is reserved for the controller
+	_, _ = bindAllocator.Next() //nolint:errcheck
+	return bindAllocator, nil
+}

--- a/frontend/cli/bind_test.go
+++ b/frontend/cli/bind_test.go
@@ -16,10 +16,10 @@ func TestBindLocalWithRemoteEndpoint(t *testing.T) {
 	bindAllocator, err := bindAllocatorWithoutController()
 	assert.NoError(t, err)
 
-	nextUrl, err := bindAllocator.Next()
+	nextURL, err := bindAllocator.Next()
 	assert.NoError(t, err)
 
-	assert.True(t, strings.HasPrefix(nextUrl.String(), "http://127.0.0.1:"), nextUrl.String())
+	assert.True(t, strings.HasPrefix(nextURL.String(), "http://127.0.0.1:"), nextURL.String())
 
 	bindAllocatorWithoutController()
 }

--- a/frontend/cli/bind_test.go
+++ b/frontend/cli/bind_test.go
@@ -21,5 +21,6 @@ func TestBindLocalWithRemoteEndpoint(t *testing.T) {
 
 	assert.True(t, strings.HasPrefix(nextURL.String(), "http://127.0.0.1:"), nextURL.String())
 
-	bindAllocatorWithoutController()
+	_, err = bindAllocatorWithoutController()
+	assert.NoError(t, err)
 }

--- a/frontend/cli/bind_test.go
+++ b/frontend/cli/bind_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/assert/v2"
+)
+
+func TestBindLocalWithRemoteEndpoint(t *testing.T) {
+	var err error
+	cli.Endpoint, err = url.Parse("http://block.xyz:80")
+	assert.NoError(t, err)
+
+	bindAllocator, err := bindAllocatorWithoutController()
+	assert.NoError(t, err)
+
+	nextUrl, err := bindAllocator.Next()
+	assert.NoError(t, err)
+
+	assert.True(t, strings.HasPrefix(nextUrl.String(), "http://127.0.0.1:"), nextUrl.String())
+
+	bindAllocatorWithoutController()
+}

--- a/frontend/cli/cmd_box.go
+++ b/frontend/cli/cmd_box.go
@@ -15,7 +15,6 @@ import (
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/controller/dsn"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine"
 	"github.com/TBD54566975/ftl/internal/exec"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -126,11 +125,10 @@ func (b *boxCmd) Run(ctx context.Context, client ftlv1connect.ControllerServiceC
 	}
 
 	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint, 0)
+	bindAllocator, err := bindAllocatorWithoutController()
 	if err != nil {
-		return fmt.Errorf("could not create bind allocator: %w", err)
+		return err
 	}
-	_, _ = bindAllocator.Next() //nolint:errcheck
 
 	engine, err := buildengine.New(ctx, client, projConfig, b.Build.Dirs, bindAllocator, buildengine.BuildEnv(b.Build.BuildEnv), buildengine.Parallelism(b.Build.Parallelism))
 	if err != nil {

--- a/frontend/cli/cmd_box_run.go
+++ b/frontend/cli/cmd_box_run.go
@@ -47,11 +47,11 @@ func (b *boxRunCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 	config.SetDefaults()
 
 	// Start the controller.
-	runnerPortAllocator, err := bind.NewBindAllocator(b.RunnerBase, 0)
+	bindAllocator, err := bind.NewBindAllocator(b.RunnerBase, 0)
 	if err != nil {
 		return fmt.Errorf("failed to create runner port allocator: %w", err)
 	}
-	runnerScaling, err := localscaling.NewLocalScaling(runnerPortAllocator, []*url.URL{b.Bind}, "", false)
+	runnerScaling, err := localscaling.NewLocalScaling(bindAllocator, []*url.URL{b.Bind}, "", false)
 	if err != nil {
 		return fmt.Errorf("failed to create runner autoscaler: %w", err)
 	}
@@ -73,7 +73,7 @@ func (b *boxRunCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 		return fmt.Errorf("controller failed to start: %w", err)
 	}
 
-	engine, err := buildengine.New(ctx, client, projConfig, []string{b.Dir}, runnerPortAllocator)
+	engine, err := buildengine.New(ctx, client, projConfig, []string{b.Dir}, bindAllocator)
 	if err != nil {
 		return fmt.Errorf("failed to create build engine: %w", err)
 	}

--- a/frontend/cli/cmd_build.go
+++ b/frontend/cli/cmd_build.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine"
 	"github.com/TBD54566975/ftl/internal/projectconfig"
 )
@@ -25,11 +24,10 @@ func (b *buildCmd) Run(ctx context.Context, client ftlv1connect.ControllerServic
 		return errors.New("no directories specified")
 	}
 	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-	bindAllocator, err := bind.NewBindAllocator(cli.Endpoint, 0)
+	bindAllocator, err := bindAllocatorWithoutController()
 	if err != nil {
-		return fmt.Errorf("could not create bind allocator: %w", err)
+		return err
 	}
-	_, _ = bindAllocator.Next() //nolint:errcheck
 
 	engine, err := buildengine.New(ctx, client, projConfig, b.Dirs, bindAllocator, buildengine.BuildEnv(b.BuildEnv), buildengine.Parallelism(b.Parallelism))
 	if err != nil {

--- a/frontend/cli/cmd_deploy.go
+++ b/frontend/cli/cmd_deploy.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"net/url"
 
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner/provisionerconnect"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine"
 	"github.com/TBD54566975/ftl/internal/projectconfig"
 	"github.com/TBD54566975/ftl/internal/rpc"
@@ -28,16 +25,10 @@ func (d *deployCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 		client = rpc.ClientFromContext[ftlv1connect.ControllerServiceClient](ctx)
 	}
 
-	// use the cli endpoint to create the bind allocator, but leave the first port unused as it is meant to be reserved by a controller
-	bindURL, err := url.Parse("http://127.0.0.1:8892")
+	bindAllocator, err := bindAllocatorWithoutController()
 	if err != nil {
-		return fmt.Errorf("could not parse default bind URL: %w", err)
+		return err
 	}
-	bindAllocator, err := bind.NewBindAllocator(bindURL, 0)
-	if err != nil {
-		return fmt.Errorf("could not create bind allocator: %w", err)
-	}
-	_, _ = bindAllocator.Next() //nolint:errcheck
 
 	engine, err := buildengine.New(ctx, client, projConfig, d.Build.Dirs, bindAllocator, buildengine.BuildEnv(d.Build.BuildEnv), buildengine.Parallelism(d.Build.Parallelism))
 	if err != nil {

--- a/frontend/cli/cmd_new.go
+++ b/frontend/cli/cmd_new.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"go/token"
-	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,7 +14,6 @@ import (
 	"github.com/alecthomas/types/optional"
 
 	"github.com/TBD54566975/ftl/internal"
-	"github.com/TBD54566975/ftl/internal/bind"
 	"github.com/TBD54566975/ftl/internal/buildengine/languageplugin"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/moduleconfig"
@@ -57,16 +55,9 @@ func prepareNewCmd(ctx context.Context, k *kong.Kong, args []string) (optionalPl
 		return optionalPlugin, fmt.Errorf("could not find new command")
 	}
 
-	// Too early to use any kong args here so we can't use cli.Endpoint.
-	// Hardcoding the default bind URL for now.
-	pluginBind, err := url.Parse("http://127.0.0.1:8893")
+	bindAllocator, err := bindAllocatorWithoutController()
 	if err != nil {
-		return optionalPlugin, fmt.Errorf("could not parse default bind URL: %w", err)
-	}
-	var bindAllocator *bind.BindAllocator
-	bindAllocator, err = bind.NewBindAllocator(pluginBind, 0)
-	if err != nil {
-		return optionalPlugin, fmt.Errorf("could not create bind allocator: %w", err)
+		return optionalPlugin, err
 	}
 
 	plugin, err := languageplugin.New(ctx, bindAllocator, language, "new")


### PR DESCRIPTION
There is odd behaviour we need when choosing a port to use for runners and language plugins:
- Do not bind to the port reserved for controllers
- Do not use the cli.Endpoint if it is a remote endpoint

Best to have all that oddness collected into one place.