### PR TITLE
fix: improve delay before subscriber receives event

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -276,7 +276,7 @@ func New(ctx context.Context, conn *sql.DB, config Config, devel bool, runnerSca
 	}
 	svc.schemaState.Store(schemaState{routes: map[string]Route{}, schema: &schema.Schema{}})
 
-	pubSub := pubsub.New(conn, encryption, svc.tasks, optional.Some[pubsub.AsyncCallListener](svc))
+	pubSub := pubsub.New(ctx, conn, encryption, optional.Some[pubsub.AsyncCallListener](svc))
 	svc.pubSub = pubSub
 
 	svc.registry = artefacts.New(conn)

--- a/backend/controller/cronjobs/internal/cronjobs_test.go
+++ b/backend/controller/cronjobs/internal/cronjobs_test.go
@@ -18,9 +18,7 @@ import (
 	parentdal "github.com/TBD54566975/ftl/backend/controller/dal"
 	dalmodel "github.com/TBD54566975/ftl/backend/controller/dal/model"
 	"github.com/TBD54566975/ftl/backend/controller/encryption"
-	"github.com/TBD54566975/ftl/backend/controller/leases"
 	"github.com/TBD54566975/ftl/backend/controller/pubsub"
-	"github.com/TBD54566975/ftl/backend/controller/scheduledtask"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
 	"github.com/TBD54566975/ftl/backend/controller/timeline"
 	"github.com/TBD54566975/ftl/backend/libdal"
@@ -49,8 +47,7 @@ func TestNewCronJobsForModule(t *testing.T) {
 	timelineSrv := timeline.New(ctx, conn, encryption)
 	cjs := cronjobs.NewForTesting(ctx, key, "test.com", encryption, timelineSrv, *dal, clk)
 
-	scheduler := scheduledtask.New(ctx, key, leases.NewFakeLeaser())
-	pubSub := pubsub.New(conn, encryption, scheduler, optional.None[pubsub.AsyncCallListener]())
+	pubSub := pubsub.New(ctx, conn, encryption, optional.None[pubsub.AsyncCallListener]())
 	parentDAL := parentdal.New(ctx, conn, encryption, pubSub, cjs)
 	moduleName := "initial"
 	jobsToCreate := newCronJobs(t, moduleName, "* * * * * *", clk, 2) // every minute

--- a/backend/controller/dal/async_calls_test.go
+++ b/backend/controller/dal/async_calls_test.go
@@ -9,9 +9,7 @@ import (
 
 	"github.com/TBD54566975/ftl/backend/controller/async"
 	"github.com/TBD54566975/ftl/backend/controller/encryption"
-	"github.com/TBD54566975/ftl/backend/controller/leases"
 	"github.com/TBD54566975/ftl/backend/controller/pubsub"
-	"github.com/TBD54566975/ftl/backend/controller/scheduledtask"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
 	"github.com/TBD54566975/ftl/backend/libdal"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -24,8 +22,7 @@ func TestNoCallToAcquire(t *testing.T) {
 	conn := sqltest.OpenForTesting(ctx, t)
 	encryption, err := encryption.New(ctx, conn, encryption.NewBuilder())
 	assert.NoError(t, err)
-	scheduler := scheduledtask.New(ctx, model.ControllerKey{}, leases.NewFakeLeaser())
-	pubSub := pubsub.New(conn, encryption, scheduler, optional.None[pubsub.AsyncCallListener]())
+	pubSub := pubsub.New(ctx, conn, encryption, optional.None[pubsub.AsyncCallListener]())
 	dal := New(ctx, conn, encryption, pubSub, nil)
 
 	_, _, err = dal.AcquireAsyncCall(ctx)

--- a/backend/controller/dal/dal_test.go
+++ b/backend/controller/dal/dal_test.go
@@ -18,9 +18,7 @@ import (
 
 	dalmodel "github.com/TBD54566975/ftl/backend/controller/dal/model"
 	"github.com/TBD54566975/ftl/backend/controller/encryption"
-	"github.com/TBD54566975/ftl/backend/controller/leases"
 	"github.com/TBD54566975/ftl/backend/controller/pubsub"
-	"github.com/TBD54566975/ftl/backend/controller/scheduledtask"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
 	"github.com/TBD54566975/ftl/backend/libdal"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -35,8 +33,7 @@ func TestDAL(t *testing.T) {
 	encryption, err := encryption.New(ctx, conn, encryption.NewBuilder())
 	assert.NoError(t, err)
 
-	scheduler := scheduledtask.New(ctx, model.ControllerKey{}, leases.NewFakeLeaser())
-	pubSub := pubsub.New(conn, encryption, scheduler, optional.None[pubsub.AsyncCallListener]())
+	pubSub := pubsub.New(ctx, conn, encryption, optional.None[pubsub.AsyncCallListener]())
 	timelineSrv := timeline.New(ctx, conn, encryption)
 	key := model.NewControllerKey("localhost", "8081")
 	cjs := cronjobs.New(ctx, key, "test.com", encryption, timelineSrv, conn)
@@ -198,8 +195,7 @@ func TestCreateArtefactConflict(t *testing.T) {
 	encryption, err := encryption.New(ctx, conn, encryption.NewBuilder())
 	assert.NoError(t, err)
 
-	scheduler := scheduledtask.New(ctx, model.ControllerKey{}, leases.NewFakeLeaser())
-	pubSub := pubsub.New(conn, encryption, scheduler, optional.None[pubsub.AsyncCallListener]())
+	pubSub := pubsub.New(ctx, conn, encryption, optional.None[pubsub.AsyncCallListener]())
 
 	timelineSrv := timeline.New(ctx, conn, encryption)
 	key := model.NewControllerKey("localhost", "8081")

--- a/backend/controller/pubsub/integration_test.go
+++ b/backend/controller/pubsub/integration_test.go
@@ -63,7 +63,7 @@ func TestConsumptionDelay(t *testing.T) {
 		in.Sleep(time.Second*2),
 
 		// Get all event created ats, and all async call created ats
-		// Compare each, make sure none are less than 0.2s of each other
+		// Compare each, make sure none are less than 0.1s of each other
 		in.QueryRow("ftl", `
 			WITH event_times AS (
 				SELECT created_at, ROW_NUMBER() OVER (ORDER BY created_at) AS row_num
@@ -80,7 +80,7 @@ func TestConsumptionDelay(t *testing.T) {
 			SELECT COUNT(*)
 			FROM event_times
 			JOIN async_call_times ON event_times.row_num = async_call_times.row_num
-			WHERE ABS(EXTRACT(EPOCH FROM (event_times.created_at - async_call_times.created_at))) < 0.2;
+			WHERE ABS(EXTRACT(EPOCH FROM (event_times.created_at - async_call_times.created_at))) < 0.1;
 		`, 0),
 	)
 }

--- a/backend/controller/pubsub/service.go
+++ b/backend/controller/pubsub/service.go
@@ -82,7 +82,9 @@ func (s *Service) poll(ctx context.Context) {
 			publishedAt = optional.None[time.Time]()
 
 		case <-time.After(poll):
-			s.progressSubscriptions(ctx)
+			if err := s.progressSubscriptions(ctx); err != nil {
+				logger.Warnf("%s", err)
+			}
 		}
 	}
 }

--- a/backend/controller/pubsub/service.go
+++ b/backend/controller/pubsub/service.go
@@ -62,7 +62,7 @@ func (s *Service) poll(ctx context.Context) {
 		}
 
 		// poll interval with jitter (1s - 1.1s)
-		poll := time.Millisecond * (time.Duration(rand.Float64())*(100.0) + 1000.0)
+		poll := time.Millisecond * (time.Duration(rand.Float64())*(100.0) + 1000.0) //nolint:gosec
 
 		select {
 		case <-ctx.Done():

--- a/backend/controller/timeline/internal/timeline_test.go
+++ b/backend/controller/timeline/internal/timeline_test.go
@@ -20,9 +20,7 @@ import (
 	controllerdal "github.com/TBD54566975/ftl/backend/controller/dal"
 	dalmodel "github.com/TBD54566975/ftl/backend/controller/dal/model"
 	"github.com/TBD54566975/ftl/backend/controller/encryption"
-	"github.com/TBD54566975/ftl/backend/controller/leases"
 	"github.com/TBD54566975/ftl/backend/controller/pubsub"
-	"github.com/TBD54566975/ftl/backend/controller/scheduledtask"
 	"github.com/TBD54566975/ftl/backend/controller/sql/sqltest"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/model"
@@ -38,8 +36,7 @@ func TestTimeline(t *testing.T) {
 
 	timeline := timeline2.New(ctx, conn, encryption)
 	registry := artefacts.New(conn)
-	scheduler := scheduledtask.New(ctx, model.ControllerKey{}, leases.NewFakeLeaser())
-	pubSub := pubsub.New(conn, encryption, scheduler, optional.None[pubsub.AsyncCallListener]())
+	pubSub := pubsub.New(ctx, conn, encryption, optional.None[pubsub.AsyncCallListener]())
 
 	key := model.NewControllerKey("localhost", strconv.Itoa(8080+1))
 	cjs := cronjobs.New(ctx, key, "test.com", encryption, timeline, conn)
@@ -248,8 +245,7 @@ func TestDeleteOldEvents(t *testing.T) {
 
 	timeline := timeline2.New(ctx, conn, encryption)
 	registry := artefacts.New(conn)
-	scheduler := scheduledtask.New(ctx, model.ControllerKey{}, leases.NewFakeLeaser())
-	pubSub := pubsub.New(conn, encryption, scheduler, optional.None[pubsub.AsyncCallListener]())
+	pubSub := pubsub.New(ctx, conn, encryption, optional.None[pubsub.AsyncCallListener]())
 	controllerDAL := controllerdal.New(ctx, conn, encryption, pubSub, nil)
 
 	var testContent = bytes.Repeat([]byte("sometestcontentthatislongerthanthereadbuffer"), 100)


### PR DESCRIPTION
Before the change, the new integration test was showing delays ranging from 0.2s - 1.2s from when an event is published to when the async call is created.
After the change we are consistently under 0.2s.