### PR TITLE
fix: always build go2proto for current arch

### DIFF
--- a/scripts/ftl
+++ b/scripts/ftl
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+# We only want to build this for the current platform
+# This may get invoked as part of a build for a different platform
+unset GOARCH
+unset GOOS
+
 FTL_DIR="$(dirname "$(readlink -f "$0")")/.."
 export FTL_DIR
 


### PR DESCRIPTION
In some cases you can end up with a linux build on a mac if you are building the kube tests.