### PR TITLE
fix: language plugins should always include an error with level=ERROR for BuildFailure

### DIFF
--- a/go-runtime/goplugin/service.go
+++ b/go-runtime/goplugin/service.go
@@ -419,8 +419,8 @@ func build(ctx context.Context, projectRoot, stubsRoot string, buildCtx buildCon
 	m, buildErrs, err := compile.Build(ctx, projectRoot, stubsRoot, buildCtx.Config, buildCtx.Schema, transaction, false)
 	if err != nil {
 		return buildFailure(buildCtx, isAutomaticRebuild, builderrors.Error{
-			Type:  builderrors.FTL,
-			Level: builderrors.ErrorLevel(builderrors.COMPILER),
+			Type:  builderrors.COMPILER,
+			Level: builderrors.ERROR,
 			Msg:   "compile: " + err.Error(),
 		}), nil
 	}

--- a/internal/buildengine/languageplugin/plugin_test.go
+++ b/internal/buildengine/languageplugin/plugin_test.go
@@ -412,7 +412,8 @@ func buildEventWithBuildError(contextID string, isAutomaticRebuild bool, msg str
 				IsAutomaticRebuild: isAutomaticRebuild,
 				Errors: langpb.ErrorsToProto([]builderrors.Error{
 					{
-						Msg: msg,
+						Msg:   msg,
+						Level: builderrors.ERROR,
 					},
 				}),
 			},


### PR DESCRIPTION
Otherwise `buildengine` tries to read a nil schema value leading to a crash