### PR TITLE
fix: handle lease failure better

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -245,12 +245,6 @@ func RetryStreamingServerStream[Req, Resp any](
 	for {
 		stream, err := rpc(ctx, connect.NewRequest(req))
 		if err == nil {
-			defer func(stream *connect.ServerStreamForClient[Resp]) {
-				err := stream.Close()
-				if err != nil {
-					logger.Debugf("Failed to close stream: %s", err)
-				}
-			}(stream)
 			for {
 				if stream.Receive() {
 					resp := stream.Msg()
@@ -265,6 +259,10 @@ func RetryStreamingServerStream[Req, Resp any](
 					}
 					select {
 					case <-ctx.Done():
+						err := stream.Close()
+						if err != nil {
+							logger.Debugf("Failed to close stream: %s", err)
+						}
 						return
 					default:
 					}
@@ -276,6 +274,10 @@ func RetryStreamingServerStream[Req, Resp any](
 					logLevel = logLevelForError(err)
 					break
 				}
+			}
+			err := stream.Close()
+			if err != nil {
+				logger.Debugf("Failed to close stream: %s", err)
 			}
 		}
 


### PR DESCRIPTION
When your laptop goes to sleep we were seeing lots of runner restarts using a cancelled lease context.

It is hard to reproduce reliably, but this should work around it for now.

I could not reproduce the issue by manually cancelling the lease, it only happens when the computer hibernates.

fixes: #3177