### PR TITLE
fix: local jvm runner relies on released jvm runner

### DIFF
--- a/deployment/Dockerfile.runner-jvm.test
+++ b/deployment/Dockerfile.runner-jvm.test
@@ -1,7 +1,6 @@
 # Huge hack, we want the JVM and same runtime environment as the runner
 # So we just take the latest published runner image and copy the JDK from it
-# TODO: change this to ftl-runner-jvm once we have released it
-FROM ftl0/ftl-runner:latest AS jdk
+FROM ftl0/ftl-runner-jvm:latest AS jdk
 # Create the runtime image.
 FROM ubuntu:24.04
 


### PR DESCRIPTION
Previously this relied on the standard runner image which no longer includes the jvm (as of the latest release)