### PR TITLE
fix: don't attempt to start if controller allready running

### DIFF
--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -114,7 +114,11 @@ func (s *serveCommonConfig) run(
 			// allow usage of --background and --stop together to "restart" the background process
 			_ = KillBackgroundServe(logger) //nolint:errcheck // ignore error here if the process is not running
 		}
-
+		_, err := controllerClient.Ping(ctx, connect.NewRequest(&ftlv1.PingRequest{}))
+		if err == nil {
+			// The controller is already running, bail out.
+			return fmt.Errorf("controller is already running")
+		}
 		if err := runInBackground(logger); err != nil {
 			return err
 		}
@@ -134,7 +138,11 @@ func (s *serveCommonConfig) run(
 	if s.Stop {
 		return KillBackgroundServe(logger)
 	}
-
+	_, err := controllerClient.Ping(ctx, connect.NewRequest(&ftlv1.PingRequest{}))
+	if err == nil {
+		// The controller is already running, bail out.
+		return fmt.Errorf("controller is already running")
+	}
 	if s.Provisioners > 0 {
 		logger.Debugf("Starting FTL with %d controller(s) and %d provisioner(s)", s.Controllers, s.Provisioners)
 	} else {
@@ -152,7 +160,7 @@ func (s *serveCommonConfig) run(
 			s.ObservabilityConfig.ExportOTEL = true
 		}
 	}
-	err := observability.Init(ctx, false, "", "ftl-serve", ftl.Version, s.ObservabilityConfig)
+	err = observability.Init(ctx, false, "", "ftl-serve", ftl.Version, s.ObservabilityConfig)
 	if err != nil {
 		return fmt.Errorf("observability init failed: %w", err)
 	}


### PR DESCRIPTION
We seem to have lost this check somewhere, and I keep hitting silent failures when I have k3d up.