### PR TITLE
fix: clear events when streaming starts

### DIFF
--- a/frontend/console/src/api/timeline/use-timeline.ts
+++ b/frontend/console/src/api/timeline/use-timeline.ts
@@ -37,6 +37,10 @@ export const useTimeline = (isStreaming: boolean, filters: EventsQuery_Filter[],
     try {
       console.debug('streaming timeline')
       console.debug('timeline-filters:', filters)
+
+      // Clear the cache when starting a new stream
+      queryClient.setQueryData<Event[]>(queryKey, (_ = []) => [])
+
       for await (const response of client.streamEvents(
         { updateInterval: { seconds: BigInt(0), nanos: updateIntervalMs * 1000 }, query: { limit, filters, order } },
         { signal },


### PR DESCRIPTION
See #3260

We can get some console connection errors in our deployed environment which causes streaming to get restarted. However, it seems like we don't clear the cache when this happens so duplicate events get returned from our streaming hooks. This change should ensure the events are cleared anytime we restart the stream.