### PR TITLE
fix: allocate runner ports randomly

### DIFF
--- a/frontend/cli/cmd_serve.go
+++ b/frontend/cli/cmd_serve.go
@@ -228,7 +228,6 @@ func (s *serveCommonConfig) run(
 
 	runnerScaling, err := localscaling.NewLocalScaling(
 		ctx,
-		bindAllocator,
 		controllerAddresses,
 		s.Lease.Bind,
 		projConfig.Path,


### PR DESCRIPTION
Currently they are racy with some of our new services, there is no real need for them the port they use to be close.