### PR TITLE
chore: disable lock file maintenance

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,10 +19,6 @@
   "java": {
     "managerBranchPrefix": "java-"
   },
-  lockFileMaintenance: {
-    "enabled": true,
-    "automerge": true
-  },
   postUpdateOptions: ["gomodTidy", "pnpmDedupe"],
   packageRules: [
     {


### PR DESCRIPTION
We don't need this without rust, and it is making renovate do weird things.