### PR TITLE
chore: don't use cashapp/activate-hermit's native caching

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -7,7 +7,20 @@ runs:
     - id: find-go-build-cache
       shell: bash
       run: echo "cache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-    - name: Cache Docker Images
+    - id: bin-hash
+      shell: bash
+      run: |
+        hash="$(find ./${{ inputs.working-directory }}/bin ! -type d | sort | xargs openssl sha256 | openssl sha256 -r | cut -d' ' -f1)"
+        echo "hash=$hash" >> "$GITHUB_OUTPUT"
+    - name: Restore Hermit Cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ runner.os == 'macOS' && '~/Library/Caches/hermit/pkg' || '~/.cache/hermit/pkg' }}
+        key: ${{ runner.os }}-hermit-cache-${{ steps.bin-hash.outputs.hash }}
+        restore-keys: |
+          ${{ runner.os }}-hermit-cache-${{ steps.bin-hash.outputs.hash }}
+          ${{ runner.os }}-hermit-cache-
+    - name: Restore Docker Images
       uses: ScribeMD/docker-cache@0.5.0
       with:
         key: docker-${{ runner.os }}-${{ hashFiles('docker-compose.yml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,8 +170,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1.1.3
-        with:
-          cache: true
       - name: Build Cache
         uses: ./.github/actions/build-cache
       - name: Install Java
@@ -303,8 +301,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1.1.3
-        with:
-          cache: true
       - name: Build Cache
         uses: ./.github/actions/build-cache
       - name: Docker Compose
@@ -350,8 +346,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1.1.3
-        with:
-          cache: true
       - name: Build Cache
         uses: ./.github/actions/build-cache
       - name: Docker Compose

--- a/.github/workflows/smoketest.yml
+++ b/.github/workflows/smoketest.yml
@@ -56,17 +56,15 @@ jobs:
           rm -r ./tmpsmoketest
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1
-        with:
-          cache: true
       - name: Build Cache
         uses: ./.github/actions/build-cache
       - name: Download Go Modules
         run: go mod download
       - name: Set up a kube cluster with the tagged release dockerhub image
         run: |
-            set -euo pipefail
-            echo "Deploying the tagged release to the cluster"
-            cd deployment && just deploy-version ${{ env.LATEST_VERSION }} && cd ..
+          set -euo pipefail
+          echo "Deploying the tagged release to the cluster"
+          cd deployment && just deploy-version ${{ env.LATEST_VERSION }} && cd ..
       # We skip this since it requires an integration test change to skip the full kube deploy.
       # Re-enable this step when the tagged release has the integration test change.
       # - name: Smoke test the tagged release images
@@ -81,9 +79,9 @@ jobs:
           fetch-depth: 1
       - name: Smoke test HEAD with a full deploy to test upgrade path
         run: |
-            set -euo pipefail
-            echo "Running smoke test on the HEAD images"
-            USE_DB_CONFIG=true go test -v -timeout 15m -tags smoketest -run '^Test' ./smoketest
+          set -euo pipefail
+          echo "Running smoke test on the HEAD images"
+          USE_DB_CONFIG=true go test -v -timeout 15m -tags smoketest -run '^Test' ./smoketest
       - name: Archive Report
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/writecache.yml
+++ b/.github/workflows/writecache.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 concurrency:
   group: ${{ github.ref }}-writecache
   cancel-in-progress: true
@@ -15,6 +16,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Init Hermit
         uses: cashapp/activate-hermit@v1.1.3
+      - name: Install Hermit Packages
+        run: hermit install
       - name: Docker Compose
         run: docker compose up -d --wait
       - name: Init DB
@@ -28,6 +31,16 @@ jobs:
       - id: find-go-build-cache
         shell: bash
         run: echo "cache=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+      - id: bin-hash
+        shell: bash
+        run: |
+          hash="$(find ./bin ! -type d | sort | xargs openssl sha256 | openssl sha256 -r | cut -d' ' -f1)"
+          echo "hash=$hash" >> "$GITHUB_OUTPUT"
+      - name: Save Hermit Cache
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.os == 'macOS' && '~/Library/Caches/hermit/pkg' || '~/.cache/hermit/pkg' }}
+          key: ${{ runner.os }}-hermit-cache-${{ steps.bin-hash.outputs.hash }}
       - name: Save Go Module Cache
         uses: actions/cache/save@v4
         with:


### PR DESCRIPTION
We only write to the cache on main.

It also turns out we were only intermittently using the native caching anyway, so this should be more reliable.