### PR TITLE
fix: prevent pubsub naming clashes

### DIFF
--- a/backend/provisioner/dev_provisioner.go
+++ b/backend/provisioner/dev_provisioner.go
@@ -265,11 +265,11 @@ func provisionSubscription() func(ctx context.Context, rc *provisioner.ResourceC
 }
 
 func kafkaTopicID(module, id string) string {
-	return shortenString(fmt.Sprintf("%s-%s", module, id), pubSubNameLimit)
+	return shortenString(fmt.Sprintf("%s.%s", module, id), pubSubNameLimit)
 }
 
 func consumerGroupID(module, id string) string {
-	return shortenString(fmt.Sprintf("%s-%s", module, id), pubSubNameLimit)
+	return shortenString(fmt.Sprintf("%s.%s", module, id), pubSubNameLimit)
 }
 
 // shortenString truncates the input string to maxLength and appends a hash of the original string for uniqueness


### PR DESCRIPTION
Topic or subscription `a.b_c` would have previously clashed with `a_b.c` as we were separating module and name by underscores