### PR TITLE
fix: smoke test the tagged release before upgrading

### DIFF
--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -29,31 +29,32 @@ jobs:
           ref: v${{ env.LATEST_VERSION }}
           fetch-depth: 1
           fetch-tags: true
-      # The following grabs the current smoke test and deployment Justfile from the HEAD. This
-      # is to solve the chicken-and-egg. Once it's in the tagged release, skip this.
-      - name: Check out the current smoke test
-        uses: actions/checkout@v4
-        with:
-          clean: false
-          repository: TBD54566975/ftl.git
-          path: tmpsmoketest
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
-          sparse-checkout: |
-            smoketest
-            deployment
-          sparse-checkout-cone-mode: false
-      # When we remove the above step to fetch the current smoke tests and deployment Justfile
-      # into tmpsmoketest, remove the overwrite step as well.
-      - name: Replace the tagged release smoketest with the current smoketest
-        run: |
-          set -euo pipefail
-          echo "Replacing tagged release smoketest with current smoketest"
-          rm -r ./smoketest && mv ./tmpsmoketest/smoketest ./smoketest
-          echo "Replacing deployment Justfile with current Justfile"
-          cp ./tmpsmoketest/deployment/Justfile ./deployment/Justfile
-          echo "Removing tmpsmoketest"
-          rm -r ./tmpsmoketest
+      # # # These are disabled until the tagged release has the integration test changes.
+      # # The following grabs the current smoke test and deployment Justfile from the HEAD. This
+      # # is to solve the chicken-and-egg. Once it's in the tagged release, skip this.
+      # - name: Check out the current smoke test
+      #   uses: actions/checkout@v4
+      #   with:
+      #     clean: false
+      #     repository: TBD54566975/ftl.git
+      #     path: tmpsmoketest
+      #     ref: ${{ github.head_ref }}
+      #     fetch-depth: 0
+      #     sparse-checkout: |
+      #       smoketest
+      #       deployment
+      #     sparse-checkout-cone-mode: false
+      # # When we remove the above step to fetch the current smoke tests and deployment Justfile
+      # # into tmpsmoketest, remove the overwrite step as well.
+      # - name: Replace the tagged release smoketest with the current smoketest
+      #   run: |
+      #     set -euo pipefail
+      #     echo "Replacing tagged release smoketest with current smoketest"
+      #     rm -r ./smoketest && mv ./tmpsmoketest/smoketest ./smoketest
+      #     echo "Replacing deployment Justfile with current Justfile"
+      #     cp ./tmpsmoketest/deployment/Justfile ./deployment/Justfile
+      #     echo "Removing tmpsmoketest"
+      #     rm -r ./tmpsmoketest
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
       - name: Build Cache

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -29,32 +29,6 @@ jobs:
           ref: v${{ env.LATEST_VERSION }}
           fetch-depth: 1
           fetch-tags: true
-      # # # These are disabled until the tagged release has the integration test changes.
-      # # The following grabs the current smoke test and deployment Justfile from the HEAD. This
-      # # is to solve the chicken-and-egg. Once it's in the tagged release, skip this.
-      # - name: Check out the current smoke test
-      #   uses: actions/checkout@v4
-      #   with:
-      #     clean: false
-      #     repository: TBD54566975/ftl.git
-      #     path: tmpsmoketest
-      #     ref: ${{ github.head_ref }}
-      #     fetch-depth: 0
-      #     sparse-checkout: |
-      #       smoketest
-      #       deployment
-      #     sparse-checkout-cone-mode: false
-      # # When we remove the above step to fetch the current smoke tests and deployment Justfile
-      # # into tmpsmoketest, remove the overwrite step as well.
-      # - name: Replace the tagged release smoketest with the current smoketest
-      #   run: |
-      #     set -euo pipefail
-      #     echo "Replacing tagged release smoketest with current smoketest"
-      #     rm -r ./smoketest && mv ./tmpsmoketest/smoketest ./smoketest
-      #     echo "Replacing deployment Justfile with current Justfile"
-      #     cp ./tmpsmoketest/deployment/Justfile ./deployment/Justfile
-      #     echo "Removing tmpsmoketest"
-      #     rm -r ./tmpsmoketest
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
       - name: Build Cache
@@ -66,13 +40,11 @@ jobs:
           set -euo pipefail
           echo "Deploying the tagged release to the cluster"
           cd deployment && just deploy-version ${{ env.LATEST_VERSION }} && cd ..
-      # We skip this since it requires an integration test change to skip the full kube deploy.
-      # Re-enable this step when the tagged release has the integration test change.
-      # - name: Smoke test the tagged release images
-      #   run: |
-      #       set -euo pipefail
-      #       echo "Running smoke test on the tagged release images"
-      #       USE_DB_CONFIG=true SKIP_KUBE_FULL_DEPLOY=true go test -v -tags smoketest -run '^Test' ./smoketest
+      - name: Smoke test the tagged release images
+        run: |
+          set -euo pipefail
+          echo "Running smoke test on the tagged release images"
+          SKIP_KUBE_FULL_DEPLOY=true go test -v -timeout 15m -tags smoketest -run '^Test' ./smoketest
       - name: Check out HEAD of the current branch
         uses: actions/checkout@v4
         with:
@@ -82,7 +54,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Running smoke test on the HEAD images"
-          USE_DB_CONFIG=true go test -v -timeout 15m -tags smoketest -run '^Test' ./smoketest
+          go test -v -timeout 15m -tags smoketest -run '^Test' ./smoketest
       - name: Archive Report
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Run the tagged release's smoke test on its released image, which sets up the deployments to upgrade, before running the upgrade tests.