### PR TITLE
feat: create reusable button component for console

### DIFF
--- a/frontend/console/src/components/Button.tsx
+++ b/frontend/console/src/components/Button.tsx
@@ -1,0 +1,41 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { classNames } from '../utils'
+
+type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  children: ReactNode
+  size?: ButtonSize
+  variant?: 'primary' | 'secondary'
+  fullWidth?: boolean
+  title?: string
+}
+
+const sizeClasses: Record<ButtonSize, string> = {
+  xs: 'rounded px-2 py-1 text-xs',
+  sm: 'rounded px-2 py-1 text-sm',
+  md: 'rounded-md px-2.5 py-1.5 text-sm',
+  lg: 'rounded-md px-3 py-2 text-sm',
+  xl: 'rounded-md px-3.5 py-2.5 text-sm',
+}
+
+export const Button = ({ children, size = 'md', variant = 'primary', fullWidth = false, className, title, ...props }: ButtonProps) => {
+  const baseClasses = 'font-semibold shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2'
+  const variantClasses = {
+    primary:
+      'bg-indigo-600 dark:bg-indigo-500 text-white hover:bg-indigo-500 dark:hover:bg-indigo-400 focus-visible:outline-indigo-600 dark:focus-visible:outline-indigo-500',
+    secondary:
+      'bg-white text-gray-900 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus-visible:outline-gray-600 dark:bg-white/10 dark:text-white dark:hover:bg-white/20 dark:ring-0',
+  }
+
+  return (
+    <button
+      type='button'
+      className={classNames(baseClasses, sizeClasses[size], variantClasses[variant], fullWidth ? 'w-full' : '', className)}
+      title={title}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/console/src/components/Multiselect.tsx
+++ b/frontend/console/src/components/Multiselect.tsx
@@ -1,6 +1,6 @@
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react'
 import { ArrowDown01Icon, CheckmarkSquare02Icon, MinusSignSquareIcon, SquareIcon } from 'hugeicons-react'
-import { Divider } from './Divider'
+import { Button } from './Button'
 
 export interface MultiselectOpt {
   group?: string
@@ -77,7 +77,7 @@ export const Multiselect = ({
     <div className='w-full'>
       <Listbox multiple value={selectedOpts} onChange={onChange}>
         <div className='relative w-[calc(100%-0.75rem)]'>
-          <ListboxButton className='w-full m-2 py-1 px-2 border border-gray-300 dark:border-gray-600 rounded-md text-sm bg-white dark:bg-gray-900 hover:text-gray-800 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'>
+          <ListboxButton className='w-full m-2 py-1 px-2 border border-gray-300 dark:border-gray-600 rounded shadow-sm text-sm bg-white dark:bg-gray-900 hover:text-gray-800 dark:hover:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-700'>
             <span className='block truncate w-[calc(100%-30px)] h-5 text-left'>{getSelectionText(selectedOpts, allOpts)}</span>
             <span className='pointer-events-none absolute inset-y-0 right-0 flex items-center'>
               <ArrowDown01Icon className='w-5 text-gray-400' />
@@ -87,7 +87,7 @@ export const Multiselect = ({
         <ListboxOptions
           anchor='bottom'
           transition
-          className='w-[var(--button-width)] min-w-48 mt-1 pt-1 rounded-md border dark:border-white/5 bg-white dark:bg-gray-800 transition duration-100 ease-in truncate drop-shadow-lg z-20'
+          className='w-[var(--button-width)] min-w-48 ml-2 pt-1 rounded-md border dark:border-white/5 bg-white dark:bg-gray-800 transition duration-100 ease-in truncate drop-shadow-lg z-20'
         >
           {allOpts
             .filter((o) => !o.group)
@@ -102,22 +102,14 @@ export const Multiselect = ({
             ...allOpts.filter((o) => o.group === group).map((o) => <Option key={o.key} o={o} p='6' />),
           ])}
 
-          <div className='w-full text-center text-xs mt-2'>
-            <Divider />
-            <div className='flex'>
-              <div
-                className='flex-1 p-2 hover:bg-gray-200 dark:hover:bg-gray-700 text-indigo-600 dark:text-indigo-400 cursor-pointer text-center'
-                onClick={() => onChange(allOpts)}
-              >
+          <div className='w-full text-center text-xs'>
+            <div className='flex gap-2 p-2'>
+              <Button variant='primary' size='xs' onClick={() => onChange(allOpts)} title='Select all' fullWidth>
                 Select all
-              </div>
-              <Divider vertical />
-              <div
-                className='flex-1 p-2 hover:bg-gray-200 dark:hover:bg-gray-700 text-indigo-600 dark:text-indigo-400 cursor-pointer text-center'
-                onClick={() => onChange([])}
-              >
+              </Button>
+              <Button variant='primary' size='xs' onClick={() => onChange([])} title='Deselect all' fullWidth>
                 Deselect all
-              </div>
+              </Button>{' '}
             </div>
           </div>
         </ListboxOptions>

--- a/frontend/console/src/features/modules/ModulesTree.tsx
+++ b/frontend/console/src/features/modules/ModulesTree.tsx
@@ -1,6 +1,7 @@
 import { ArrowRight01Icon, ArrowShrink02Icon, CircleArrowRight02Icon, CodeFolderIcon, ViewIcon, ViewOffSlashIcon } from 'hugeicons-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useParams, useSearchParams } from 'react-router-dom'
+import { Button } from '../../components/Button'
 import { Multiselect, sortMultiselectOpts } from '../../components/Multiselect'
 import type { MultiselectOpt } from '../../components/Multiselect'
 import { classNames } from '../../utils'
@@ -180,23 +181,19 @@ export const ModulesTree = ({ modules }: { modules: ModuleTreeItem[] }) => {
           <span className='w-full'>
             <Multiselect allOpts={declTypeMultiselectOpts} selectedOpts={selectedDeclTypes} onChange={msOnChange} />
           </span>
-          <button
+          <Button
             id='hide-exported'
-            type='button'
-            className='flex items-center p-1 ml-1 mr-2 rounded-md bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700'
+            variant='secondary'
+            size='sm'
             onClick={() => setHideUnexportedState(!hideUnexported)}
             title='Show/hide unexported'
+            className='mr-1'
           >
             {hideUnexported ? <ViewOffSlashIcon className='size-5 ' /> : <ViewIcon className='size-5' />}
-          </button>
-          <button
-            type='button'
-            className='flex items-center p-1 mr-2 rounded-md bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700'
-            onClick={collapseAll}
-            title='Collapse all modules'
-          >
-            <ArrowShrink02Icon className='size-5 ' />
-          </button>
+          </Button>
+          <Button variant='secondary' size='sm' onClick={collapseAll} title='Collapse all modules' className='mr-1'>
+            <ArrowShrink02Icon className='size-5' />
+          </Button>
         </div>
         <ul>
           {modules.map((m) => (

--- a/frontend/console/src/features/timeline/filters/TimelineTimeControls.tsx
+++ b/frontend/console/src/features/timeline/filters/TimelineTimeControls.tsx
@@ -2,6 +2,7 @@ import { Timestamp } from '@bufbuild/protobuf'
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/react'
 import { ArrowDown01Icon, Backward02Icon, Forward02Icon, PauseIcon, PlayIcon, Tick02Icon } from 'hugeicons-react'
 import { useEffect, useState } from 'react'
+import { Button } from '../../../components/Button'
 import { bgColor, borderColor, classNames, formatTimestampShort, formatTimestampTime, panelColor, textColor } from '../../../utils'
 
 interface TimeRange {
@@ -152,15 +153,9 @@ export const TimelineTimeControls = ({
           </div>
         </Listbox>
         {isTailing && (
-          <span className={`isolate inline-flex rounded-md shadow-sm h-6 ${textColor} ${isPaused ? bgColor : 'bg-indigo-600 text-white'} `}>
-            <button
-              type='button'
-              onClick={() => setIsPaused(!isPaused)}
-              className={`relative inline-flex items-center rounded-md px-3 text-sm font-semibold ring-1 ring-inset ${borderColor} hover:text-gray-600 hover:bg-gray-50 dark:hover:text-gray-300 dark:hover:bg-indigo-700`}
-            >
-              {isPaused ? <PlayIcon className='w-4 h-4' /> : <PauseIcon className='w-4 h-4' />}
-            </button>
-          </span>
+          <Button variant='secondary' size='xs' onClick={() => setIsPaused(!isPaused)} title={isPaused ? 'Resume' : 'Pause'}>
+            {isPaused ? <PlayIcon className='w-4 h-4' /> : <PauseIcon className='w-4 h-4' />}
+          </Button>
         )}
         {!isTailing && (
           <span className={`isolate inline-flex rounded-md shadow-sm h-6 ${textColor} ${bgColor}`}>

--- a/frontend/console/src/features/traces/TraceGraphHeader.tsx
+++ b/frontend/console/src/features/traces/TraceGraphHeader.tsx
@@ -2,6 +2,7 @@ import { Activity03Icon } from 'hugeicons-react'
 import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useRequestTraceEvents } from '../../api/timeline/use-request-trace-events'
+import { Button } from '../../components/Button'
 import { totalDurationForRequest } from './traces.utils'
 
 export const TraceGraphHeader = ({ requestKey, eventId }: { requestKey?: string; eventId: bigint }) => {
@@ -16,19 +17,14 @@ export const TraceGraphHeader = ({ requestKey, eventId }: { requestKey?: string;
   }
 
   return (
-    <div className='flex items-center justify-between'>
+    <div className='flex items-center justify-between mb-1'>
       <span className='text-xs font-mono'>
         Total <span>{totalEventDuration}ms</span>
       </span>
 
-      <button
-        type='button'
-        title='View trace'
-        onClick={() => navigate(`/traces/${requestKey}?event_id=${eventId}`)}
-        className='flex items-center p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 cursor-pointer'
-      >
-        <Activity03Icon className='w-5 h-5' />
-      </button>
+      <Button variant='secondary' size='sm' onClick={() => navigate(`/traces/${requestKey}?event_id=${eventId}`)} title='View trace'>
+        <Activity03Icon className='size-5' />
+      </Button>
     </div>
   )
 }

--- a/frontend/console/src/features/traces/TracesPage.tsx
+++ b/frontend/console/src/features/traces/TracesPage.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft02Icon } from 'hugeicons-react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useRequestTraceEvents } from '../../api/timeline/use-request-trace-events'
+import { Button } from '../../components/Button'
 import { Divider } from '../../components/Divider'
 import { Loader } from '../../components/Loader'
 import { TraceDetails } from './TraceDetails'
@@ -68,9 +69,9 @@ export const TracesPage = () => {
     <div className='flex h-full'>
       <div className='w-1/2 p-4 h-full overflow-y-auto'>
         <div className='flex items-center mb-2'>
-          <button type='button' onClick={handleBack} className='flex items-center p-2 rounded hover:bg-gray-200 dark:hover:bg-gray-600 cursor-pointer'>
-            <ArrowLeft02Icon className='w-6 h-6' />
-          </button>
+          <Button variant='secondary' size='sm' onClick={handleBack} title='Back'>
+            <ArrowLeft02Icon className='size-6' />
+          </Button>
           <span className='text-xl font-semibold ml-2'>Trace Details</span>
         </div>
         <TraceDetails requestKey={requestKey} events={events} selectedEventId={selectedEventId} />

--- a/frontend/console/src/features/verbs/KeyValuePairForm.tsx
+++ b/frontend/console/src/features/verbs/KeyValuePairForm.tsx
@@ -86,9 +86,9 @@ export const KeyValuePairForm = ({ keyValuePairs, onChange }: KeyValuePairFormPr
               placeholder='Value'
               className='flex-1 block rounded-md border-0 py-1.5 text-gray-900 dark:text-white shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-gray-700 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 dark:bg-gray-800 sm:text-sm sm:leading-6'
             />
-            <div className='w-9 flex-shrink-0'>
+            <div className='w-8 flex-shrink-0'>
               {(pair.key || pair.value || keyValuePairs.length > 1) && index !== keyValuePairs.length - 1 && (
-                <button type='button' onClick={() => updatePair(pair.id, { key: '', value: '' })} className='p-2 text-gray-400 hover:text-gray-500'>
+                <button type='button' onClick={() => updatePair(pair.id, { key: '', value: '' })} className='p-2 text-gray-500 hover:text-gray-500'>
                   <Delete03Icon className='h-5 w-5' />
                 </button>
               )}

--- a/frontend/console/src/features/verbs/VerbFormInput.tsx
+++ b/frontend/console/src/features/verbs/VerbFormInput.tsx
@@ -1,3 +1,6 @@
+import { Copy01Icon } from 'hugeicons-react'
+import { Button } from '../../components/Button'
+
 export const VerbFormInput = ({
   requestType,
   path,
@@ -5,6 +8,7 @@ export const VerbFormInput = ({
   requestPath,
   readOnly,
   onSubmit,
+  handleCopyButton,
 }: {
   requestType: string
   path: string
@@ -12,6 +16,7 @@ export const VerbFormInput = ({
   requestPath: string
   readOnly: boolean
   onSubmit: (path: string) => void
+  handleCopyButton?: () => void
 }) => {
   const handleSubmit: React.FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
@@ -20,7 +25,7 @@ export const VerbFormInput = ({
 
   return (
     <form onSubmit={handleSubmit} className='rounded-lg'>
-      <div className='flex rounded-md shadow-sm'>
+      <div className='flex rounded-md'>
         <span id='call-type' className='inline-flex items-center rounded-l-md border border-r-0 border-gray-300 dark:border-gray-500 px-3 ml-4 sm:text-sm'>
           {requestType}
         </span>
@@ -33,9 +38,12 @@ export const VerbFormInput = ({
           readOnly={readOnly}
           onChange={(event) => setPath(event.target.value)}
         />
-        <button type='submit' className='bg-indigo-700 text-white ml-2 mr-4 px-4 py-2 rounded-lg hover:bg-indigo-600 focus:outline-none focus:bg-indigo-600'>
+        <Button variant='primary' size='md' type='submit' title='Send' className='mx-2'>
           Send
-        </button>
+        </Button>
+        <Button variant='secondary' size='md' type='button' title='Copy' onClick={handleCopyButton} className='mr-2'>
+          <Copy01Icon className='size-5' />
+        </Button>
       </div>
       {!readOnly && <span className='ml-4 text-xs text-gray-500'>{requestPath}</span>}
     </form>

--- a/frontend/console/src/features/verbs/VerbRequestForm.tsx
+++ b/frontend/console/src/features/verbs/VerbRequestForm.tsx
@@ -1,4 +1,3 @@
-import { Copy01Icon } from 'hugeicons-react'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { CodeEditor } from '../../components/CodeEditor'
 import { ResizableVerticalPanels } from '../../components/ResizableVerticalPanels'
@@ -194,6 +193,7 @@ export const VerbRequestForm = ({ module, verb }: { module?: Module; verb?: Verb
         requestPath={fullRequestPath(module, verb)}
         readOnly={!isHttpIngress(verb)}
         onSubmit={handleSubmit}
+        handleCopyButton={handleCopyButton}
       />
       <div>
         <div className='border-b border-gray-200 dark:border-white/10'>
@@ -216,14 +216,6 @@ export const VerbRequestForm = ({ module, verb }: { module?: Module; verb?: Verb
                 </button>
               ))}
             </nav>
-            <button
-              type='button'
-              title='Copy'
-              className='flex items-center p-1 rounded text-indigo-500 hover:bg-gray-200 dark:hover:bg-gray-600 cursor-pointer'
-              onClick={handleCopyButton}
-            >
-              <Copy01Icon className='size-5' />
-            </button>
           </div>
         </div>
       </div>

--- a/frontend/console/src/stories/Button.stories.ts
+++ b/frontend/console/src/stories/Button.stories.ts
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Button } from '../components/Button'
+
+// Meta information for the Button component
+const meta = {
+  title: 'Components/Button',
+  component: Button,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+    },
+    size: {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+    },
+  },
+} satisfies Meta<typeof Button>
+
+export default meta
+type Story = StoryObj<typeof Button>
+
+// Default button story
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    children: 'Button',
+    size: 'md',
+  },
+}
+
+// Secondary button story
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    children: 'Button',
+    size: 'md',
+  },
+}
+
+// Small button story
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    children: 'Button',
+    variant: 'primary',
+  },
+}
+
+// Large button story
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    children: 'Button',
+    variant: 'primary',
+  },
+}


### PR DESCRIPTION
Creating reusable `<Button />` component to avoid all the duplicated styles everywhere and keep things a bit more consistent.

Some examples:

![Screenshot 2024-11-14 at 10 56 08 AM](https://github.com/user-attachments/assets/87483fcb-7562-4cf7-9436-98946c10bc29)
![Screenshot 2024-11-14 at 10 56 29 AM](https://github.com/user-attachments/assets/f68c4c0a-3e39-4620-bbfd-3dd03cea6a48)
