### PR TITLE
fix: add service account to runners

### DIFF
--- a/charts/ftl/templates/runner.yaml
+++ b/charts/ftl/templates/runner.yaml
@@ -111,3 +111,13 @@ data:
           tolerations:
             {{- toYaml .Values.runner.tolerations | nindent 12 }}
           {{- end }}
+  serviceAccountTemplate: |-
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app: ftl-runner
+      {{- if .Values.runner.runnersRoleArn }}
+      annotations:
+        eks.amazonaws.com/role-arn: {{ .Values.runner.runnersRoleArn }}
+      {{- end }}


### PR DESCRIPTION
This is so that we can attach a single IAM role to runners. This is a temporary workaround until we will have proper runner based identities in AWS per module