### PR TITLE
refactor: simplify main entry points a bit

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ builds:
       - linux
       - darwin
     flags: -trimpath
-    ldflags: -s -w -buildid= -X github.com/TBD54566975/ftl.Version={{.Version}} -X  github.com/TBD54566975/ftl.Timestamp={{ .CommitTimestamp }}
+    ldflags: -s -w -buildid= -X github.com/TBD54566975/ftl.Version={{.Version}} -X  github.com/TBD54566975/ftl.timestamp={{ .CommitTimestamp }}
     tags: [release]
   - id: ftl-language-go
     main: ./go-runtime/cmd/ftl-language-go

--- a/Justfile
+++ b/Justfile
@@ -137,9 +137,9 @@ build-go-binary dir binary="": build-zips build-protos
   binary="${2:-$(basename "$1")}"
 
   if [ "${FTL_DEBUG:-}" = "true" ]; then
-    go build -o "{{RELEASE}}/${binary}" -tags release -gcflags=all="-N -l" -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.Timestamp={{TIMESTAMP}}" "$1"
+    go build -o "{{RELEASE}}/${binary}" -tags release -gcflags=all="-N -l" -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.timestamp={{TIMESTAMP}}" "$1"
   else
-    mk "{{RELEASE}}/${binary}" : !(build|integration|infrastructure|node_modules|Procfile*|Dockerfile*) -- go build -o "{{RELEASE}}/${binary}" -tags release -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.Timestamp={{TIMESTAMP}}" "$1"
+    mk "{{RELEASE}}/${binary}" : !(build|integration|infrastructure|node_modules|Procfile*|Dockerfile*) -- go build -o "{{RELEASE}}/${binary}" -tags release -ldflags "-X github.com/TBD54566975/ftl.Version={{VERSION}} -X github.com/TBD54566975/ftl.timestamp={{TIMESTAMP}}" "$1"
   fi
 
 export DATABASE_URL := "postgres://postgres:secret@localhost:15432/ftl?sslmode=disable"

--- a/backend/timeline/service.go
+++ b/backend/timeline/service.go
@@ -17,7 +17,6 @@ import (
 	ftlv1 "github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1"
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/rpc"
-	"github.com/TBD54566975/ftl/internal/schema/schemaeventsource"
 	"github.com/TBD54566975/ftl/internal/slices"
 )
 
@@ -37,7 +36,7 @@ type service struct {
 	events []*timelinepb.Event
 }
 
-func Start(ctx context.Context, config Config, schemaEventSource schemaeventsource.EventSource) error {
+func Start(ctx context.Context, config Config) error {
 	config.SetDefaults()
 
 	logger := log.FromContext(ctx).Scope("timeline")

--- a/cmd/ftl-controller/main.go
+++ b/cmd/ftl-controller/main.go
@@ -2,11 +2,8 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/alecthomas/kong"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -40,23 +37,18 @@ var cli struct {
 }
 
 func main() {
-	t, err := strconv.ParseInt(ftl.Timestamp, 10, 64)
-	if err != nil {
-		panic(fmt.Sprintf("invalid timestamp %q: %s", ftl.Timestamp, err))
-	}
 	kctx := kong.Parse(&cli,
 		kong.Description(`FTL - Towards a 𝝺-calculus for large-scale systems`),
 		kong.UsageOnError(),
 		kong.Vars{
-			"version":   ftl.Version,
-			"timestamp": time.Unix(t, 0).Format(time.RFC3339),
-			"dsn":       dsn.PostgresDSN("ftl"),
+			"version": ftl.FormattedVersion,
+			"dsn":     dsn.PostgresDSN("ftl"),
 		},
 	)
 	cli.ControllerConfig.SetDefaults()
 
 	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
-	err = observability.Init(ctx, false, "", "ftl-controller", ftl.Version, cli.ObservabilityConfig)
+	err := observability.Init(ctx, false, "", "ftl-controller", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
 	storage, err := artefacts.NewOCIRegistryStorage(cli.RegistryConfig)

--- a/cmd/ftl-provisioner/main.go
+++ b/cmd/ftl-provisioner/main.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/alecthomas/kong"
 
@@ -28,19 +25,15 @@ var cli struct {
 }
 
 func main() {
-	t, err := strconv.ParseInt(ftl.Timestamp, 10, 64)
-	if err != nil {
-		panic(fmt.Sprintf("invalid timestamp %q: %s", ftl.Timestamp, err))
-	}
 	kctx := kong.Parse(&cli,
 		kong.Description(`FTL - Towards a 𝝺-calculus for large-scale systems`),
 		kong.UsageOnError(),
-		kong.Vars{"version": ftl.Version, "timestamp": time.Unix(t, 0).Format(time.RFC3339)},
+		kong.Vars{"version": ftl.FormattedVersion},
 	)
 	cli.ProvisionerConfig.SetDefaults()
 
 	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
-	err = observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)
+	err := observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
 	controllerClient := rpc.Dial(ftlv1connect.NewControllerServiceClient, cli.ProvisionerConfig.ControllerEndpoint.String(), log.Error)

--- a/cmd/ftl-proxy-pg/main.go
+++ b/cmd/ftl-proxy-pg/main.go
@@ -2,10 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/alecthomas/kong"
 
@@ -24,18 +21,14 @@ var cli struct {
 }
 
 func main() {
-	t, err := strconv.ParseInt(ftl.Timestamp, 10, 64)
-	if err != nil {
-		panic(fmt.Sprintf("invalid timestamp %q: %s", ftl.Timestamp, err))
-	}
 	kctx := kong.Parse(&cli,
 		kong.Description(`FTL - Towards a 𝝺-calculus for large-scale systems`),
 		kong.UsageOnError(),
-		kong.Vars{"version": ftl.Version, "timestamp": time.Unix(t, 0).Format(time.RFC3339)},
+		kong.Vars{"version": ftl.FormattedVersion},
 	)
 
 	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
-	err = observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)
+	err := observability.Init(ctx, false, "", "ftl-provisioner", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
 	proxy := pgproxy.New(cli.Config.Listen, func(ctx context.Context, params map[string]string) (string, error) {

--- a/cmd/ftl-timeline/main.go
+++ b/cmd/ftl-timeline/main.go
@@ -2,51 +2,35 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"net/url"
 	"os"
-	"strconv"
-	"time"
 
 	"github.com/alecthomas/kong"
 
 	"github.com/TBD54566975/ftl"
-	"github.com/TBD54566975/ftl/backend/protos/xyz/block/ftl/v1/ftlv1connect"
 	"github.com/TBD54566975/ftl/backend/timeline"
 	_ "github.com/TBD54566975/ftl/internal/automaxprocs" // Set GOMAXPROCS to match Linux container CPU quota.
 	"github.com/TBD54566975/ftl/internal/log"
 	"github.com/TBD54566975/ftl/internal/observability"
-	"github.com/TBD54566975/ftl/internal/rpc"
-	"github.com/TBD54566975/ftl/internal/schema/schemaeventsource"
 )
 
 var cli struct {
-	Version               kong.VersionFlag     `help:"Show version."`
-	ObservabilityConfig   observability.Config `embed:"" prefix:"o11y-"`
-	LogConfig             log.Config           `embed:"" prefix:"log-"`
-	TimelineConfig        timeline.Config      `embed:"" prefix:"timeline-"`
-	ConfigFlag            string               `name:"config" short:"C" help:"Path to FTL project cf file." env:"FTL_CONFIG" placeholder:"FILE"`
-	SchemaServiceEndpoint *url.URL             `name:"ftl-endpoint" help:"SchemaService endpoint." env:"FTL_ENDPOINT" default:"http://127.0.0.1:8892"`
+	Version             kong.VersionFlag     `help:"Show version."`
+	ObservabilityConfig observability.Config `embed:"" prefix:"o11y-"`
+	LogConfig           log.Config           `embed:"" prefix:"log-"`
+	TimelineConfig      timeline.Config      `embed:"" prefix:"timeline-"`
 }
 
 func main() {
-	t, err := strconv.ParseInt(ftl.Timestamp, 10, 64)
-	if err != nil {
-		panic(fmt.Sprintf("invalid timestamp %q: %s", ftl.Timestamp, err))
-	}
 	kctx := kong.Parse(&cli,
 		kong.Description(`FTL - Timeline`),
 		kong.UsageOnError(),
-		kong.Vars{"version": ftl.Version, "timestamp": time.Unix(t, 0).Format(time.RFC3339)},
+		kong.Vars{"version": ftl.FormattedVersion},
 	)
 
 	ctx := log.ContextWithLogger(context.Background(), log.Configure(os.Stderr, cli.LogConfig))
-	err = observability.Init(ctx, false, "", "ftl-timeline", ftl.Version, cli.ObservabilityConfig)
+	err := observability.Init(ctx, false, "", "ftl-timeline", ftl.Version, cli.ObservabilityConfig)
 	kctx.FatalIfErrorf(err, "failed to initialize observability")
 
-	schemaClient := rpc.Dial(ftlv1connect.NewSchemaServiceClient, cli.SchemaServiceEndpoint.String(), log.Error)
-	schemaEventSource := schemaeventsource.New(ctx, schemaClient)
-
-	err = timeline.Start(ctx, cli.TimelineConfig, schemaEventSource)
-	kctx.FatalIfErrorf(err, "failed to start HTTP ingress")
+	err = timeline.Start(ctx, cli.TimelineConfig)
+	kctx.FatalIfErrorf(err, "failed to start timeline service")
 }

--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -319,7 +319,7 @@ func (s *serveCommonConfig) run(
 
 	// Start Timeline
 	wg.Go(func() error {
-		err := timeline.Start(ctx, s.Timeline, schemaEventSourceFactory())
+		err := timeline.Start(ctx, s.Timeline)
 		if err != nil {
 			return fmt.Errorf("timeline failed: %w", err)
 		}

--- a/frontend/cli/main.go
+++ b/frontend/cli/main.go
@@ -173,7 +173,7 @@ func createKongApplication(cli any, csm *currentStatusManager) *kong.Kong {
 			return &kong.Group{Key: node.Name, Title: "Command flags:"}
 		}),
 		kong.Vars{
-			"version": ftl.Version,
+			"version": ftl.FormattedVersion,
 			"os":      runtime.GOOS,
 			"arch":    runtime.GOARCH,
 			"numcpu":  strconv.Itoa(runtime.NumCPU()),

--- a/version.go
+++ b/version.go
@@ -1,8 +1,12 @@
 package ftl
 
 import (
+	"fmt"
 	"regexp"
+	"strconv"
+	"time"
 
+	"github.com/alecthomas/types/must"
 	"golang.org/x/mod/semver"
 )
 
@@ -28,5 +32,11 @@ func IsVersionAtLeastMin(v string, minVersion string) bool {
 // Version of FTL binary (set by linker).
 var Version = "dev"
 
+// FormattedVersion includes the version and timestamp.
+var FormattedVersion = fmt.Sprintf("%s (%s)", Version, Timestamp.Format("2006-01-02"))
+
 // Timestamp of FTL binary (set by linker).
-var Timestamp = "0"
+var timestamp = "0"
+
+// Timestamp parsed from timestamp (set by linker).
+var Timestamp = time.Unix(0, must.Get(strconv.ParseInt(timestamp, 0, 64)))


### PR DESCRIPTION
Move version parsing into the ftl package, combine version+timestamp into a single variable.