### PR TITLE
feat: Resolve DSN from runtime in PG Proxy

### DIFF
--- a/backend/controller/controller.go
+++ b/backend/controller/controller.go
@@ -769,7 +769,8 @@ func (s *Service) GetModuleContext(ctx context.Context, req *connect.Request[ftl
 						continue
 					}
 					dbTypes[db.Name] = dbType
-					if db.Runtime != nil {
+					// TODO: Move the DSN resolution to the runtime once MySQL proxy is working
+					if db.Runtime != nil && dbType == modulecontext.DBTypeMySQL {
 						databases[db.Name] = modulecontext.Database{
 							DSN:    db.Runtime.DSN,
 							DBType: dbType,

--- a/cmd/ftl-proxy-pg/main.go
+++ b/cmd/ftl-proxy-pg/main.go
@@ -38,10 +38,10 @@ func main() {
 	err = observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
-	proxy := pgproxy.New(cli.Config, func(ctx context.Context, params map[string]string) (string, error) {
+	proxy := pgproxy.New(cli.Config.Listen, func(ctx context.Context, params map[string]string) (string, error) {
 		return "postgres://localhost:5432/postgres?user=" + params["user"], nil
 	})
-	if err := proxy.Start(ctx); err != nil {
+	if err := proxy.Start(ctx, nil); err != nil {
 		kctx.FatalIfErrorf(err, "failed to start proxy")
 	}
 }

--- a/cmd/ftl-runner/main.go
+++ b/cmd/ftl-runner/main.go
@@ -2,25 +2,21 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/TBD54566975/ftl"
 	"github.com/TBD54566975/ftl/backend/runner"
 	_ "github.com/TBD54566975/ftl/internal/automaxprocs" // Set GOMAXPROCS to match Linux container CPU quota.
 	"github.com/TBD54566975/ftl/internal/log"
-	"github.com/TBD54566975/ftl/internal/pgproxy"
 )
 
 var cli struct {
 	Version      kong.VersionFlag `help:"Show version."`
 	LogConfig    log.Config       `prefix:"log-" embed:""`
 	RunnerConfig runner.Config    `embed:""`
-	ProxyConfig  pgproxy.Config   `embed:"" prefix:"pgproxy-"`
 }
 
 func main() {
@@ -47,21 +43,5 @@ and route to user code.
 	logger := log.Configure(os.Stderr, cli.LogConfig)
 	ctx := log.ContextWithLogger(context.Background(), logger)
 
-	g, ctx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		return runPGProxy(ctx, cli.ProxyConfig)
-	})
-	g.Go(func() error {
-		return runner.Start(ctx, cli.RunnerConfig)
-	})
-	kctx.FatalIfErrorf(g.Wait())
-}
-
-func runPGProxy(ctx context.Context, config pgproxy.Config) error {
-	if err := pgproxy.New(config, func(ctx context.Context, params map[string]string) (string, error) {
-		return "postgres://127.0.0.1:5432/postgres?user=" + params["user"], nil
-	}).Start(ctx); err != nil {
-		return fmt.Errorf("failed to start pgproxy: %w", err)
-	}
-	return nil
+	kctx.FatalIfErrorf(runner.Start(ctx, cli.RunnerConfig))
 }

--- a/go-runtime/server/database.go
+++ b/go-runtime/server/database.go
@@ -47,7 +47,6 @@ func InitDatabase(ref reflection.Ref, dbtype string, protoDBtype modulecontext.D
 		DBType: dbtype,
 		DB: once.Once(func(ctx context.Context) (*sql.DB, error) {
 			logger := log.FromContext(ctx)
-
 			provider := modulecontext.FromContext(ctx).CurrentContext()
 			dsn, testDB, err := provider.GetDatabase(ref.Name, protoDBtype)
 			if err != nil {

--- a/internal/modulecontext/module_context.go
+++ b/internal/modulecontext/module_context.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -158,7 +159,12 @@ func (m ModuleContext) GetSecret(name string, value any) error {
 // if the database is not a test database.
 func (m ModuleContext) GetDatabase(name string, dbType DBType) (string, bool, error) {
 	db, ok := m.databases[name]
+	// TODO: Remove databases from the context once we have a way to inject test dbs in some other way
 	if !ok {
+		if dbType == DBTypePostgres {
+			proxyAddress := os.Getenv("FTL_PROXY_POSTGRES_ADDRESS")
+			return "postgres://" + proxyAddress + "/" + name, false, nil
+		}
 		return "", false, fmt.Errorf("missing DSN for database %s", name)
 	}
 	if db.DBType != dbType {


### PR DESCRIPTION
High level changes:
- Stop sending PostgreSQL DSNs with the `ModuleContext` to the runners.
- Instead, when `GetDatabase` in the runner is called, and there is no DSN for the DB, it gets translated to pgproxy DSN. 
- We start the pgproxy before the deployment in the runner, and pass the local address in an environment variable to the runner.
- pgproxy gets the active schema, and redirects connections to the DSN defined in the runtime of that schema.

Follow-ups
- Integrate MySQL proxy
- Remove DSNs from `ModuleContext` completely