### PR TITLE
fix: kill language plugins after cli and tests

### DIFF
--- a/frontend/cli/cmd_build.go
+++ b/frontend/cli/cmd_build.go
@@ -29,6 +29,9 @@ func (b *buildCmd) Run(ctx context.Context, client ftlv1connect.ControllerServic
 		return err
 	}
 
+	// Cancel build engine context to ensure all language plugins are killed.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	engine, err := buildengine.New(ctx, client, projConfig, b.Dirs, bindAllocator, buildengine.BuildEnv(b.BuildEnv), buildengine.Parallelism(b.Parallelism))
 	if err != nil {
 		return err

--- a/frontend/cli/cmd_deploy.go
+++ b/frontend/cli/cmd_deploy.go
@@ -30,6 +30,9 @@ func (d *deployCmd) Run(ctx context.Context, projConfig projectconfig.Config) er
 		return err
 	}
 
+	// Cancel build engine context to ensure all language plugins are killed.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	engine, err := buildengine.New(ctx, client, projConfig, d.Build.Dirs, bindAllocator, buildengine.BuildEnv(d.Build.BuildEnv), buildengine.Parallelism(d.Build.Parallelism))
 	if err != nil {
 		return err

--- a/frontend/cli/cmd_new.go
+++ b/frontend/cli/cmd_new.go
@@ -131,6 +131,7 @@ func (i newCmd) Run(ctx context.Context, ktctx *kong.Context, config projectconf
 			return err
 		}
 	}
+	plugin.Kill()
 	return nil
 }
 

--- a/frontend/cli/cmd_new.go
+++ b/frontend/cli/cmd_new.go
@@ -131,7 +131,7 @@ func (i newCmd) Run(ctx context.Context, ktctx *kong.Context, config projectconf
 			return err
 		}
 	}
-	plugin.Kill()
+	_ = plugin.Kill() //nolint:errcheck
 	return nil
 }
 

--- a/frontend/cli/main.go
+++ b/frontend/cli/main.go
@@ -93,7 +93,7 @@ func main() {
 	if plugin, ok := languagePlugin.Get(); ok {
 		// Kill the plugin when the app exits due to an error, or after showing help.
 		addToExit(app, func(code int) {
-			plugin.Kill()
+			_ = plugin.Kill() //nolint:errcheck
 		})
 	}
 

--- a/internal/buildengine/engine_test.go
+++ b/internal/buildengine/engine_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 func TestGraph(t *testing.T) {
-	ctx := log.ContextWithNewDefaultLogger(context.Background())
+	ctx, cancel := context.WithCancel(log.ContextWithNewDefaultLogger(context.Background()))
+	t.Cleanup(cancel)
 
 	bindURL, err := url.Parse("http://127.0.0.1:8893")
 	assert.NoError(t, err)

--- a/jvm-runtime/plugin/common/java_plugin_test.go
+++ b/jvm-runtime/plugin/common/java_plugin_test.go
@@ -75,6 +75,9 @@ func TestJavaConfigDefaults(t *testing.T) {
 			assert.NoError(t, err)
 			plugin, err := languageplugin.New(ctx, allocator, "java", "test")
 			assert.NoError(t, err)
+			t.Cleanup(func() {
+				_ = plugin.Kill() //nolint:errcheck
+			})
 
 			defaults, err := plugin.ModuleConfigDefaults(ctx, dir)
 			assert.NoError(t, err)


### PR DESCRIPTION
Fixes #3287
Handles `ftl build`, `ftl deploy`, `ftl new` and `just test-backend`