### PR TITLE
revert: "fix: reduce spammy logs for pings"

### DIFF
--- a/frontend/cli/cmd_bench.go
+++ b/frontend/cli/cmd_bench.go
@@ -29,7 +29,9 @@ type benchCmd struct {
 }
 
 func (c *benchCmd) Run(ctx context.Context, client ftlv1connect.VerbServiceClient) error {
-	if err := rpc.Wait(ctx, backoff.Backoff{Max: time.Second * 2}, c.Wait, client); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, c.Wait)
+	defer cancel()
+	if err := rpc.Wait(ctx, backoff.Backoff{Max: time.Second * 2}, client); err != nil {
 		return fmt.Errorf("FTL cluster did not become ready: %w", err)
 	}
 	logger := log.FromContext(ctx)

--- a/frontend/cli/cmd_box_run.go
+++ b/frontend/cli/cmd_box_run.go
@@ -69,7 +69,9 @@ func (b *boxRunCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 
 	// Wait for the controller to come up.
 	client := ftlv1connect.NewControllerServiceClient(rpc.GetHTTPClient(b.Bind.String()), b.Bind.String())
-	if err := rpc.Wait(ctx, backoff.Backoff{}, b.ControllerTimeout, client); err != nil {
+	waitCtx, cancel := context.WithTimeout(ctx, b.ControllerTimeout)
+	defer cancel()
+	if err := rpc.Wait(waitCtx, backoff.Backoff{}, client); err != nil {
 		return fmt.Errorf("controller failed to start: %w", err)
 	}
 

--- a/frontend/cli/cmd_call.go
+++ b/frontend/cli/cmd_call.go
@@ -29,7 +29,9 @@ type callCmd struct {
 }
 
 func (c *callCmd) Run(ctx context.Context, client ftlv1connect.VerbServiceClient, ctlCli ftlv1connect.ControllerServiceClient) error {
-	if err := rpc.Wait(ctx, backoff.Backoff{Max: time.Second * 2}, c.Wait, client); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, c.Wait)
+	defer cancel()
+	if err := rpc.Wait(ctx, backoff.Backoff{Max: time.Second * 2}, client); err != nil {
 		return err
 	}
 

--- a/frontend/cli/cmd_ping.go
+++ b/frontend/cli/cmd_ping.go
@@ -15,5 +15,7 @@ type pingCmd struct {
 }
 
 func (c *pingCmd) Run(ctx context.Context, controller ftlv1connect.ControllerServiceClient) error {
-	return rpc.Wait(ctx, backoff.Backoff{Max: time.Second}, c.Wait, controller) //nolint:wrapcheck
+	ctx, cancel := context.WithTimeout(ctx, c.Wait)
+	defer cancel()
+	return rpc.Wait(ctx, backoff.Backoff{Max: time.Second}, controller)
 }

--- a/frontend/cli/cmd_ping.go
+++ b/frontend/cli/cmd_ping.go
@@ -17,5 +17,5 @@ type pingCmd struct {
 func (c *pingCmd) Run(ctx context.Context, controller ftlv1connect.ControllerServiceClient) error {
 	ctx, cancel := context.WithTimeout(ctx, c.Wait)
 	defer cancel()
-	return rpc.Wait(ctx, backoff.Backoff{Max: time.Second}, controller)
+	return rpc.Wait(ctx, backoff.Backoff{Max: time.Second}, controller) //nolint:wrapcheck
 }

--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -83,7 +83,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 			return err
 		}
 		if s.Provisioners > 0 {
-			if err := rpc.Wait(ctx, backoff.Backoff{Max: s.StartupTimeout}, s.StartupTimeout, provisionerClient); err != nil {
+			if err := rpc.Wait(ctx, backoff.Backoff{Max: s.StartupTimeout}, provisionerClient); err != nil {
 				return fmt.Errorf("provisioner failed to start: %w", err)
 			}
 		}
@@ -244,7 +244,7 @@ func (s *serveCmd) run(ctx context.Context, projConfig projectconfig.Config, ini
 		return fmt.Errorf("controller failed to start: %w", err)
 	}
 	if s.Provisioners > 0 {
-		if err := rpc.Wait(ctx, backoff.Backoff{Max: s.StartupTimeout}, s.StartupTimeout, provisionerClient); err != nil {
+		if err := rpc.Wait(ctx, backoff.Backoff{Max: s.StartupTimeout}, provisionerClient); err != nil {
 			return fmt.Errorf("provisioner failed to start: %w", err)
 		}
 	}

--- a/internal/buildengine/languageplugin/external_plugin_client.go
+++ b/internal/buildengine/languageplugin/external_plugin_client.go
@@ -124,7 +124,10 @@ func (p *externalPluginImpl) start(ctx context.Context, bind *url.URL, language,
 }
 
 func (p *externalPluginImpl) ping(ctx context.Context) error {
-	err := rpc.Wait(ctx, backoff.Backoff{}, launchTimeout, p.client)
+	retry := backoff.Backoff{}
+	heartbeatCtx, cancel := context.WithTimeout(ctx, launchTimeout)
+	defer cancel()
+	err := rpc.Wait(heartbeatCtx, retry, p.client)
 	if err != nil {
 		return connect.NewError(connect.CodeUnavailable, fmt.Errorf("failed to connect to runner: %w", err))
 	}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -151,7 +151,7 @@ func Wait(ctx context.Context, retry backoff.Backoff, client Pingable) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return ctx.Err() //nolint:wrapcheck
 		default:
 		}
 		resp, err := client.Ping(ctx, connect.NewRequest(&ftlv1.PingRequest{}))


### PR DESCRIPTION
Reverts TBD54566975/ftl#3150

This broke runners. They failed to start with
```
{"level":"warn","attributes":{"deployment":"dpl-alice-4p86gzxx2zr5soc0","module":"alice","scope":"alice"},"message":"Plugin failed to start, terminating pid 11","time":"2024-10-30T03:06:14.701727838Z"}
ftl-runner: error: failed to spawn plugin: plugin process died: context canceled
```