### PR TITLE
fix: language plugin logs

### DIFF
--- a/go-runtime/compile/build.go
+++ b/go-runtime/compile/build.go
@@ -423,7 +423,7 @@ func Build(ctx context.Context, projectRootDir, stubsRoot string, config modulec
 
 	wg.Go(func() error {
 		if !importsChanged {
-			log.FromContext(ctx).Debugf("skipped go mod tidy (module dir)\n")
+			log.FromContext(ctx).Debugf("skipped go mod tidy (module dir)")
 			return nil
 		}
 		if err := exec.Command(wgctx, log.Debug, config.Dir, "go", "mod", "tidy").RunStderrError(wgctx); err != nil {
@@ -437,7 +437,7 @@ func Build(ctx context.Context, projectRootDir, stubsRoot string, config modulec
 	mainDir := filepath.Join(buildDir, "go", "main")
 	wg.Go(func() error {
 		if !mainModuleCtxChanged {
-			log.FromContext(ctx).Debugf("skipped go mod tidy (build dir)\n")
+			log.FromContext(ctx).Debugf("skipped go mod tidy (build dir)")
 			return nil
 		}
 		if err := exec.Command(wgctx, log.Debug, mainDir, "go", "mod", "tidy").RunStderrError(wgctx); err != nil {

--- a/internal/buildengine/languageplugin/plugin_client.go
+++ b/internal/buildengine/languageplugin/plugin_client.go
@@ -65,7 +65,7 @@ func (p *pluginClientImpl) start(ctx context.Context, dir, language, name string
 		dir,
 		cmdPath,
 		langconnect.NewLanguageServiceClient,
-		plugin.WithEnvars("FTL_Name="+name),
+		plugin.WithEnvars("FTL_NAME="+name),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to spawn plugin for %s: %w", name, err)


### PR DESCRIPTION
Language plugin logs had the following issues:
- No scope
- Some logs had extra new line chars