### PR TITLE
fix: handle error disconnecting from port

### DIFF
--- a/common/plugin/serve.go
+++ b/common/plugin/serve.go
@@ -174,7 +174,9 @@ func allocatePort() (*net.TCPAddr, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to allocate port: %w", err)
 	}
-	_ = l.Close()
+	if err := l.Close(); err != nil {
+		return nil, fmt.Errorf("could not close connection during port check: %w", err)
+	}
 	return l.Addr().(*net.TCPAddr), nil //nolint:forcetypeassert
 }
 


### PR DESCRIPTION
It is unlikely this is the issue behind #3419, but the inability to disconnect from the port we want the plugin to bind to should be an error.
Even if it is the issue behind that ticket it won't fix it, but it should help us uncover why.