### PR TITLE
feat: Add index to async_table to speed up lease deletions

### DIFF
--- a/backend/controller/sql/schema/20241029142130_add_index_to_async_calls.sql
+++ b/backend/controller/sql/schema/20241029142130_add_index_to_async_calls.sql
@@ -1,0 +1,6 @@
+-- migrate:up
+
+CREATE INDEX idx_async_calls_lease_id ON async_calls(lease_id);
+
+-- migrate:down
+


### PR DESCRIPTION
Lease deletions are done by executing the following sql statement: 
```sql
-- name: ReleaseLease :one
DELETE FROM leases
WHERE idempotency_key = $1 AND key = $2::lease_key
RETURNING true
```

This table is referenced by `leases_id` in the `async_calls` table. So a deletion needs to lookup of such foreign key within the `async_calls` table in order to set the row's value to NULL.

This PR adds an index to that foreign_key, so that deletions of leases can happen much much faster. 