### PR TITLE
chore: reduce log info output on startup

### DIFF
--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -108,9 +108,9 @@ func (s *serveCmd) run(
 	}
 
 	if s.Provisioners > 0 {
-		logger.Infof("Starting FTL with %d controller(s) and %d provisioner(s)", s.Controllers, s.Provisioners)
+		logger.Debugf("Starting FTL with %d controller(s) and %d provisioner(s)", s.Controllers, s.Provisioners)
 	} else {
-		logger.Infof("Starting FTL with %d controller(s)", s.Controllers)
+		logger.Debugf("Starting FTL with %d controller(s)", s.Controllers)
 	}
 
 	err := observability.Init(ctx, false, "", "ftl-serve", ftl.Version, s.ObservabilityConfig)

--- a/go-runtime/goplugin/service.go
+++ b/go-runtime/goplugin/service.go
@@ -86,7 +86,7 @@ func New() *Service {
 }
 
 func (s *Service) Ping(ctx context.Context, req *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
-	log.FromContext(ctx).Infof("Received Ping")
+	log.FromContext(ctx).Debugf("Received Ping")
 	return connect.NewResponse(&ftlv1.PingResponse{}), nil
 }
 
@@ -308,7 +308,7 @@ func watchFiles(ctx context.Context, watcher *watch.Watcher, buildCtx buildConte
 	if err != nil {
 		return fmt.Errorf("could not watch for file changes: %w", err)
 	}
-	log.FromContext(ctx).Infof("Watching for file changes: %s", buildCtx.Config.Dir)
+	log.FromContext(ctx).Debugf("Watching for file changes: %s", buildCtx.Config.Dir)
 	watchEvents := make(chan watch.WatchEvent, 32)
 	watchTopic.Subscribe(watchEvents)
 

--- a/jvm-runtime/plugin/common/jvmcommon.go
+++ b/jvm-runtime/plugin/common/jvmcommon.go
@@ -94,7 +94,7 @@ func New(scaffoldFiles *zip.Reader) *Service {
 }
 
 func (s *Service) Ping(ctx context.Context, req *connect.Request[ftlv1.PingRequest]) (*connect.Response[ftlv1.PingResponse], error) {
-	log.FromContext(ctx).Infof("Received Ping")
+	log.FromContext(ctx).Debugf("Received Ping")
 	return connect.NewResponse(&ftlv1.PingResponse{}), nil
 }
 
@@ -352,7 +352,7 @@ func watchFiles(ctx context.Context, watcher *watch.Watcher, buildCtx buildConte
 	if err != nil {
 		return fmt.Errorf("could not watch for file changes: %w", err)
 	}
-	log.FromContext(ctx).Infof("Watching for file changes: %s", buildCtx.Config.Dir)
+	log.FromContext(ctx).Debugf("Watching for file changes: %s", buildCtx.Config.Dir)
 	watchEvents := make(chan watch.WatchEvent, 32)
 	watchTopic.Subscribe(watchEvents)
 


### PR DESCRIPTION
BEFORE:
![Screenshot 2024-11-13 at 1 27 43 PM](https://github.com/user-attachments/assets/65fc9fc0-6bd7-4b52-87de-1a9f320cb53b)

AFTER:
![Screenshot 2024-11-13 at 1 26 41 PM](https://github.com/user-attachments/assets/c6762b26-ff3e-4e74-9e85-7dc3d4c000f6)
