### PR TITLE
fix: remove FTL_ENDPOINT var

### DIFF
--- a/bin/hermit.hcl
+++ b/bin/hermit.hcl
@@ -1,7 +1,6 @@
 env = {
   "DBMATE_MIGRATIONS_DIR": "${HERMIT_ENV}/backend/controller/sql/schema",
   "DBMATE_NO_DUMP_SCHEMA": "true",
-  "FTL_ENDPOINT": "http://127.0.0.1:8892",
   "FTL_INIT_GO_REPLACE": "github.com/TBD54566975/ftl=${HERMIT_ENV}",
   "FTL_SOURCE": "${HERMIT_ENV}",
   "FTL_STARTUP_TIMEOUT": "30s",


### PR DESCRIPTION
This breaks JVM runner proxying as we can't override this when running java.