### PR TITLE
fix: fallback to asm secret provider in cluster

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -59,7 +59,6 @@ import (
 	frontend "github.com/TBD54566975/ftl/frontend/console"
 	"github.com/TBD54566975/ftl/internal/configuration"
 	cf "github.com/TBD54566975/ftl/internal/configuration/manager"
-	"github.com/TBD54566975/ftl/internal/configuration/providers"
 	"github.com/TBD54566975/ftl/internal/cors"
 	ftlhttp "github.com/TBD54566975/ftl/internal/http"
 	"github.com/TBD54566975/ftl/internal/log"
@@ -72,6 +71,9 @@ import (
 	"github.com/TBD54566975/ftl/internal/schema"
 	"github.com/TBD54566975/ftl/internal/sha256"
 	"github.com/TBD54566975/ftl/internal/slices"
+
+	goslices "slices"
+
 	status "github.com/TBD54566975/ftl/internal/terminal"
 )
 
@@ -1047,8 +1049,18 @@ func (s *Service) CreateDeployment(ctx context.Context, req *connect.Request[ftl
 	for _, d := range module.Decls {
 		if db, ok := d.(*schema.Database); ok && db.Runtime != nil {
 			key := dsnSecretKey(module.Name, db.Name)
+
 			// TODO: Use a cluster specific default provider
-			if err := sm.Set(ctx, providers.InlineProviderKey, configuration.NewRef(module.Name, key), db.Runtime.DSN); err != nil {
+			allKeys := sm.ProviderKeys()
+			var providerKey configuration.ProviderKey
+			for _, key := range []configuration.ProviderKey{"inline", "asm"} {
+				if goslices.Contains(allKeys, key) {
+					providerKey = key
+					break
+				}
+			}
+
+			if err := sm.Set(ctx, providerKey, configuration.NewRef(module.Name, key), db.Runtime.DSN); err != nil {
 				return nil, fmt.Errorf("could not set database secret %s: %w", key, err)
 			}
 			logger.Infof("Database declaration: %s -> %s", db.Name, db.Runtime.DSN)

--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	goslices "slices"
 	"sort"
 	"strings"
 	"sync"
@@ -71,9 +72,6 @@ import (
 	"github.com/TBD54566975/ftl/internal/schema"
 	"github.com/TBD54566975/ftl/internal/sha256"
 	"github.com/TBD54566975/ftl/internal/slices"
-
-	goslices "slices"
-
 	status "github.com/TBD54566975/ftl/internal/terminal"
 )
 

--- a/internal/configuration/manager/manager.go
+++ b/internal/configuration/manager/manager.go
@@ -141,6 +141,15 @@ func (m *Manager[R]) availableProviderKeys() []string {
 	return keys
 }
 
+// ProviderKeys returns the keys of the available providers.
+func (m *Manager[R]) ProviderKeys() []configuration.ProviderKey {
+	keys := make([]configuration.ProviderKey, 0, len(m.providers))
+	for k := range m.providers {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
 // Set a configuration value, encoding "value" as JSON before storing it.
 func (m *Manager[R]) Set(ctx context.Context, pkey configuration.ProviderKey, ref configuration.Ref, value any) error {
 	data, err := json.Marshal(value)


### PR DESCRIPTION
We need to proeprly define a defaul secret manager, but for now, fall back to ASM manager if inline is not available. This will unblock DB provisioning in dev