### PR TITLE
feat: use one ServiceAccount per module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV PATH="$PATH:/root"
 # Service-specific configurations
 EXPOSE 8891
 EXPOSE 8892
+EXPOSE 8893
 
 # Environment variables for all (most) services
 ENV FTL_ENDPOINT="http://host.docker.internal:8892"

--- a/backend/provisioner/runner_scaling_provisioner.go
+++ b/backend/provisioner/runner_scaling_provisioner.go
@@ -50,6 +50,7 @@ func provisionRunner(scaling scaling.RunnerScaling, client ftlv1connect.Controll
 		logger.Debugf("provisioning runner: %s.%s for deployment %s", module, id, deployment)
 		err = scaling.StartDeployment(ctx, module, deployment, schema)
 		if err != nil {
+			logger.Infof("failed to start deployment: %v", err)
 			return nil, fmt.Errorf("failed to start deployment: %w", err)
 		}
 		endpoint, err := scaling.GetEndpointForDeployment(ctx, module, deployment)


### PR DESCRIPTION
Per deployment is to granular for our security use cases.