### PR TITLE
feat: console shows verb subtypes: cronjob, ingress, subscriber, all other verbs

### DIFF
--- a/frontend/console/src/components/Multiselect.tsx
+++ b/frontend/console/src/components/Multiselect.tsx
@@ -99,7 +99,7 @@ export const Multiselect = ({
               <GroupIcon group={group} allOpts={allOpts} selectedOpts={selectedOpts} />
               {group}
             </div>,
-            ...allOpts.filter((o) => o.group === group).map((o) => <Option key={o.key} o={o} p='7' />),
+            ...allOpts.filter((o) => o.group === group).map((o) => <Option key={o.key} o={o} p='6' />),
           ])}
 
           <div className='w-full text-center text-xs mt-2'>

--- a/frontend/console/src/features/command-pallete/CommandPalette.tsx
+++ b/frontend/console/src/features/command-pallete/CommandPalette.tsx
@@ -89,7 +89,7 @@ export const CommandPalette: React.FC<CommandPaletteProps> = ({ isOpen, onClose 
                     value={item}
                     className='group flex cursor-default select-none rounded-md px-2 py-2 data-[focus]:bg-indigo-600 data-[focus]:text-white dark:data-[focus]:bg-indigo-500'
                   >
-                    <div className='flex size-10 flex-none items-center justify-center rounded-lg'>
+                    <div title={item.iconType} className='flex size-10 flex-none items-center justify-center rounded-lg'>
                       <item.icon className='size-5 text-gray-500 dark:text-gray-400 group-data-[focus]:text-white' aria-hidden='true' />
                     </div>
                     <div className='ml-2 flex-auto'>

--- a/frontend/console/src/features/command-pallete/command-palette.utils.ts
+++ b/frontend/console/src/features/command-pallete/command-palette.utils.ts
@@ -1,10 +1,11 @@
-import { CellsIcon, type HugeiconsProps } from 'hugeicons-react'
+import { type HugeiconsProps, PackageIcon } from 'hugeicons-react'
 import type { PullSchemaResponse } from '../../protos/xyz/block/ftl/v1/ftl_pb'
-import { declIcon, declUrl } from '../modules/module.utils'
+import { declIcon, declTypeName, declUrl } from '../modules/module.utils'
 
 export interface PaletteItem {
   id: string
   icon: React.FC<Omit<HugeiconsProps, 'ref'> & React.RefAttributes<SVGSVGElement>>
+  iconType: string
   title: string
   subtitle?: string
   url: string
@@ -16,7 +17,8 @@ export const paletteItems = (schema: PullSchemaResponse[]): PaletteItem[] => {
   for (const module of schema) {
     items.push({
       id: `${module.moduleName}-module`,
-      icon: CellsIcon,
+      icon: PackageIcon,
+      iconType: 'module',
       title: module.moduleName,
       subtitle: module.moduleName,
       url: `/modules/${module.moduleName}`,
@@ -29,7 +31,8 @@ export const paletteItems = (schema: PullSchemaResponse[]): PaletteItem[] => {
 
       items.push({
         id: `${module.moduleName}-${decl.value.value.name}`,
-        icon: declIcon(decl.value.case),
+        icon: declIcon(decl.value.case, decl.value.value),
+        iconType: declTypeName(decl.value.case, decl.value.value),
         title: decl.value.value.name,
         subtitle: `${module.moduleName}.${decl.value.value.name}`,
         url: declUrl(module.moduleName, decl),
@@ -39,7 +42,8 @@ export const paletteItems = (schema: PullSchemaResponse[]): PaletteItem[] => {
         for (const field of decl.value.value.fields) {
           items.push({
             id: `${module.moduleName}-${decl.value.value.name}-${field.name}`,
-            icon: declIcon(decl.value.case),
+            icon: declIcon(decl.value.case, decl.value.value),
+            iconType: declTypeName(decl.value.case, decl.value.value),
             title: field.name,
             subtitle: `${module.moduleName}.${decl.value.value.name}.${field.name}`,
             url: declUrl(module.moduleName, decl),

--- a/frontend/console/src/features/modules/ModulesTree.tsx
+++ b/frontend/console/src/features/modules/ModulesTree.tsx
@@ -4,13 +4,13 @@ import { Link, useParams, useSearchParams } from 'react-router-dom'
 import { Multiselect, sortMultiselectOpts } from '../../components/Multiselect'
 import type { MultiselectOpt } from '../../components/Multiselect'
 import { classNames } from '../../utils'
-import type { ModuleTreeItem } from './module.utils'
+import type { DeclInfo, ModuleTreeItem } from './module.utils'
 import {
-  type DeclInfo,
   addModuleToLocalStorageIfMissing,
   collapseAllModulesInLocalStorage,
   declIcon,
   declSumTypeIsExported,
+  declTypeName,
   declUrlFromInfo,
   getHideUnexportedFromLocalStorage,
   hasHideUnexportedInLocalStorage,
@@ -34,7 +34,8 @@ const DeclNode = ({ decl, href, isSelected }: { decl: DeclInfo; href: string; is
     }
   }, [isSelected])
 
-  const Icon = useMemo(() => declIcon(decl.declType), [decl.declType])
+  const Icon = useMemo(() => declIcon(decl.declType, decl.value), [decl])
+  const declType = useMemo(() => declTypeName(decl.declType, decl.value), [decl])
   return (
     <li className='my-1'>
       <Link id={`decl-${decl.value.name}`} to={href}>
@@ -46,7 +47,9 @@ const DeclNode = ({ decl, href, isSelected }: { decl: DeclInfo; href: string; is
             'group flex items-center gap-x-2 pl-4 pr-2 text-sm font-light leading-6 w-full cursor-pointer scroll-mt-10',
           )}
         >
-          <Icon aria-hidden='true' className='size-4 shrink-0 ml-3' />
+          <span title={declType}>
+            <Icon aria-hidden='true' className='size-4 shrink-0 ml-3' />
+          </span>
           {decl.value.name}
         </div>
       </Link>
@@ -79,7 +82,7 @@ const ModuleSection = ({
   const filteredDecls = useMemo(
     () =>
       module.decls
-        .filter((d) => !!selectedDeclTypes.find((o) => o.key === d.declType))
+        .filter((d) => !!selectedDeclTypes.find((o) => o.key === declTypeName(d.declType, d.value)))
         .filter((d) => !hideUnexported || (isSelected && declName === d.value.name) || declSumTypeIsExported(d.value)),
     [module.decls, selectedDeclTypes, hideUnexported, isSelected, declName],
   )
@@ -95,7 +98,9 @@ const ModuleSection = ({
         )}
         onClick={() => toggleExpansion(module.name)}
       >
-        <PackageIcon aria-hidden='true' className='size-4 my-1 ml-3 shrink-0' />
+        <span title='module'>
+          <PackageIcon aria-hidden='true' className='size-4 my-1 ml-3 shrink-0' />
+        </span>
         {module.name}
         <Link to={`/modules/${module.name}`} onClick={(e) => e.stopPropagation()}>
           <CircleArrowRight02Icon id={`module-${module.name}-view-icon`} className='size-4 shrink-0 rounded-md hover:bg-gray-200 dark:hover:bg-gray-600' />

--- a/frontend/console/src/features/modules/schema/schema.utils.ts
+++ b/frontend/console/src/features/modules/schema/schema.utils.ts
@@ -40,8 +40,24 @@ export const declTypeMultiselectOpts = [
     displayName: 'Subscription',
   },
   {
+    group: 'Verb',
+    key: 'cronjob',
+    displayName: 'Cron Job',
+  },
+  {
+    group: 'Verb',
+    key: 'ingress',
+    displayName: 'Ingress Verb',
+  },
+  {
+    group: 'Verb',
+    key: 'subscriber',
+    displayName: 'Subscriber',
+  },
+  {
+    group: 'Verb',
     key: 'verb',
-    displayName: 'Verb',
+    displayName: 'All Other Verbs',
   },
 ]
 


### PR DESCRIPTION
Fixes: https://github.com/TBD54566975/ftl/issues/3219

https://github.com/user-attachments/assets/dccdc8e9-1c72-4de1-8538-0bdece0beed2

Use verb metadata to classify each verb as a subtype: cronjob, ingress, subscriber, or none of the above. The backend guarantees these metadata are mutually exclusive, so the frontend can just check which (if any) exists in a verb proto.

Changes:
* Add new icons for each subtype
* Thread new icons through both existing callsites: module tree and global fuzzy search
* Show decl type name on hover of each icon
* Add new verb types to filter dropdown
* Support groups in `Multiselect` to handle verb subtypes
* Make fuzzy search use the same icon for modules as the module tree. They had accidentally diverged.

Next: verb page customizations per subtype