### PR TITLE
chore: speed up subscription provisioning

### DIFF
--- a/backend/provisioner/dev_provisioner.go
+++ b/backend/provisioner/dev_provisioner.go
@@ -238,9 +238,6 @@ func provisionTopic() InMemResourceProvisionerFn {
 func provisionSubscription() InMemResourceProvisionerFn {
 	return func(ctx context.Context, moduleName string, res schema.Provisioned) (*RuntimeEvent, error) {
 		logger := log.FromContext(ctx)
-		if err := dev.SetUpRedPanda(ctx); err != nil {
-			return nil, fmt.Errorf("could not set up redpanda: %w", err)
-		}
 		verb, ok := res.(*schema.Verb)
 		if !ok {
 			panic(fmt.Errorf("unexpected resource type: %T", res))


### PR DESCRIPTION
No need to make sure redpanda is up for subscriptions as they rely on topics which rely on redpanda being up.