### PR TITLE
feat: Create psql DB in the CF provisioner

### DIFF
--- a/cmd/devel-provisioner/main.go
+++ b/cmd/devel-provisioner/main.go
@@ -34,7 +34,7 @@ func main() {
 		"ftl-provisioner-cloudformation",
 		provisionerconnect.NewProvisionerPluginServiceClient,
 		plugin.WithEnvars("FTL_PROVISIONER_CF_DB_SUBNET_GROUP=aurora-postgres-subnet-group"),
-		plugin.WithEnvars("FTL_PROVISIONER_CF_DB_SECURITY_GROUP=aurora-postgres-security-group"),
+		plugin.WithEnvars("FTL_PROVISIONER_CF_DB_SECURITY_GROUP=sg-08e06d6f8327024de"),
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/devel-provisioner/main.go
+++ b/cmd/devel-provisioner/main.go
@@ -34,6 +34,7 @@ func main() {
 		"ftl-provisioner-cloudformation",
 		provisionerconnect.NewProvisionerPluginServiceClient,
 		plugin.WithEnvars("FTL_PROVISIONER_CF_DB_SUBNET_GROUP=aurora-postgres-subnet-group"),
+		plugin.WithEnvars("FTL_PROVISIONER_CF_DB_SECURITY_GROUP=aurora-postgres-security-group"),
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/ftl-provisioner-cloudformation/cloudformation_util.go
+++ b/cmd/ftl-provisioner-cloudformation/cloudformation_util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/smithy-go"
 	goformation "github.com/awslabs/goformation/v7/cloudformation"
 	"github.com/jpillora/backoff"
@@ -98,6 +99,19 @@ func createClient(ctx context.Context) (*cloudformation.Client, error) {
 
 	return cloudformation.New(
 		cloudformation.Options{
+			Credentials: cfg.Credentials,
+			Region:      cfg.Region,
+		},
+	), nil
+}
+
+func createSecretsClient(ctx context.Context) (*secretsmanager.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load default aws config: %w", err)
+	}
+	return secretsmanager.New(
+		secretsmanager.Options{
 			Credentials: cfg.Credentials,
 			Region:      cfg.Region,
 		},

--- a/cmd/ftl-provisioner-cloudformation/provisioner.go
+++ b/cmd/ftl-provisioner-cloudformation/provisioner.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	PropertyDBReadEndpoint      = "db:read_endpoint"
-	PropertyDBWriteEndpoint     = "db:write_endpoint"
-	PropertyMasterUserSecretARN = "db:maser_user_secret_arn"
+	PropertyDBReadEndpoint  = "db:read_endpoint"
+	PropertyDBWriteEndpoint = "db:write_endpoint"
+	PropertyMasterUserARN   = "db:maser_user_secret_arn"
 )
 
 type Config struct {
@@ -174,7 +174,7 @@ func (c *CloudformationProvisioner) resourceToCF(cluster, module string, templat
 		})
 		addOutput(template.Outputs, goformation.GetAtt(clusterID, "MasterUserSecret.SecretArn"), &CloudformationOutputKey{
 			ResourceID:   resource.ResourceId,
-			PropertyName: PropertyMasterUserSecretARN,
+			PropertyName: PropertyMasterUserARN,
 		})
 		return nil
 	}

--- a/cmd/ftl-provisioner-cloudformation/status.go
+++ b/cmd/ftl-provisioner-cloudformation/status.go
@@ -14,10 +14,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	_ "github.com/lib/pq"
 
 	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1beta1/provisioner"
-
-	_ "github.com/lib/pq"
 )
 
 func (c *CloudformationProvisioner) Status(ctx context.Context, req *connect.Request[provisioner.StatusRequest]) (*connect.Response[provisioner.StatusResponse], error) {


### PR DESCRIPTION
Connects to the freshly created psql instance, and creates a database if it does not exist.

This closes https://github.com/TBD54566975/ftl/issues/3117 with https://github.com/tbdeng/ftl-aws/pull/35

We should refactor the DB creation from the success step to be part of the actual provisioning flow. Thicket for this: https://github.com/TBD54566975/ftl/issues/3333

We should also not use the root credentials when connecting to the DB from a module. However, we should change this when looking at DB migrations, when we won't expect modules to execute DDL anymore.