### PR TITLE
fix: improve startup time

### DIFF
--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -390,7 +390,7 @@ func waitForControllerOnline(ctx context.Context, startupTimeout time.Duration, 
 	ctx, cancel := context.WithTimeout(ctx, startupTimeout)
 	defer cancel()
 
-	ticker := time.NewTicker(time.Second)
+	ticker := time.NewTicker(time.Millisecond * 50)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
1s is a very long poll time, reducing this will improve startup time