### PR TITLE
fix: split up the runner image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
       - uses: cashapp/activate-hermit@v1.1.3
       - uses: ./.github/actions/build-cache
       - run: just build-docker cron
-  docker-build-runners:
+  docker-build-runner:
     name: Build Runner Docker Images
     # if: github.event_name != 'pull_request' || github.event.action == 'enqueued' || contains( github.event.pull_request.labels.*.name, 'run-all')
     runs-on: ubuntu-latest
@@ -255,6 +255,14 @@ jobs:
       - uses: ./.github/actions/build-cache
       - name: Build Runner Docker Image
         run: just build-docker runner
+  docker-build-jvm-runners:
+    name: Build JVM Runner Docker Images
+    # if: github.event_name != 'pull_request' || github.event.action == 'enqueued' || contains( github.event.pull_request.labels.*.name, 'run-all')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cashapp/activate-hermit@v1.1.3
+      - uses: ./.github/actions/build-cache
       - name: Build JVM Docker Image
         run: just build-docker runner-jvm
   console-e2e:


### PR DESCRIPTION
This is now the slowest CI job and is holding up merging.