### PR TITLE
ci: CI uses build/release for language plugins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         uses: ./.github/actions/build-cache
       - name: Docker Compose
         run: docker compose up -d --wait
+      - name: Build Language Plugins
+        run: just build-language-plugins
       - name: Test
         run: |
           go-test-annotate
@@ -34,6 +36,8 @@ jobs:
         uses: ./.github/actions/build-cache
       - name: Docker Compose
         run: docker compose up -d --wait
+      - name: Build Language Plugins
+        run: just build-language-plugins
       - name: Test README
         run: just test-readme
   test-scripts:
@@ -265,6 +269,8 @@ jobs:
         uses: ./.github/actions/build-cache
       - name: Console pnpm install
         run: just pnpm-install
+      - name: Build Language Plugins
+        run: just build-language-plugins
       - name: Console e2e
         run: just e2e-frontend
   integration-shard:
@@ -307,6 +313,8 @@ jobs:
         run: just init-db
       - name: Download Go Modules
         run: go mod download
+      - name: Build Language Plugins
+        run: just build-language-plugins
       - name: Run ${{ matrix.test }}
         run: |
           set -euo pipefail
@@ -352,6 +360,8 @@ jobs:
         run: just init-db
       - name: Download Go Modules
         run: go mod download
+      - name: Build Language Plugins
+        run: just build-language-plugins
       - name: Run ${{ matrix.test }}
         run: |
           set -euo pipefail

--- a/Justfile
+++ b/Justfile
@@ -39,7 +39,7 @@ dev *args:
   watchexec -r {{WATCHEXEC_ARGS}} -- "just build-sqlc && ftl dev --plain {{args}}"
 
 # Build everything
-build-all: build-protos-unconditionally build-backend build-backend-tests build-frontend build-generate build-sqlc build-zips lsp-generate build-java build-python
+build-all: build-protos-unconditionally build-backend build-backend-tests build-frontend build-generate build-sqlc build-zips lsp-generate build-java build-language-plugins
 
 # Run "go generate" on all packages
 build-generate:
@@ -73,6 +73,9 @@ build-backend-tests:
 
 build-java *args:
   mvn -f jvm-runtime/ftl-runtime install {{args}}
+
+# Builds all language plugins
+build-language-plugins: build-python
 
 # Build ftl-language-python
 build-python: build-zips build-protos

--- a/scripts/ftl-language-python
+++ b/scripts/ftl-language-python
@@ -2,6 +2,11 @@
 set -euo pipefail
 ftldir="$(dirname "$(readlink -f "$0")")/.."
 name="ftl-language-python"
-dest="${ftldir}/build/devel"
-mkdir -p "$dest"
-(cd "${ftldir}/python-runtime/cmd/ftl-language-python" && "${ftldir}/bin/go" build -ldflags="-s -w -buildid=" -o "$dest/${name}" ./) && exec "$dest/${name}" "$@"
+if [ -n "${CI-}" ]; then
+  dest="${ftldir}/build/release"
+else
+  dest="${ftldir}/build/devel"
+  mkdir -p "$dest"
+  (cd "${ftldir}/python-runtime/cmd/ftl-language-python" && "${ftldir}/bin/go" build -ldflags="-s -w -buildid=" -o "$dest/${name}" ./)
+fi
+exec "$dest/${name}" "$@"


### PR DESCRIPTION
Language plugins can timeout if `./script/language-plugin-xyz` builds it each time in CI.
Instead in CI we pre-build all language plugins and make the script use the release binary.
